### PR TITLE
Improve leaderboard: summary view, sort fix, cost cleanup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,5 @@
 language: en-US
 reviews:
   auto_review:
-    enabled: false
+    enabled: true
+    auto_incremental_review: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+language: en-US
+reviews:
+  auto_review:
+    enabled: false

--- a/llm_quest_benchmark/core/leaderboard.py
+++ b/llm_quest_benchmark/core/leaderboard.py
@@ -168,6 +168,7 @@ def generate_leaderboard(benchmark_dirs: List[str], output_path: str) -> Dict[st
             quest_lang = _detect_quest_lang(quest_path)
             outcome = str(result_row.get("outcome") or "UNKNOWN")
 
+            # TODO: cost tracking is broken - run_summary.json usage data is not populated by OpenRouter runs
             # Correlate with db_runs by index to get run ID for metrics
             usage: Dict[str, Any] = {}
             metrics: Dict[str, Any] = {}

--- a/site/about.html
+++ b/site/about.html
@@ -126,7 +126,7 @@ YAML Config                    Quest Engine (TypeScript)
 +-----------------------+      +-------------------------+
 | models:               |      |  .qm quest file         |
 |   - claude-sonnet-4   |      |  branching narrative     |
-|   - gpt-5.4-mini      | ---> |  state machine          |
+|   - gpt-5.4-mini      | &rarr; |  state machine          |
 |   - gemini-2.5-flash  |      |  success/failure outcome |
 | modes: [A, B, C, D]   |      +-------------------------+
 | quests: [15 selected]  |                |

--- a/site/about.html
+++ b/site/about.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>About - LLM-Quest Benchmark</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+:root { --bg: #0d1117; --surface: #161b22; --border: #30363d; --text: #e6edf3; --muted: #c9d1d9; --accent: #58a6ff; --green: #3fb950; --orange: #d29922; --red: #f85149; }
+body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; line-height: 1.7; }
+.navbar { background: var(--surface); border-bottom: 1px solid var(--border); }
+.nav-link-custom { color: var(--muted); text-decoration: none; margin-left: 1.5rem; }
+.nav-link-custom:hover, .nav-link-custom.active { color: var(--accent); }
+.card { background: var(--surface); border: 1px solid var(--border); }
+a { color: var(--accent); }
+h2 { margin-top: 2.5rem; margin-bottom: 1rem; }
+h3 { margin-top: 2rem; color: var(--muted); font-size: 1.1rem; text-transform: uppercase; letter-spacing: 0.05em; }
+.hero { padding: 3rem 0 2rem; border-bottom: 1px solid var(--border); margin-bottom: 2rem; }
+.hero h1 { font-size: 2.2rem; font-weight: 700; }
+.hero p { color: var(--muted); font-size: 1.15rem; max-width: 700px; }
+.mode-card { padding: 1.25rem; height: 100%; }
+.mode-card h5 { font-size: 1rem; margin-bottom: 0.5rem; }
+.mode-card p { font-size: 0.9rem; color: var(--muted); margin-bottom: 0; }
+.mode-letter { font-weight: 700; font-size: 0.85rem; display: inline-block; width: 1.8em; height: 1.8em; line-height: 1.8em; text-align: center; border-radius: 4px; margin-right: 0.5rem; }
+.mode-a { background: var(--muted); color: var(--bg); }
+.mode-b { background: var(--accent); color: var(--bg); }
+.mode-c { background: #a371f7; color: var(--bg); }
+.mode-d { background: var(--orange); color: var(--bg); }
+.mode-e { background: var(--green); color: var(--bg); }
+.diagram { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.5rem; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.85rem; color: var(--muted); overflow-x: auto; }
+.metric-row { display: flex; gap: 2rem; flex-wrap: wrap; margin: 1rem 0; }
+.metric-item { flex: 1; min-width: 200px; }
+.metric-name { font-weight: 600; color: var(--text); }
+.metric-desc { font-size: 0.9rem; color: var(--muted); }
+.text-muted { color: var(--muted) !important; }
+</style>
+</head>
+<body>
+
+<nav class="navbar navbar-dark py-3">
+  <div class="container d-flex align-items-center">
+    <span class="navbar-brand mb-0 h1">LLM-Quest Benchmark</span>
+    <div>
+      <a href="about.html" class="nav-link-custom active">About</a>
+      <a href="index.html" class="nav-link-custom">Leaderboard</a>
+      <a href="https://github.com/yourconscience/llm_quest_benchmark" class="nav-link-custom">GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<div class="container" style="max-width: 860px;">
+
+<div class="hero">
+  <h1>LLM-Quest Benchmark</h1>
+  <p>Evaluating how cognitive scaffolding - prompting strategies, planning, and tool use - affects LLM decision-making in complex interactive environments.</p>
+</div>
+
+<h2>What is this?</h2>
+<p>
+  LLM-Quest is a benchmark for measuring LLM agent performance in text-based decision environments.
+  Each evaluation episode presents the model with a branching narrative where it must read a situation description, weigh available actions, and choose one. The outcome (success or failure) depends on a chain of decisions across multiple turns.
+</p>
+<p>
+  The core question is not "which model is smartest" but rather <strong>how much does the cognitive architecture around the model matter?</strong>
+  The same model can be evaluated with a bare prompt, a reasoning scaffold, domain knowledge injection, multi-step planning, or access to tools - and the results are often dramatically different.
+</p>
+
+<h2>Evaluation Domain</h2>
+<p>
+  The benchmark uses interactive fiction quests originally created for the Space Rangers universe - a large corpus of community-authored text adventures with branching narratives, resource management, and non-obvious optimal paths.
+  These quests serve as a challenging evaluation domain because they require:
+</p>
+<ul>
+  <li>Reading comprehension across multi-paragraph descriptions</li>
+  <li>Multi-step sequential decision-making (10-50+ turns per quest)</li>
+  <li>Reasoning under uncertainty with incomplete information</li>
+  <li>Avoiding repetitive loops and dead ends</li>
+  <li>Balancing exploration vs. exploitation</li>
+</ul>
+<p>
+  The quest corpus contains hundreds of scenarios ranging from straightforward to extremely difficult.
+  The benchmark selects a balanced subset for evaluation.
+</p>
+
+<h2>Agent Modes</h2>
+<p>Each model is evaluated across multiple agent architectures that add increasing cognitive scaffolding:</p>
+
+<div class="row g-3 my-3">
+  <div class="col-md-6">
+    <div class="card mode-card">
+      <h5><span class="mode-letter mode-a">A</span> Baseline</h5>
+      <p>Minimal prompt. The model sees the situation and action list, returns a single number. No reasoning, no context, no guidance. This is the control condition.</p>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card mode-card">
+      <h5><span class="mode-letter mode-b">B</span> Prompted</h5>
+      <p>Structured reasoning prompt with guidelines: avoid abandonment, gather information, reuse hints. The model returns analysis, reasoning, and a choice in JSON format.</p>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card mode-card">
+      <h5><span class="mode-letter mode-c">C</span> Knowledge</h5>
+      <p>Reasoning prompt augmented with domain-specific hints about quest mechanics: read descriptions literally, prefer preparation over confrontation, avoid premature exits.</p>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card mode-card">
+      <h5><span class="mode-letter mode-d">D</span> Planner</h5>
+      <p>Multi-turn planning agent. First generates a 3-5 sentence strategy, then executes it. Replans when the situation changes significantly. Maintains strategic coherence across turns.</p>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card mode-card">
+      <h5><span class="mode-letter mode-e">E</span> Tool-augmented</h5>
+      <p>Agent with access to tools: quest history queries, state tracking. Can gather information before committing to an action. Two-phase select-then-execute loop.</p>
+    </div>
+  </div>
+</div>
+
+<h2>How It Works</h2>
+
+<div class="diagram">
+<pre style="margin:0; color: var(--muted);">
+YAML Config                    Quest Engine (TypeScript)
++-----------------------+      +-------------------------+
+| models:               |      |  .qm quest file         |
+|   - claude-sonnet-4   |      |  branching narrative     |
+|   - gpt-5.4-mini      | ---> |  state machine          |
+|   - gemini-2.5-flash  |      |  success/failure outcome |
+| modes: [A, B, C, D]   |      +-------------------------+
+| quests: [15 selected]  |                |
+| runs_per_config: 1     |                v
++-----------------------+      +-------------------------+
+                               | Agent (Python)          |
+                               |  prompt template        |
+                               |  LLM API call           |
+                               |  action selection       |
+                               |  per-run metrics        |
+                               +-------------------------+
+                                          |
+                                          v
+                               +-------------------------+
+                               | Leaderboard (JSON)      |
+                               |  success rates          |
+                               |  token usage            |
+                               |  repetition rates       |
+                               |  aggregated by model    |
+                               |    and mode             |
+                               +-------------------------+
+</pre>
+</div>
+
+<p class="mt-3">
+  The benchmark is configured via YAML files that define the cross-product of models, prompt templates, and quests to evaluate.
+  Each configuration runs through the quest engine, which presents situations and actions to the LLM agent, records the agent's choices, and determines the final outcome.
+</p>
+
+<h2>Metrics</h2>
+
+<div class="metric-row">
+  <div class="metric-item">
+    <div class="metric-name">Success Rate</div>
+    <div class="metric-desc">Fraction of quest runs that end in a successful outcome. The primary metric. Aggregated across quests per model-mode pair.</div>
+  </div>
+  <div class="metric-item">
+    <div class="metric-name">Average Steps</div>
+    <div class="metric-desc">Mean number of decision turns per quest run. Fewer steps can indicate efficiency or premature termination.</div>
+  </div>
+</div>
+<div class="metric-row">
+  <div class="metric-item">
+    <div class="metric-name">Average Tokens</div>
+    <div class="metric-desc">Mean total tokens (input + output) consumed per run. Proxy for computational cost.</div>
+  </div>
+  <div class="metric-item">
+    <div class="metric-name">Repetition Rate</div>
+    <div class="metric-desc">Fraction of agent actions that repeat the immediately previous choice. High values indicate the agent is stuck in a decision loop.</div>
+  </div>
+</div>
+
+<h2>Reproducing Results</h2>
+
+<div class="card" style="padding: 1.25rem; margin: 1rem 0;">
+<pre style="margin:0; color: var(--text); font-size: 0.9rem;"><code># Clone and setup
+git clone https://github.com/yourconscience/llm_quest_benchmark.git
+cd llm_quest_benchmark
+uv sync
+
+# Download quest files
+./scripts/download_quests.sh
+
+# Run a benchmark
+uv run benchmark --config configs/benchmarks/your_config.yaml
+
+# Generate leaderboard
+uv run benchmark-report --benchmark-dir results/your_run -o site/leaderboard.json</code></pre>
+</div>
+
+<p>
+  Configure your API keys in <code>.env</code> (supports OpenAI, Anthropic, Google, DeepSeek, or <a href="https://openrouter.ai">OpenRouter</a> as a unified proxy).
+  Write a YAML config specifying the model-mode-quest matrix, and the benchmark handles the rest.
+</p>
+
+<h2>Models Evaluated</h2>
+<p>Current leaderboard includes results from:</p>
+<ul>
+  <li><strong>Anthropic</strong> - Claude Sonnet 4.6</li>
+  <li><strong>OpenAI</strong> - GPT-5.4, GPT-5.4 Mini</li>
+  <li><strong>Google</strong> - Gemini 2.5 Flash</li>
+  <li><strong>DeepSeek</strong> - DeepSeek Chat (V3)</li>
+  <li><strong>Alibaba</strong> - Qwen 2.5 72B Instruct</li>
+</ul>
+<p>
+  All models are accessed through <a href="https://openrouter.ai">OpenRouter</a> for unified billing and consistent API interface.
+  Adding new models requires only a config change.
+</p>
+
+<footer class="text-center py-5 text-muted" style="font-size: 0.85rem; border-top: 1px solid var(--border); margin-top: 3rem;">
+  <p><a href="index.html">View Leaderboard</a> | <a href="leaderboard.json">Raw JSON</a> | <a href="https://github.com/yourconscience/llm_quest_benchmark">Source Code</a></p>
+</footer>
+
+</div>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -12,10 +12,10 @@ body { background: var(--bg); color: var(--text); font-family: -apple-system, Bl
 .navbar { background: var(--surface); border-bottom: 1px solid var(--border); }
 .card { background: var(--surface); border: 1px solid var(--border); }
 .table { color: var(--text); --bs-table-bg: var(--surface); --bs-table-border-color: var(--border); }
-.table thead th { border-bottom: 2px solid var(--border); color: var(--muted); font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; cursor: pointer; user-select: none; }
-.table thead th:hover { color: var(--accent); }
-.table thead th.sorted-asc::after { content: ' \u25b2'; }
-.table thead th.sorted-desc::after { content: ' \u25bc'; }
+.table thead th { border-bottom: 2px solid var(--border); color: var(--muted); font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; user-select: none; }
+.table thead th[data-col] { cursor: pointer; }
+.table thead th[data-col]:hover { color: var(--accent); }
+.table thead th .sort-arrow { font-size: 0.7rem; margin-left: 0.3em; text-transform: none; }
 .table tbody tr:hover { background: rgba(88,166,255,0.05); }
 .badge-mode { font-size: 0.75rem; padding: 0.25em 0.6em; border-radius: 4px; }
 .mode-stub { background: var(--muted); color: var(--bg); }
@@ -33,6 +33,9 @@ body { background: var(--bg); color: var(--text); font-family: -apple-system, Bl
 a { color: var(--accent); }
 .subtitle { color: var(--muted); font-size: 1rem; font-weight: 400; }
 .text-muted { color: var(--muted) !important; }
+.nav-pills .nav-link { color: var(--muted); border: 1px solid var(--border); margin-right: 0.5rem; }
+.nav-pills .nav-link.active { background: var(--accent); color: var(--bg); border-color: var(--accent); }
+.tooltip-icon { color: var(--muted); cursor: help; font-size: 0.75rem; border: 1px solid var(--muted); border-radius: 50%; width: 1.1em; height: 1.1em; display: inline-flex; align-items: center; justify-content: center; vertical-align: middle; margin-left: 0.3em; }
 </style>
 </head>
 <body>
@@ -54,29 +57,21 @@ a { color: var(--accent); }
 
   <div class="card mb-4">
     <div class="card-body">
+      <ul class="nav nav-pills mb-3" id="view-tabs">
+        <li class="nav-item"><a class="nav-link active" href="#" data-view="summary">Summary</a></li>
+        <li class="nav-item"><a class="nav-link" href="#" data-view="quests">Per Quest</a></li>
+      </ul>
       <div class="d-flex flex-wrap gap-2 mb-3">
         <span class="text-muted me-2 align-self-center" style="font-size:0.85rem">Mode:</span>
         <button class="filter-btn active" data-filter="mode" data-value="all">All</button>
-        <div id="mode-filters"></div>
-        <span class="text-muted ms-3 me-2 align-self-center" style="font-size:0.85rem">Quest:</span>
-        <button class="filter-btn active" data-filter="quest" data-value="all">All</button>
-        <div id="quest-filters"></div>
+        <div id="mode-filters" class="d-flex flex-wrap gap-1"></div>
+        <span class="text-muted ms-3 me-2 align-self-center" style="font-size:0.85rem" id="quest-filter-label">Quest:</span>
+        <button class="filter-btn active" data-filter="quest" data-value="all" id="quest-all-btn">All</button>
+        <div id="quest-filters" class="d-flex flex-wrap gap-1"></div>
       </div>
       <div class="table-responsive">
         <table class="table table-sm mb-0" id="leaderboard">
-          <thead>
-            <tr>
-              <th>#</th>
-              <th data-col="model">Model</th>
-              <th data-col="mode">Mode</th>
-              <th data-col="quest">Quest</th>
-              <th data-col="success_rate">Success Rate</th>
-              <th data-col="avg_steps">Steps</th>
-              <th data-col="avg_tokens">Tokens</th>
-              <th data-col="avg_cost_usd">Cost</th>
-              <th data-col="repetition_rate">Repetition</th>
-            </tr>
-          </thead>
+          <thead><tr id="table-header"></tr></thead>
           <tbody></tbody>
         </table>
       </div>
@@ -92,7 +87,7 @@ a { color: var(--accent); }
     </div>
     <div class="col-lg-6">
       <div class="card h-100"><div class="card-body">
-        <h6 class="text-muted mb-3">Cost vs Success Rate</h6>
+        <h6 class="text-muted mb-3">Steps vs Success Rate</h6>
         <div id="chart-scatter" style="height:360px"></div>
       </div></div>
     </div>
@@ -119,6 +114,7 @@ let sortCol = 'success_rate';
 let sortAsc = false;
 let filterMode = 'all';
 let filterQuest = 'all';
+let viewMode = 'summary';
 
 const MODE_LABELS = {stub:'Baseline (A)', reasoning:'Prompted (B)', light_hints:'Knowledge (C)', planner:'Planner (D)', tool_augmented:'Tool-aug (E)'};
 const MODE_CLASSES = {stub:'mode-stub', reasoning:'mode-reasoning', light_hints:'mode-light_hints', planner:'mode-planner', tool_augmented:'mode-tool'};
@@ -128,23 +124,64 @@ const MODEL_SYMBOLS = ['circle','rect','triangle','diamond','pin','arrow'];
 function successColor(v) { return v >= 0.8 ? 'var(--green)' : v >= 0.4 ? 'var(--orange)' : 'var(--red)'; }
 function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 
+function filtered() {
+  return DATA.results.filter(r => (filterMode === 'all' || r.mode === filterMode) && (filterQuest === 'all' || r.quest === filterQuest));
+}
+
+function aggregated() {
+  const groups = {};
+  filtered().forEach(r => {
+    const key = `${r.model}|${r.mode}`;
+    if (!groups[key]) groups[key] = { model: r.model, mode: r.mode, rates: [], steps: [], tokens: [], reps: [], runs: 0 };
+    const g = groups[key];
+    g.rates.push(r.success_rate);
+    g.steps.push(r.avg_steps);
+    g.tokens.push(r.avg_tokens);
+    g.reps.push(r.repetition_rate);
+    g.runs += r.runs;
+  });
+  return Object.values(groups).map(g => ({
+    model: g.model,
+    mode: g.mode,
+    success_rate: g.rates.reduce((a,b)=>a+b,0) / g.rates.length,
+    avg_steps: g.steps.reduce((a,b)=>a+b,0) / g.steps.length,
+    avg_tokens: g.tokens.reduce((a,b)=>a+b,0) / g.tokens.length,
+    repetition_rate: g.reps.reduce((a,b)=>a+b,0) / g.reps.length,
+    runs: g.runs,
+    quests: g.rates.length,
+  }));
+}
+
 async function init() {
   const resp = await fetch('leaderboard.json');
   DATA = await resp.json();
   document.getElementById('footer-date').textContent = DATA.generated?.split('T')[0] || '';
   buildFilters();
-  renderStats();
-  renderTable();
-  renderBarChart();
-  renderScatterChart();
-  renderLiftChart();
-  document.querySelectorAll('#leaderboard thead th').forEach(th => {
-    th.addEventListener('click', () => {
-      const col = th.dataset.col;
-      if (sortCol === col) sortAsc = !sortAsc; else { sortCol = col; sortAsc = col === 'model' || col === 'mode' || col === 'quest'; }
-      renderTable();
-    });
+  renderAll();
+  document.getElementById('leaderboard').addEventListener('click', e => {
+    const th = e.target.closest('th[data-col]');
+    if (!th) return;
+    const col = th.dataset.col;
+    if (sortCol === col) sortAsc = !sortAsc; else { sortCol = col; sortAsc = col === 'model' || col === 'mode' || col === 'quest'; }
+    renderTable();
   });
+  document.getElementById('view-tabs').addEventListener('click', e => {
+    e.preventDefault();
+    const link = e.target.closest('[data-view]');
+    if (!link) return;
+    viewMode = link.dataset.view;
+    document.querySelectorAll('#view-tabs .nav-link').forEach(l => l.classList.remove('active'));
+    link.classList.add('active');
+    const showQuest = viewMode === 'quests';
+    document.getElementById('quest-filter-label').style.display = showQuest ? '' : 'none';
+    document.getElementById('quest-all-btn').style.display = showQuest ? '' : 'none';
+    document.getElementById('quest-filters').style.display = showQuest ? '' : 'none';
+    sortCol = 'success_rate'; sortAsc = false;
+    renderTable();
+  });
+  document.getElementById('quest-filter-label').style.display = 'none';
+  document.getElementById('quest-all-btn').style.display = 'none';
+  document.getElementById('quest-filters').style.display = 'none';
 }
 
 function buildFilters() {
@@ -159,57 +196,98 @@ function buildFilters() {
       else filterQuest = btn.dataset.value;
       document.querySelectorAll(`.filter-btn[data-filter="${type}"]`).forEach(b => b.classList.remove('active'));
       btn.classList.add('active');
-      renderTable();
-      renderStats();
-      renderBarChart();
-      renderScatterChart();
-      renderLiftChart();
+      renderAll();
     });
   });
 }
 
-function filtered() {
-  return DATA.results.filter(r => (filterMode === 'all' || r.mode === filterMode) && (filterQuest === 'all' || r.quest === filterQuest));
+function renderAll() {
+  renderStats();
+  renderTable();
+  renderBarChart();
+  renderScatterChart();
+  renderLiftChart();
 }
 
 function renderStats() {
-  const rows = filtered();
+  const rows = viewMode === 'summary' ? aggregated() : filtered();
   const avg = (arr, key) => arr.length ? arr.reduce((s, r) => s + r[key], 0) / arr.length : 0;
+  const totalRuns = rows.reduce((s, r) => s + r.runs, 0);
   const stats = [
     {value: (avg(rows,'success_rate')*100).toFixed(0)+'%', label: 'Avg Success Rate'},
+    {value: avg(rows,'avg_steps').toFixed(0), label: 'Avg Steps/Run'},
     {value: avg(rows,'avg_tokens').toFixed(0), label: 'Avg Tokens/Run'},
-    {value: '$'+avg(rows,'avg_cost_usd').toFixed(4), label: 'Avg Cost/Run'},
-    {value: (avg(rows,'repetition_rate')*100).toFixed(1)+'%', label: 'Avg Repetition'},
+    {value: totalRuns.toLocaleString(), label: 'Total Runs'},
   ];
   document.getElementById('stats-row').innerHTML = stats.map(s => `<div class="col-6 col-md-3"><div class="card stat-card"><div class="stat-value">${s.value}</div><div class="stat-label">${s.label}</div></div></div>`).join('');
 }
 
+function sortArrow(col) {
+  if (sortCol !== col) return '';
+  return `<span class="sort-arrow">${sortAsc ? '\u25B2' : '\u25BC'}</span>`;
+}
+
 function renderTable() {
-  const rows = filtered().slice().sort((a,b) => {
+  const header = document.getElementById('table-header');
+  if (viewMode === 'summary') {
+    header.innerHTML = `<th>#</th>
+      <th data-col="model">Model ${sortArrow('model')}</th>
+      <th data-col="mode">Mode ${sortArrow('mode')}</th>
+      <th data-col="quests">Quests ${sortArrow('quests')}</th>
+      <th data-col="runs">Runs ${sortArrow('runs')}</th>
+      <th data-col="success_rate">Success Rate ${sortArrow('success_rate')}</th>
+      <th data-col="avg_steps">Avg Steps ${sortArrow('avg_steps')}</th>
+      <th data-col="avg_tokens">Avg Tokens ${sortArrow('avg_tokens')}</th>
+      <th data-col="repetition_rate">Repetition <span class="tooltip-icon" title="Fraction of agent actions that repeat the immediately previous choice. High values indicate the agent is stuck in a loop.">?</span>${sortArrow('repetition_rate')}</th>`;
+  } else {
+    header.innerHTML = `<th>#</th>
+      <th data-col="model">Model ${sortArrow('model')}</th>
+      <th data-col="mode">Mode ${sortArrow('mode')}</th>
+      <th data-col="quest">Quest ${sortArrow('quest')}</th>
+      <th data-col="runs">Runs ${sortArrow('runs')}</th>
+      <th data-col="success_rate">Success Rate ${sortArrow('success_rate')}</th>
+      <th data-col="avg_steps">Steps ${sortArrow('avg_steps')}</th>
+      <th data-col="avg_tokens">Tokens ${sortArrow('avg_tokens')}</th>
+      <th data-col="repetition_rate">Repetition <span class="tooltip-icon" title="Fraction of agent actions that repeat the immediately previous choice. High values indicate the agent is stuck in a loop.">?</span>${sortArrow('repetition_rate')}</th>`;
+  }
+
+  const rows = (viewMode === 'summary' ? aggregated() : filtered()).slice().sort((a,b) => {
     let va = a[sortCol], vb = b[sortCol];
     if (typeof va === 'string') return sortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
     return sortAsc ? va - vb : vb - va;
   });
-  document.querySelectorAll('#leaderboard thead th').forEach(th => {
-    th.classList.remove('sorted-asc','sorted-desc');
-    if (th.dataset.col === sortCol) th.classList.add(sortAsc ? 'sorted-asc' : 'sorted-desc');
-  });
+
   const tbody = document.querySelector('#leaderboard tbody');
-  tbody.innerHTML = rows.map((r,i) => `<tr>
-    <td>${i+1}</td>
-    <td><strong>${esc(r.model)}</strong></td>
-    <td><span class="badge badge-mode ${MODE_CLASSES[r.mode]||''}">${MODE_LABELS[r.mode]||esc(r.mode)}</span></td>
-    <td>${esc(r.quest)}</td>
-    <td><div class="d-flex align-items-center gap-2"><div class="success-bar"><div class="success-fill" style="width:${r.success_rate*100}%;background:${successColor(r.success_rate)}"></div></div><span>${(r.success_rate*100).toFixed(0)}%</span></div></td>
-    <td>${r.avg_steps}</td>
-    <td>${r.avg_tokens.toLocaleString()}</td>
-    <td>$${r.avg_cost_usd.toFixed(4)}</td>
-    <td>${(r.repetition_rate*100).toFixed(1)}%</td>
-  </tr>`).join('');
+  if (viewMode === 'summary') {
+    tbody.innerHTML = rows.map((r,i) => `<tr>
+      <td>${i+1}</td>
+      <td><strong>${esc(r.model)}</strong></td>
+      <td><span class="badge badge-mode ${MODE_CLASSES[r.mode]||''}">${MODE_LABELS[r.mode]||esc(r.mode)}</span></td>
+      <td>${r.quests}</td>
+      <td>${r.runs}</td>
+      <td><div class="d-flex align-items-center gap-2"><div class="success-bar"><div class="success-fill" style="width:${r.success_rate*100}%;background:${successColor(r.success_rate)}"></div></div><span>${(r.success_rate*100).toFixed(0)}%</span></div></td>
+      <td>${r.avg_steps.toFixed(1)}</td>
+      <td>${r.avg_tokens.toLocaleString(undefined,{maximumFractionDigits:0})}</td>
+      <td>${(r.repetition_rate*100).toFixed(1)}%</td>
+    </tr>`).join('');
+  } else {
+    tbody.innerHTML = rows.map((r,i) => `<tr>
+      <td>${i+1}</td>
+      <td><strong>${esc(r.model)}</strong></td>
+      <td><span class="badge badge-mode ${MODE_CLASSES[r.mode]||''}">${MODE_LABELS[r.mode]||esc(r.mode)}</span></td>
+      <td>${esc(r.quest)}</td>
+      <td>${r.runs}</td>
+      <td><div class="d-flex align-items-center gap-2"><div class="success-bar"><div class="success-fill" style="width:${r.success_rate*100}%;background:${successColor(r.success_rate)}"></div></div><span>${(r.success_rate*100).toFixed(0)}%</span></div></td>
+      <td>${r.avg_steps}</td>
+      <td>${r.avg_tokens.toLocaleString()}</td>
+      <td>${(r.repetition_rate*100).toFixed(1)}%</td>
+    </tr>`).join('');
+  }
 }
 
 function renderBarChart() {
-  const chart = echarts.init(document.getElementById('chart-bar'));
+  const el = document.getElementById('chart-bar');
+  const chart = echarts.getInstanceByDom(el) || echarts.init(el);
   const models = DATA.models.map(m => m.label);
   const series = DATA.modes.map(mode => ({
     name: MODE_LABELS[mode.id], type: 'bar',
@@ -227,34 +305,36 @@ function renderBarChart() {
     xAxis: {type:'category', data:models, axisLabel:{color:'#c9d1d9'}, axisLine:{lineStyle:{color:'#30363d'}}},
     yAxis: {type:'value', name:'Success %', nameTextStyle:{color:'#c9d1d9'}, axisLabel:{color:'#c9d1d9'}, splitLine:{lineStyle:{color:'#21262d'}}},
     series
-  });
+  }, true);
   window.addEventListener('resize', () => chart.resize());
 }
 
 function renderScatterChart() {
-  const chart = echarts.init(document.getElementById('chart-scatter'));
+  const el = document.getElementById('chart-scatter');
+  const chart = echarts.getInstanceByDom(el) || echarts.init(el);
   const series = DATA.modes.map((mode, mi) => ({
     name: MODE_LABELS[mode.id], type: 'scatter', symbolSize: 14, symbol: MODEL_SYMBOLS[mi] || 'circle',
     data: filtered().filter(r => r.mode === mode.id).map(r => ({
-      value: [r.avg_cost_usd, r.success_rate * 100],
+      value: [r.avg_steps, r.success_rate * 100],
       name: `${r.model} / ${r.quest}`
     })),
     itemStyle: {color: COLORS[mode.id]}
   }));
   chart.setOption({
     tooltip: {trigger:'item', backgroundColor:'#161b22', borderColor:'#30363d', textStyle:{color:'#e6edf3'},
-      formatter: p => `${p.seriesName}<br/>${p.data.name}<br/>Cost: $${p.value[0].toFixed(4)}<br/>Success: ${p.value[1].toFixed(0)}%`},
+      formatter: p => `${esc(p.seriesName)}<br/>${esc(p.data.name)}<br/>Steps: ${p.value[0]}<br/>Success: ${p.value[1].toFixed(0)}%`},
     legend: {textStyle:{color:'#c9d1d9'}, bottom: 0},
     grid: {left:'3%',right:'4%',bottom:'15%',containLabel:true},
-    xAxis: {name:'Avg Cost (USD)', nameTextStyle:{color:'#c9d1d9'}, axisLabel:{color:'#c9d1d9', formatter:v=>'$'+v}, splitLine:{lineStyle:{color:'#21262d'}}, axisLine:{lineStyle:{color:'#30363d'}}},
+    xAxis: {name:'Avg Steps', nameTextStyle:{color:'#c9d1d9'}, axisLabel:{color:'#c9d1d9'}, splitLine:{lineStyle:{color:'#21262d'}}, axisLine:{lineStyle:{color:'#30363d'}}},
     yAxis: {name:'Success %', nameTextStyle:{color:'#c9d1d9'}, axisLabel:{color:'#c9d1d9'}, splitLine:{lineStyle:{color:'#21262d'}}, max:105},
     series
-  });
+  }, true);
   window.addEventListener('resize', () => chart.resize());
 }
 
 function renderLiftChart() {
-  const chart = echarts.init(document.getElementById('chart-lift'));
+  const el = document.getElementById('chart-lift');
+  const chart = echarts.getInstanceByDom(el) || echarts.init(el);
   const models = DATA.models.map(m => m.label);
   const nonBaseline = DATA.modes.filter(m => m.id !== 'stub');
   const series = nonBaseline.map(mode => ({
@@ -277,7 +357,7 @@ function renderLiftChart() {
     xAxis: {type:'category', data:models, axisLabel:{color:'#c9d1d9'}, axisLine:{lineStyle:{color:'#30363d'}}},
     yAxis: {type:'value', name:'Lift (pp)', nameTextStyle:{color:'#c9d1d9'}, axisLabel:{color:'#c9d1d9', formatter:v=>(v>0?'+':'')+v+'pp'}, splitLine:{lineStyle:{color:'#21262d'}}},
     series
-  });
+  }, true);
   window.addEventListener('resize', () => chart.resize());
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -43,7 +43,11 @@ a { color: var(--accent); }
 <nav class="navbar navbar-dark py-3">
   <div class="container">
     <span class="navbar-brand mb-0 h1">LLM-Quest Benchmark</span>
-    <a href="https://github.com/yourconscience/llm_quest_benchmark" class="text-decoration-none" style="color:var(--muted)">GitHub</a>
+    <div>
+      <a href="about.html" class="text-decoration-none" style="color:var(--muted); margin-left:1.5rem">About</a>
+      <a href="index.html" class="text-decoration-none" style="color:var(--accent); margin-left:1.5rem">Leaderboard</a>
+      <a href="https://github.com/yourconscience/llm_quest_benchmark" class="text-decoration-none" style="color:var(--muted); margin-left:1.5rem">GitHub</a>
+    </div>
   </div>
 </nav>
 

--- a/site/index.html
+++ b/site/index.html
@@ -129,30 +129,32 @@ function successColor(v) { return v >= 0.8 ? 'var(--green)' : v >= 0.4 ? 'var(--
 function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 
 function filtered() {
-  return DATA.results.filter(r => (filterMode === 'all' || r.mode === filterMode) && (filterQuest === 'all' || r.quest === filterQuest));
+  const q = viewMode === 'summary' ? 'all' : filterQuest;
+  return DATA.results.filter(r => (filterMode === 'all' || r.mode === filterMode) && (q === 'all' || r.quest === q));
 }
 
 function aggregated() {
   const groups = {};
   filtered().forEach(r => {
     const key = `${r.model}|${r.mode}`;
-    if (!groups[key]) groups[key] = { model: r.model, mode: r.mode, rates: [], steps: [], tokens: [], reps: [], runs: 0 };
+    if (!groups[key]) groups[key] = { model: r.model, mode: r.mode, s: 0, st: 0, t: 0, rp: 0, runs: 0, q: 0 };
     const g = groups[key];
-    g.rates.push(r.success_rate);
-    g.steps.push(r.avg_steps);
-    g.tokens.push(r.avg_tokens);
-    g.reps.push(r.repetition_rate);
+    g.s += r.success_rate * r.runs;
+    g.st += r.avg_steps * r.runs;
+    g.t += r.avg_tokens * r.runs;
+    g.rp += r.repetition_rate * r.runs;
     g.runs += r.runs;
+    g.q += 1;
   });
   return Object.values(groups).map(g => ({
     model: g.model,
     mode: g.mode,
-    success_rate: g.rates.reduce((a,b)=>a+b,0) / g.rates.length,
-    avg_steps: g.steps.reduce((a,b)=>a+b,0) / g.steps.length,
-    avg_tokens: g.tokens.reduce((a,b)=>a+b,0) / g.tokens.length,
-    repetition_rate: g.reps.reduce((a,b)=>a+b,0) / g.reps.length,
+    success_rate: g.runs ? g.s / g.runs : 0,
+    avg_steps: g.runs ? g.st / g.runs : 0,
+    avg_tokens: g.runs ? g.t / g.runs : 0,
+    repetition_rate: g.runs ? g.rp / g.runs : 0,
     runs: g.runs,
-    quests: g.rates.length,
+    quests: g.q,
   }));
 }
 
@@ -181,7 +183,7 @@ async function init() {
     document.getElementById('quest-all-btn').style.display = showQuest ? '' : 'none';
     document.getElementById('quest-filters').style.display = showQuest ? '' : 'none';
     sortCol = 'success_rate'; sortAsc = false;
-    renderTable();
+    renderAll();
   });
   document.getElementById('quest-filter-label').style.display = 'none';
   document.getElementById('quest-all-btn').style.display = 'none';
@@ -215,12 +217,12 @@ function renderAll() {
 
 function renderStats() {
   const rows = viewMode === 'summary' ? aggregated() : filtered();
-  const avg = (arr, key) => arr.length ? arr.reduce((s, r) => s + r[key], 0) / arr.length : 0;
   const totalRuns = rows.reduce((s, r) => s + r.runs, 0);
+  const wAvg = (key) => totalRuns ? rows.reduce((s, r) => s + (r[key] * r.runs), 0) / totalRuns : 0;
   const stats = [
-    {value: (avg(rows,'success_rate')*100).toFixed(0)+'%', label: 'Avg Success Rate'},
-    {value: avg(rows,'avg_steps').toFixed(0), label: 'Avg Steps/Run'},
-    {value: avg(rows,'avg_tokens').toFixed(0), label: 'Avg Tokens/Run'},
+    {value: (wAvg('success_rate')*100).toFixed(0)+'%', label: 'Avg Success Rate'},
+    {value: wAvg('avg_steps').toFixed(0), label: 'Avg Steps/Run'},
+    {value: wAvg('avg_tokens').toFixed(0), label: 'Avg Tokens/Run'},
     {value: totalRuns.toLocaleString(), label: 'Total Runs'},
   ];
   document.getElementById('stats-row').innerHTML = stats.map(s => `<div class="col-6 col-md-3"><div class="card stat-card"><div class="stat-value">${s.value}</div><div class="stat-label">${s.label}</div></div></div>`).join('');

--- a/site/index.html
+++ b/site/index.html
@@ -284,8 +284,8 @@ function renderTable() {
       <td>${esc(r.quest)}</td>
       <td>${r.runs}</td>
       <td><div class="d-flex align-items-center gap-2"><div class="success-bar"><div class="success-fill" style="width:${r.success_rate*100}%;background:${successColor(r.success_rate)}"></div></div><span>${(r.success_rate*100).toFixed(0)}%</span></div></td>
-      <td>${r.avg_steps}</td>
-      <td>${r.avg_tokens.toLocaleString()}</td>
+      <td>${r.avg_steps.toFixed(1)}</td>
+      <td>${r.avg_tokens.toLocaleString(undefined,{maximumFractionDigits:0})}</td>
       <td>${(r.repetition_rate*100).toFixed(1)}%</td>
     </tr>`).join('');
   }


### PR DESCRIPTION
## Summary
- Add Summary / Per Quest tab views. Summary aggregates results by model+mode across all quests; Per Quest shows individual quest-level detail.
- Remove broken cost column and cost stat card (cost tracking returns $0 for all OpenRouter runs).
- Fix sort arrow rendering: replaced CSS `::after` pseudo-elements (broken by `text-transform: uppercase`) with inline `<span>` elements.
- Add `?` tooltip for repetition metric explaining what it measures.
- Replace cost-vs-success scatter chart with steps-vs-success.
- Add new "Mode Impact" lift chart showing success rate improvement over baseline.
- Add TODO in `leaderboard.py` for fixing cost tracking.

## Test plan
- [ ] Verify Summary tab shows aggregated model+mode rows (not per-quest)
- [ ] Verify Per Quest tab shows individual quest rows with quest filter controls
- [ ] Verify sort arrows render correctly (no `U25BC` text artifacts)
- [ ] Verify repetition metric `?` tooltip shows description on hover
- [ ] Verify charts update when mode filters change
- [ ] Verify no cost column appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a dark-themed About page with benchmark details, metrics, reproduction steps, and model list
  - Added Summary vs Per Quest view modes with aggregated Summary (Quests, Runs) and a new Total Runs metric

* **UX / Data Display**
  - Table sorting and headers made data-driven and rebuilt per view
  - Filtering respects view mode (Summary shows all quests)
  - Scatter chart now shows average steps (axis/tooltip updated)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->