### PR TITLE
Update model selection to 6 tested providers + Phase 1 configs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -72,19 +72,21 @@ The C1-vs-C0 delta is the "does knowledge help?" finding. The C2-vs-C1 delta mea
 
 Mid-tier models: we benchmark the "Sonnet-equivalent" production tier for each provider - the models most developers actually use. This keeps per-run cost in the $0.01-0.04 range and makes the comparison fair (similar capability/price class). High-tier comparison (Claude Sonnet, GPT-5.4, Gemini Pro) is a planned follow-up.
 
-**Primary (7 models, all via OpenRouter):**
+**Primary (6 models, all via OpenRouter, Arena ELO 1403-1474):**
 
-| Provider | Model | OpenRouter ID | In $/1M | Out $/1M |
-|---|---|---|---|---|
-| DeepSeek | V3.2 | `deepseek/deepseek-v3.2` | $0.26 | $0.42 |
-| Qwen | Qwen3.5 Plus | `qwen/qwen3.5-plus-02-15` | $0.26 | $1.56 |
-| Moonshot | Kimi K2.5 | `moonshotai/kimi-k2.5` | $0.38 | $1.72 |
-| Google | Gemini 3 Flash | `google/gemini-3-flash-preview` | $0.50 | $3.00 |
-| Z.ai (GLM) | GLM-5 | `z-ai/glm-5` | $0.72 | $2.30 |
-| OpenAI | GPT-5.4 Mini | `openai/gpt-5.4-mini` | $0.75 | $4.50 |
+| Provider | Model | OpenRouter ID | In $/1M | Out $/1M | Arena ELO |
+|---|---|---|---|---|---|
+| Google | Gemini 3 Flash | `google/gemini-3-flash-preview` | $0.50 | $3.00 | 1474 |
+| OpenAI | GPT-5.4 Mini | `openai/gpt-5.4-mini` | $0.75 | $4.50 | 1458 |
+| DeepSeek | V3.2 | `deepseek/deepseek-v3.2` | $0.26 | $0.42 | 1424 |
+| Mistral | Medium 3.1 | `mistralai/mistral-medium-3.1` | $0.40 | $2.00 | 1410 |
+| Anthropic | Claude Haiku 4.5 | `anthropic/claude-haiku-4.5` | $1.00 | $5.00 | 1408 |
+| Minimax | M2.5 | `minimax/minimax-m2.5` | $0.12 | $0.99 | 1403 |
+
+Selection rationale: one model per major provider, mid-tier production class (ELO 1400-1475), all tested for speed and reliability via OpenRouter. Qwen excluded (all recent models too slow on OpenRouter routing). Kimi K2.5 and GLM-5 excluded (latency and parse reliability issues on OpenRouter).
 
 **Excluded from main benchmark (high-tier, follow-up):**
-- Anthropic Claude Sonnet 4.6 ($3/$15) - 10-35x output price of mid-tier
+- Anthropic Claude Sonnet 4.6 ($3/$15) - frontier tier
 - OpenAI GPT-5.4 ($1.25/$10) - frontier tier
 - Google Gemini 3 Pro - frontier tier
 

--- a/configs/benchmarks/phase1/phase1_deepseek_v3.yaml
+++ b/configs/benchmarks/phase1/phase1_deepseek_v3.yaml
@@ -1,0 +1,30 @@
+name: phase1_deepseek_v3
+quests:
+- quests/Boat.qm
+- quests/sr_2_1_2121_eng/Badday_eng.qm
+- quests/sr_2_1_2121_eng/Banket_eng.qm
+- quests/sr_2_1_2121_eng/Codebox_eng.qm
+- quests/sr_2_1_2121_eng/Depth_eng.qm
+- quests/sr_2_1_2121_eng/Driver_eng.qm
+- quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+- quests/sr_2_1_2121_eng/Election_eng.qm
+- quests/sr_2_1_2121_eng/Foncers_eng.qm
+- quests/sr_2_1_2121_eng/Leonardo_eng.qm
+- quests/sr_2_1_2121_eng/Ministry_eng.qm
+- quests/sr_2_1_2121_eng/Pizza_eng.qm
+- quests/sr_2_1_2121_eng/Prison_eng.qm
+- quests/sr_2_1_2121_eng/Robots_eng.qm
+- quests/sr_2_1_2121_eng/Ski_eng.qm
+agents:
+- model: openrouter:deepseek/deepseek-v3.2
+  template: stub
+  temperature: 0.4
+  runs: 3
+- model: openrouter:deepseek/deepseek-v3.2
+  template: reasoning
+  temperature: 0.4
+  runs: 3
+debug: false
+quest_timeout: 600
+max_workers: 1
+output_dir: results/benchmarks

--- a/configs/benchmarks/phase1/phase1_gemini3_flash.yaml
+++ b/configs/benchmarks/phase1/phase1_gemini3_flash.yaml
@@ -1,0 +1,30 @@
+name: phase1_gemini3_flash
+quests:
+- quests/Boat.qm
+- quests/sr_2_1_2121_eng/Badday_eng.qm
+- quests/sr_2_1_2121_eng/Banket_eng.qm
+- quests/sr_2_1_2121_eng/Codebox_eng.qm
+- quests/sr_2_1_2121_eng/Depth_eng.qm
+- quests/sr_2_1_2121_eng/Driver_eng.qm
+- quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+- quests/sr_2_1_2121_eng/Election_eng.qm
+- quests/sr_2_1_2121_eng/Foncers_eng.qm
+- quests/sr_2_1_2121_eng/Leonardo_eng.qm
+- quests/sr_2_1_2121_eng/Ministry_eng.qm
+- quests/sr_2_1_2121_eng/Pizza_eng.qm
+- quests/sr_2_1_2121_eng/Prison_eng.qm
+- quests/sr_2_1_2121_eng/Robots_eng.qm
+- quests/sr_2_1_2121_eng/Ski_eng.qm
+agents:
+- model: openrouter:google/gemini-3-flash-preview
+  template: stub
+  temperature: 0.4
+  runs: 3
+- model: openrouter:google/gemini-3-flash-preview
+  template: reasoning
+  temperature: 0.4
+  runs: 3
+debug: false
+quest_timeout: 600
+max_workers: 1
+output_dir: results/benchmarks

--- a/configs/benchmarks/phase1/phase1_gpt54_mini.yaml
+++ b/configs/benchmarks/phase1/phase1_gpt54_mini.yaml
@@ -1,0 +1,30 @@
+name: phase1_gpt54_mini
+quests:
+- quests/Boat.qm
+- quests/sr_2_1_2121_eng/Badday_eng.qm
+- quests/sr_2_1_2121_eng/Banket_eng.qm
+- quests/sr_2_1_2121_eng/Codebox_eng.qm
+- quests/sr_2_1_2121_eng/Depth_eng.qm
+- quests/sr_2_1_2121_eng/Driver_eng.qm
+- quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+- quests/sr_2_1_2121_eng/Election_eng.qm
+- quests/sr_2_1_2121_eng/Foncers_eng.qm
+- quests/sr_2_1_2121_eng/Leonardo_eng.qm
+- quests/sr_2_1_2121_eng/Ministry_eng.qm
+- quests/sr_2_1_2121_eng/Pizza_eng.qm
+- quests/sr_2_1_2121_eng/Prison_eng.qm
+- quests/sr_2_1_2121_eng/Robots_eng.qm
+- quests/sr_2_1_2121_eng/Ski_eng.qm
+agents:
+- model: openrouter:openai/gpt-5.4-mini
+  template: stub
+  temperature: 0.4
+  runs: 3
+- model: openrouter:openai/gpt-5.4-mini
+  template: reasoning
+  temperature: 0.4
+  runs: 3
+debug: false
+quest_timeout: 600
+max_workers: 1
+output_dir: results/benchmarks

--- a/configs/benchmarks/phase1/phase1_haiku45.yaml
+++ b/configs/benchmarks/phase1/phase1_haiku45.yaml
@@ -1,0 +1,30 @@
+name: phase1_haiku45
+quests:
+- quests/Boat.qm
+- quests/sr_2_1_2121_eng/Badday_eng.qm
+- quests/sr_2_1_2121_eng/Banket_eng.qm
+- quests/sr_2_1_2121_eng/Codebox_eng.qm
+- quests/sr_2_1_2121_eng/Depth_eng.qm
+- quests/sr_2_1_2121_eng/Driver_eng.qm
+- quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+- quests/sr_2_1_2121_eng/Election_eng.qm
+- quests/sr_2_1_2121_eng/Foncers_eng.qm
+- quests/sr_2_1_2121_eng/Leonardo_eng.qm
+- quests/sr_2_1_2121_eng/Ministry_eng.qm
+- quests/sr_2_1_2121_eng/Pizza_eng.qm
+- quests/sr_2_1_2121_eng/Prison_eng.qm
+- quests/sr_2_1_2121_eng/Robots_eng.qm
+- quests/sr_2_1_2121_eng/Ski_eng.qm
+agents:
+- model: openrouter:anthropic/claude-haiku-4.5
+  template: stub
+  temperature: 0.4
+  runs: 3
+- model: openrouter:anthropic/claude-haiku-4.5
+  template: reasoning
+  temperature: 0.4
+  runs: 3
+debug: false
+quest_timeout: 600
+max_workers: 1
+output_dir: results/benchmarks

--- a/configs/benchmarks/phase1/phase1_minimax_m25.yaml
+++ b/configs/benchmarks/phase1/phase1_minimax_m25.yaml
@@ -1,0 +1,30 @@
+name: phase1_minimax_m25
+quests:
+- quests/Boat.qm
+- quests/sr_2_1_2121_eng/Badday_eng.qm
+- quests/sr_2_1_2121_eng/Banket_eng.qm
+- quests/sr_2_1_2121_eng/Codebox_eng.qm
+- quests/sr_2_1_2121_eng/Depth_eng.qm
+- quests/sr_2_1_2121_eng/Driver_eng.qm
+- quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+- quests/sr_2_1_2121_eng/Election_eng.qm
+- quests/sr_2_1_2121_eng/Foncers_eng.qm
+- quests/sr_2_1_2121_eng/Leonardo_eng.qm
+- quests/sr_2_1_2121_eng/Ministry_eng.qm
+- quests/sr_2_1_2121_eng/Pizza_eng.qm
+- quests/sr_2_1_2121_eng/Prison_eng.qm
+- quests/sr_2_1_2121_eng/Robots_eng.qm
+- quests/sr_2_1_2121_eng/Ski_eng.qm
+agents:
+- model: openrouter:minimax/minimax-m2.5
+  template: stub
+  temperature: 0.4
+  runs: 3
+- model: openrouter:minimax/minimax-m2.5
+  template: reasoning
+  temperature: 0.4
+  runs: 3
+debug: false
+quest_timeout: 600
+max_workers: 1
+output_dir: results/benchmarks

--- a/configs/benchmarks/phase1/phase1_mistral_large.yaml
+++ b/configs/benchmarks/phase1/phase1_mistral_large.yaml
@@ -1,0 +1,30 @@
+name: phase1_mistral_large
+quests:
+- quests/Boat.qm
+- quests/sr_2_1_2121_eng/Badday_eng.qm
+- quests/sr_2_1_2121_eng/Banket_eng.qm
+- quests/sr_2_1_2121_eng/Codebox_eng.qm
+- quests/sr_2_1_2121_eng/Depth_eng.qm
+- quests/sr_2_1_2121_eng/Driver_eng.qm
+- quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+- quests/sr_2_1_2121_eng/Election_eng.qm
+- quests/sr_2_1_2121_eng/Foncers_eng.qm
+- quests/sr_2_1_2121_eng/Leonardo_eng.qm
+- quests/sr_2_1_2121_eng/Ministry_eng.qm
+- quests/sr_2_1_2121_eng/Pizza_eng.qm
+- quests/sr_2_1_2121_eng/Prison_eng.qm
+- quests/sr_2_1_2121_eng/Robots_eng.qm
+- quests/sr_2_1_2121_eng/Ski_eng.qm
+agents:
+- model: openrouter:mistralai/mistral-medium-3.1
+  template: stub
+  temperature: 0.4
+  runs: 3
+- model: openrouter:mistralai/mistral-medium-3.1
+  template: reasoning
+  temperature: 0.4
+  runs: 3
+debug: false
+quest_timeout: 600
+max_workers: 1
+output_dir: results/benchmarks

--- a/configs/benchmarks/phase1/phase1_mistral_medium.yaml
+++ b/configs/benchmarks/phase1/phase1_mistral_medium.yaml
@@ -1,4 +1,4 @@
-name: phase1_mistral_large
+name: phase1_mistral_medium
 quests:
 - quests/Boat.qm
 - quests/sr_2_1_2121_eng/Badday_eng.qm

--- a/llm_quest_benchmark/llm/client.py
+++ b/llm_quest_benchmark/llm/client.py
@@ -67,13 +67,14 @@ DEFAULT_MODEL_PRICING_USD_PER_1M = {
     "openai:gpt-5-mini": {"input": 0.25, "output": 2.0},
     "openai:gpt-5-nano": {"input": 0.05, "output": 0.4},
     "openai:gpt-5.4": {"input": 1.25, "output": 10.0},
-    "openai:gpt-5.4-mini": {"input": 0.25, "output": 2.0},
+    "openai:gpt-5.4-mini": {"input": 0.75, "output": 4.5},
     "openai:o4-mini": {"input": 4.0, "output": 16.0},
     # Anthropic
     "anthropic:claude-sonnet-4-5": {"input": 3.0, "output": 15.0},
     "anthropic:claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
     "anthropic:claude-opus-4-1-20250805": {"input": 15.0, "output": 75.0},
     "anthropic:claude-3-5-haiku-latest": {"input": 0.8, "output": 4.0},
+    "anthropic:claude-haiku-4.5": {"input": 1.0, "output": 5.0},
     # Google Gemini
     "google:gemini-2.5-pro": {"input": 1.25, "output": 10.0},
     "google:gemini-2.5-flash": {"input": 0.3, "output": 2.5},
@@ -87,7 +88,14 @@ DEFAULT_MODEL_PRICING_USD_PER_1M = {
     # Qwen (via OpenRouter)
     "qwen:qwen-2.5-72b-instruct": {"input": 0.4, "output": 0.4},
     "qwen:qwen3-235b-a22b": {"input": 0.14, "output": 0.6},
+    "qwen:qwen3-235b-a22b-2507": {"input": 0.071, "output": 0.10},
+    "qwen:qwen3.5-flash-02-23": {"input": 0.065, "output": 0.26},
     "qwen:qwen3.5-plus-02-15": {"input": 0.26, "output": 1.56},
+    # Mistral
+    "mistralai:mistral-large-2512": {"input": 0.5, "output": 1.5},
+    "mistralai:mistral-medium-3.1": {"input": 0.4, "output": 2.0},
+    # Minimax
+    "minimax:minimax-m2.5": {"input": 0.118, "output": 0.99},
     # Moonshot / Kimi
     "moonshotai:kimi-k2.5": {"input": 0.38, "output": 1.72},
     # Z.ai / GLM

--- a/scripts/generate_parallel_configs.py
+++ b/scripts/generate_parallel_configs.py
@@ -1,0 +1,71 @@
+"""Generate per-model benchmark configs for parallel execution."""
+
+from pathlib import Path
+
+import yaml
+
+QUESTS = [
+    "quests/Boat.qm",
+    "quests/sr_2_1_2121_eng/Badday_eng.qm",
+    "quests/sr_2_1_2121_eng/Banket_eng.qm",
+    "quests/sr_2_1_2121_eng/Codebox_eng.qm",
+    "quests/sr_2_1_2121_eng/Depth_eng.qm",
+    "quests/sr_2_1_2121_eng/Driver_eng.qm",
+    "quests/sr_2_1_2121_eng/Edelweiss_eng.qm",
+    "quests/sr_2_1_2121_eng/Election_eng.qm",
+    "quests/sr_2_1_2121_eng/Foncers_eng.qm",
+    "quests/sr_2_1_2121_eng/Leonardo_eng.qm",
+    "quests/sr_2_1_2121_eng/Ministry_eng.qm",
+    "quests/sr_2_1_2121_eng/Pizza_eng.qm",
+    "quests/sr_2_1_2121_eng/Prison_eng.qm",
+    "quests/sr_2_1_2121_eng/Robots_eng.qm",
+    "quests/sr_2_1_2121_eng/Ski_eng.qm",
+]
+
+MODELS = [
+    ("google/gemini-3-flash-preview", "gemini3_flash"),
+    ("openai/gpt-5.4-mini", "gpt54_mini"),
+    ("deepseek/deepseek-v3.2", "deepseek_v3"),
+    ("mistralai/mistral-large-2512", "mistral_large"),
+    ("anthropic/claude-haiku-4.5", "haiku45"),
+    ("minimax/minimax-m2.5", "minimax_m25"),
+]
+
+TEMPLATES = ["stub", "reasoning"]
+RUNS = 3
+TEMPERATURE = 0.4
+QUEST_TIMEOUT = 600
+
+output_dir = Path("configs/benchmarks/phase1")
+output_dir.mkdir(exist_ok=True)
+
+for model_id, short_name in MODELS:
+    config = {
+        "name": f"phase1_{short_name}",
+        "quests": QUESTS,
+        "agents": [
+            {
+                "model": f"openrouter:{model_id}",
+                "template": template,
+                "temperature": TEMPERATURE,
+                "runs": RUNS,
+            }
+            for template in TEMPLATES
+        ],
+        "debug": False,
+        "quest_timeout": QUEST_TIMEOUT,
+        "max_workers": 1,
+        "output_dir": "results/benchmarks",
+    }
+    path = output_dir / f"phase1_{short_name}.yaml"
+    with open(path, "w") as f:
+        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+    print(f"Generated: {path}")
+
+print(
+    f"\nGenerated {len(MODELS)} configs, {len(QUESTS)} quests x {len(TEMPLATES)} templates x {RUNS} runs = {len(QUESTS) * len(TEMPLATES) * RUNS} runs per model"
+)
+print(f"Total: {len(MODELS) * len(QUESTS) * len(TEMPLATES) * RUNS} runs")
+print("\nTo run in parallel:")
+for _, short_name in MODELS:
+    print(f"  uv run llm-quest benchmark --config configs/benchmarks/phase1/phase1_{short_name}.yaml &")

--- a/scripts/generate_parallel_configs.py
+++ b/scripts/generate_parallel_configs.py
@@ -26,7 +26,7 @@ MODELS = [
     ("google/gemini-3-flash-preview", "gemini3_flash"),
     ("openai/gpt-5.4-mini", "gpt54_mini"),
     ("deepseek/deepseek-v3.2", "deepseek_v3"),
-    ("mistralai/mistral-large-2512", "mistral_large"),
+    ("mistralai/mistral-medium-3.1", "mistral_medium"),
     ("anthropic/claude-haiku-4.5", "haiku45"),
     ("minimax/minimax-m2.5", "minimax_m25"),
 ]
@@ -37,7 +37,7 @@ TEMPERATURE = 0.4
 QUEST_TIMEOUT = 600
 
 output_dir = Path("configs/benchmarks/phase1")
-output_dir.mkdir(exist_ok=True)
+output_dir.mkdir(parents=True, exist_ok=True)
 
 for model_id, short_name in MODELS:
     config = {


### PR DESCRIPTION
## Summary

- Replaces 7-model provider matrix (Qwen, Kimi, GLM included) with a final 6-model lineup: one model per major provider, all tested for speed and reliability on OpenRouter
- Excluded models: Qwen (all recent variants too slow on OpenRouter routing), Kimi K2.5 and GLM-5 (latency and parse reliability issues)
- Adds Arena ELO scores to the provider matrix table (range: 1403-1474, mid-tier production class)
- Corrects `gpt-5.4-mini` pricing: was $0.25/$2.0, now $0.75/$4.5
- Adds pricing entries for new models: `claude-haiku-4.5`, `qwen3-235b-a22b-2507`, `qwen3.5-flash-02-23`, `mistral-large-2512`, `mistral-medium-3.1`, `minimax-m2.5`
- Adds `scripts/generate_parallel_configs.py` - script that generated the per-model Phase 1 configs
- Adds `configs/benchmarks/phase1/` with 6 per-model YAML configs (15 quests x 2 templates x 3 runs each, all via OpenRouter)

## Final model lineup

| Provider | Model | ELO |
|---|---|---|
| Google | Gemini 3 Flash | 1474 |
| OpenAI | GPT-5.4 Mini | 1458 |
| DeepSeek | V3.2 | 1424 |
| Mistral | Medium 3.1 | 1410 |
| Anthropic | Claude Haiku 4.5 | 1408 |
| Minimax | M2.5 | 1403 |

## Test plan

- `uv run ruff check` passes (2 style fixes auto-applied to the new script)
- `uv run ruff format` passes
- 89 unit tests pass; 9 integration test failures are pre-existing (require TypeScript submodule not present in worktree)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added benchmark configurations for six AI models, including DeepSeek V3, Gemini 3 Flash, GPT 5.4 Mini, Claude Haiku, Minimax M2.5, and Mistral Medium 3.1
  * Introduced automated benchmark configuration generation tool

* **Updates**
  * Refined primary model roster with narrower mid-tier selection and explicit selection rationale
  * Updated model pricing information for cost estimation
  * Enhanced benchmark specifications with Arena ELO metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->