### PR TITLE
Add memory modes and authoritative outcome detection

### DIFF
--- a/configs/benchmarks/memory_modes_pilot.yaml
+++ b/configs/benchmarks/memory_modes_pilot.yaml
@@ -1,0 +1,38 @@
+name: memory_modes_pilot
+quests:
+- quests/sr_2_1_2121_eng/Pizza_eng.qm
+- quests/sr_2_1_2121_eng/Ski_eng.qm
+agents:
+# A: Baseline - default memory (3 obs, 5 decisions)
+- model: openrouter:google/gemini-3-flash-preview
+  template: reasoning
+  temperature: 0.4
+  runs: 3
+  memory_mode: default
+
+# B: Loop-aware template - default memory
+- model: openrouter:google/gemini-3-flash-preview
+  template: loop_aware_reasoning
+  temperature: 0.4
+  runs: 3
+  memory_mode: default
+
+# C: Full transcript memory
+- model: openrouter:google/gemini-3-flash-preview
+  template: reasoning
+  temperature: 0.4
+  runs: 3
+  memory_mode: full_transcript
+
+# D: Compaction memory (compact every 10 steps)
+- model: openrouter:google/gemini-3-flash-preview
+  template: reasoning
+  temperature: 0.4
+  runs: 3
+  memory_mode: compaction
+  compaction_interval: 10
+
+debug: false
+quest_timeout: 600
+max_workers: 1
+output_dir: results/benchmarks

--- a/llm_quest_benchmark/agents/agent_factory.py
+++ b/llm_quest_benchmark/agents/agent_factory.py
@@ -26,6 +26,8 @@ def create_agent(
     temperature: float = DEFAULT_TEMPERATURE,
     skip_single: bool = False,
     debug: bool = False,
+    memory_mode: str = "default",
+    compaction_interval: int = 10,
 ) -> QuestPlayer:
     """Create a quest agent based on model name and parameters.
 
@@ -91,4 +93,6 @@ def create_agent(
         action_template=resolved_action_template,
         temperature=temperature,
         skip_single=skip_single,
+        memory_mode=memory_mode,
+        compaction_interval=compaction_interval,
     )

--- a/llm_quest_benchmark/agents/llm_agent.py
+++ b/llm_quest_benchmark/agents/llm_agent.py
@@ -540,7 +540,14 @@ class LLMAgent(QuestPlayer):
                     else getattr(compaction_usage, "completion_tokens", 0)
                 )
                 self._record_compaction_usage(pt, ct)
-            self._compaction_summary = summary.strip()
+            stripped = (summary or "").strip()
+            if not stripped:
+                if self.debug:
+                    self.logger.warning("Compaction returned empty summary at step %d", self._step_count)
+                self._steps_since_compaction = max(0, self._compaction_interval // 2)
+                return
+            self._compaction_summary = stripped
+            self._transcript = []
             self._steps_since_compaction = 0
             if self.debug:
                 self.logger.debug(
@@ -549,6 +556,7 @@ class LLMAgent(QuestPlayer):
         except Exception as e:
             if self.debug:
                 self.logger.warning("Compaction failed at step %d: %s", self._step_count, e)
+            self._steps_since_compaction = max(0, self._compaction_interval // 2)
 
     def _record_compaction_usage(self, prompt_tokens: int, completion_tokens: int) -> None:
         """Record token usage from compaction calls into agent history."""

--- a/llm_quest_benchmark/agents/llm_agent.py
+++ b/llm_quest_benchmark/agents/llm_agent.py
@@ -275,6 +275,8 @@ class LLMAgent(QuestPlayer):
         temperature: float = DEFAULT_TEMPERATURE,
         skip_single: bool = False,
         debug: bool = False,
+        memory_mode: str = "default",
+        compaction_interval: int = 10,
     ):
         super().__init__(skip_single=skip_single)
         self.debug = debug
@@ -316,7 +318,20 @@ class LLMAgent(QuestPlayer):
         self._loop_repetition_threshold = 1
         self._max_state_signatures = 200
         self._use_safety_filter = True
-        self._last_response = LLMResponse(action=1, is_default=True)  # Initialize with default response
+        self._last_response = LLMResponse(action=1, is_default=True)
+
+        # Quest briefing: pinned first observation (mission goal)
+        self._quest_briefing: str | None = None
+
+        # Memory mode: "default", "full_transcript", "compaction"
+        if memory_mode not in ("default", "full_transcript", "compaction"):
+            raise ValueError(f"Invalid memory_mode: {memory_mode}")
+        self._memory_mode = memory_mode
+        self._transcript: list[dict[str, Any]] = []
+        self._compaction_interval = compaction_interval
+        self._compaction_summary: str | None = None
+        self._steps_since_compaction = 0
+        self._step_count = 0
 
     def _ensure_llm(self):
         """Lazily create the provider client only when inference is needed."""
@@ -340,13 +355,38 @@ class LLMAgent(QuestPlayer):
         clean = (observation or "").strip()
         if not clean:
             return
+        if self._quest_briefing is None:
+            self._quest_briefing = clean
         self._observation_history.append(clean)
         if len(self._observation_history) > 20:
             self._observation_history = self._observation_history[-20:]
 
     def _build_contextual_state(self, state: str) -> str:
-        """Add compact state+decision memory for better local decisions."""
+        """Build context-augmented state based on memory mode."""
+        if self._memory_mode == "full_transcript":
+            return self._build_full_transcript_state(state)
+        if self._memory_mode == "compaction":
+            return self._build_compaction_state(state)
+        return self._build_default_state(state)
+
+    def _briefing_block(self, state: str) -> str | None:
+        """Return quest briefing block if available and not redundant with current state."""
+        if not self._quest_briefing:
+            return None
+        if state.strip() == self._quest_briefing:
+            return None
+        briefing = self._quest_briefing
+        if len(briefing) > 800:
+            briefing = briefing[:800] + "..."
+        return f"Quest briefing (your mission):\n{briefing}"
+
+    def _build_default_state(self, state: str) -> str:
+        """Original sliding-window context, now with pinned briefing."""
         blocks: list[str] = []
+
+        briefing = self._briefing_block(state)
+        if briefing:
+            blocks.append(briefing)
 
         if len(self._observation_history) > 1:
             previous = self._observation_history[:-1][-self._context_window :]
@@ -387,6 +427,163 @@ class LLMAgent(QuestPlayer):
 
         sep = "\n\n"
         return f"{sep.join(blocks)}\n\nCurrent story state:\n{state}"
+
+    def _build_full_transcript_state(self, state: str) -> str:
+        """Full decision transcript with pinned briefing."""
+        blocks: list[str] = []
+
+        briefing = self._briefing_block(state)
+        if briefing:
+            blocks.append(briefing)
+
+        if self._transcript:
+            lines = []
+            entries = self._transcript
+            # Budget: keep first 3 + last N that fit under ~40 entries total
+            if len(entries) > 40:
+                entries = entries[:3] + [{"_gap": len(entries) - 40}] + entries[-(40 - 3) :]
+            for entry in entries:
+                if "_gap" in entry:
+                    lines.append(f"  ... ({entry['_gap']} steps omitted) ...")
+                    continue
+                step = entry.get("step", "?")
+                obs = entry.get("observation", "")
+                if len(obs) > 400:
+                    obs = obs[:400] + "..."
+                chosen = entry.get("choice_text", "")
+                reasoning = entry.get("reasoning", "")
+                line = f"Step {step}: {obs}"
+                if chosen:
+                    line += f"\n  You chose: {chosen}"
+                if reasoning:
+                    line += f"\n  Reasoning: {reasoning[:150]}"
+                lines.append(line)
+            blocks.append("=== QUEST TRANSCRIPT ===\n" + "\n\n".join(lines))
+
+        blocks.append(f"Step {self._step_count} (CURRENT):\n{state}")
+        return "\n\n".join(blocks)
+
+    def _build_compaction_state(self, state: str) -> str:
+        """Compacted memory summary + recent steps since last compaction."""
+        blocks: list[str] = []
+
+        briefing = self._briefing_block(state)
+        if briefing:
+            blocks.append(briefing)
+
+        if self._compaction_summary:
+            blocks.append(
+                f"=== QUEST MEMORY (compacted at step {self._step_count - self._steps_since_compaction}) ===\n{self._compaction_summary}"
+            )
+
+        if self._transcript:
+            recent = self._transcript[-self._steps_since_compaction :] if self._steps_since_compaction > 0 else []
+            if recent:
+                lines = []
+                for entry in recent:
+                    step = entry.get("step", "?")
+                    obs = entry.get("observation", "")
+                    if len(obs) > 400:
+                        obs = obs[:400] + "..."
+                    chosen = entry.get("choice_text", "")
+                    line = f"Step {step}: {obs}"
+                    if chosen:
+                        line += f"\n  You chose: {chosen}"
+                    lines.append(line)
+                blocks.append("=== RECENT STEPS ===\n" + "\n\n".join(lines))
+
+        blocks.append(f"Step {self._step_count} (CURRENT):\n{state}")
+        return "\n\n".join(blocks)
+
+    def _maybe_compact(self) -> None:
+        """Run compaction if interval reached. Called after recording a decision."""
+        if self._memory_mode != "compaction":
+            return
+        if self._steps_since_compaction < self._compaction_interval:
+            return
+
+        transcript_text = self._format_transcript_for_compaction()
+        if not transcript_text:
+            return
+
+        prompt_parts = []
+        prompt_parts.append("You are summarizing an agent's progress through a text quest.")
+        if self._quest_briefing:
+            prompt_parts.append(f"\nQUEST BRIEFING (the original mission):\n{self._quest_briefing}")
+        if self._compaction_summary:
+            prompt_parts.append(f"\nPREVIOUS SUMMARY:\n{self._compaction_summary}")
+        prompt_parts.append(f"\nTRANSCRIPT OF LAST {self._steps_since_compaction} STEPS:\n{transcript_text}")
+        prompt_parts.append(
+            "\nSummarize the agent's progress. Include:\n"
+            "- Current objective (what the agent should do next)\n"
+            "- Progress so far (what has been accomplished)\n"
+            "- Key facts (NPCs, items, locations, deadlines discovered)\n"
+            "- Failed approaches (actions/paths that didn't work)\n"
+            "- Map knowledge (locations visited and connections)\n\n"
+            "Write a concise summary in plain text, max 300 words."
+        )
+
+        compaction_prompt = "\n".join(prompt_parts)
+        try:
+            self._ensure_llm()
+            summary = self.llm.get_completion(compaction_prompt)
+            compaction_usage = self.llm.get_last_usage() or {}
+            if compaction_usage:
+                pt = int(
+                    compaction_usage.get("prompt_tokens", 0)
+                    if isinstance(compaction_usage, dict)
+                    else getattr(compaction_usage, "prompt_tokens", 0)
+                )
+                ct = int(
+                    compaction_usage.get("completion_tokens", 0)
+                    if isinstance(compaction_usage, dict)
+                    else getattr(compaction_usage, "completion_tokens", 0)
+                )
+                self._record_compaction_usage(pt, ct)
+            self._compaction_summary = summary.strip()
+            self._steps_since_compaction = 0
+            if self.debug:
+                self.logger.debug(
+                    "Compaction completed at step %d: %s", self._step_count, self._compaction_summary[:200]
+                )
+        except Exception as e:
+            if self.debug:
+                self.logger.warning("Compaction failed at step %d: %s", self._step_count, e)
+
+    def _record_compaction_usage(self, prompt_tokens: int, completion_tokens: int) -> None:
+        """Record token usage from compaction calls into agent history."""
+        compaction_response = LLMResponse(
+            action=0,
+            is_default=True,
+            parse_mode="compaction",
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        )
+        self.history.append(compaction_response)
+
+    def _format_transcript_for_compaction(self) -> str:
+        """Format recent transcript entries for the compaction prompt."""
+        recent = (
+            self._transcript[-self._steps_since_compaction :]
+            if self._steps_since_compaction > 0
+            else self._transcript[-self._compaction_interval :]
+        )
+        lines = []
+        for entry in recent:
+            step = entry.get("step", "?")
+            obs = entry.get("observation", "")
+            if len(obs) > 400:
+                obs = obs[:400] + "..."
+            chosen = entry.get("choice_text", "")
+            reasoning = entry.get("reasoning", "")
+            line = f"Step {step}: {obs}"
+            if chosen:
+                line += f"\n  Chose: {chosen}"
+            if reasoning:
+                line += f"\n  Reasoning: {reasoning[:100]}"
+            lines.append(line)
+        return "\n\n".join(lines)
 
     @staticmethod
     def _normalize_for_signature(value: str, max_len: int = 320) -> str:
@@ -471,6 +668,21 @@ class LLMAgent(QuestPlayer):
         )
         if len(self._decision_history) > 40:
             self._decision_history = self._decision_history[-40:]
+
+        # Transcript for full_transcript and compaction modes
+        if self._memory_mode in ("full_transcript", "compaction"):
+            self._step_count += 1
+            self._steps_since_compaction += 1
+            self._transcript.append(
+                {
+                    "step": self._step_count,
+                    "observation": state_snippet if self._memory_mode == "compaction" else state.strip()[:400],
+                    "choice_text": selected_text,
+                    "reasoning": (response.reasoning or "")[:150],
+                    "action": action,
+                }
+            )
+            self._maybe_compact()
 
     def _choice_risk_score(self, choice_text: str) -> int:
         text = (choice_text or "").lower()
@@ -740,7 +952,12 @@ class LLMAgent(QuestPlayer):
         self._observation_history = []
         self._decision_history = []
         self._state_action_counts = {}
-        self._last_response = LLMResponse(action=1, is_default=True)  # Reset to default response
+        self._last_response = LLMResponse(action=1, is_default=True)
+        self._quest_briefing = None
+        self._transcript = []
+        self._compaction_summary = None
+        self._steps_since_compaction = 0
+        self._step_count = 0
 
     def on_game_start(self) -> None:
         """Called when game starts"""
@@ -748,7 +965,12 @@ class LLMAgent(QuestPlayer):
         self._observation_history = []
         self._decision_history = []
         self._state_action_counts = {}
-        self._last_response = LLMResponse(action=1, is_default=True)  # Reset to default response
+        self._last_response = LLMResponse(action=1, is_default=True)
+        self._quest_briefing = None
+        self._transcript = []
+        self._compaction_summary = None
+        self._steps_since_compaction = 0
+        self._step_count = 0
 
     def on_game_end(self, final_state: dict[str, Any]) -> None:
         """Log final state for analysis"""

--- a/llm_quest_benchmark/constants.py
+++ b/llm_quest_benchmark/constants.py
@@ -107,13 +107,15 @@ MAX_BENCHMARK_TIMEOUT = 7200  # Maximum benchmark timeout (2 hours)
 INFINITE_TIMEOUT = 10**9  # Infinite timeout (used for interactive play)
 
 # Quest state detection patterns
-# Pattern to detect credit rewards in text (e.g., "10000 cr")
-CREDIT_REWARD_PATTERN = re.compile(r"(\d+)\s*cr\b")
+# Pattern to detect credit rewards in text (e.g., "10000 cr", "10000 credits")
+CREDIT_REWARD_PATTERN = re.compile(r"(\d+)\s*(?:cr(?:edits?)?)\b")
 
 # Common success indicators in text for quest completion
+# NOTE: order matters - failure indicators are checked first in detect_quest_outcome
+# to avoid false positives like "mission completely failed" matching "mission complete"
 SUCCESS_INDICATORS = [
-    "mission complete",
     "mission accomplished",
+    "mission is complete",
     "succeeded",
     "successful",
     "congratulations",
@@ -133,9 +135,11 @@ SUCCESS_INDICATORS = [
 # Common failure indicators in text
 FAILURE_INDICATORS = [
     "mission failed",
+    "mission completely",
     "you died",
     "game over",
     "you lost",
+    "you failed",
     "failure",
     "failed",
     "провал",

--- a/llm_quest_benchmark/environments/qm.py
+++ b/llm_quest_benchmark/environments/qm.py
@@ -3,11 +3,9 @@
 import logging
 from typing import Any
 
-from llm_quest_benchmark.constants import SYNTHETIC_SUCCESS_LOCATION
 from llm_quest_benchmark.executors.ts_bridge.bridge import QMBridge
 from llm_quest_benchmark.schemas.state import QMState
 from llm_quest_benchmark.utils.choice_mapper import ChoiceMapper
-from llm_quest_benchmark.utils.text_processor import detect_quest_outcome
 
 
 def find_quest_file(quest_path: str) -> str:
@@ -244,35 +242,15 @@ class QMPlayerEnv:
                 "info": {},
             }
 
-            # Determine success based on multiple factors
-            success = False
-
-            # Handle special case for synthetic success location
-            if new_bridge_state.location_id == SYNTHETIC_SUCCESS_LOCATION and new_bridge_state.game_ended:
-                success = True
-                self.logger.info("Quest ended successfully with synthetic success marker")
-
-            # Check if there's a positive reward value
-            elif new_bridge_state.game_ended and new_bridge_state.reward > 0:
-                success = True
-                self.logger.info("Quest ended successfully based on reward value")
-
-            # If the quest ended but wasn't determined successful yet, check text content using our utility
-            elif new_bridge_state.game_ended and new_bridge_state.text:
-                # Use our dedicated outcome detection utility
-                success, reward, reason = detect_quest_outcome(new_bridge_state.text)
-
-                # Log the result
-                if success:
-                    self.logger.info(f"Quest ended successfully based on {reason}")
-                    if reward > 0:
-                        self.logger.info(f"Detected reward: {reward}")
-                elif reason != "no_indicators":
-                    self.logger.info(f"Quest failed based on {reason}")
+            # Determine success from the TS engine's authoritative gameState.
+            # "win" = success, "fail"/"dead" = failure, "running" = not ended yet.
+            success = new_bridge_state.game_state == "win"
 
             if new_bridge_state.game_ended:
-                # Just log the essential info at INFO level for better visibility
-                self.logger.info(f"Game ended with reward: {new_bridge_state.reward}, success: {success}")
+                self.logger.info(
+                    f"Game ended: game_state={new_bridge_state.game_state}, "
+                    f"location={new_bridge_state.location_id}, success={success}"
+                )
 
             return (
                 self._compose_observation_text(self._current_state["text"], self._current_state.get("params_state")),

--- a/llm_quest_benchmark/executors/benchmark.py
+++ b/llm_quest_benchmark/executors/benchmark.py
@@ -230,6 +230,8 @@ def run_benchmark(config: BenchmarkConfig, progress_callback=None) -> list[dict[
                         action_template=agent_config.action_template,
                         skip_single=agent_config.skip_single,
                         debug=agent_config.debug,
+                        memory_mode=agent_config.memory_mode,
+                        compaction_interval=agent_config.compaction_interval,
                     )
 
                     # Run quest with timeout

--- a/llm_quest_benchmark/executors/ts_bridge/bridge.py
+++ b/llm_quest_benchmark/executors/ts_bridge/bridge.py
@@ -378,6 +378,7 @@ class QMBridge:
 
             params_state_raw = state.get("paramsState") or []
             params_state = [clean_qm_text(p) for p in params_state_raw if isinstance(p, str) and clean_qm_text(p)]
+            game_state_raw = state.get("gameState", "running")
             initial_state = QMBridgeState(
                 location_id=str(saving["locationId"]),
                 text=clean_qm_text(state.get("text", "")),
@@ -387,8 +388,9 @@ class QMBridge:
                     for c in (state.get("choices") or [])
                     if isinstance(c, dict) and c.get("active", False)
                 ],
-                reward=0.0,  # UI state does not provide reward directly
-                game_ended=state.get("gameState") != "running",
+                reward=0.0,
+                game_ended=game_state_raw != "running",
+                game_state=game_state_raw,
             )
 
             if not initial_state.choices and not initial_state.game_ended:
@@ -425,6 +427,7 @@ class QMBridge:
 
             params_state_raw = state.get("paramsState") or []
             params_state = [clean_qm_text(p) for p in params_state_raw if isinstance(p, str) and clean_qm_text(p)]
+            game_state_raw = state.get("gameState", "running")
             current_state = QMBridgeState(
                 location_id=str(saving["locationId"]),
                 text=clean_qm_text(state.get("text", "")),
@@ -434,8 +437,9 @@ class QMBridge:
                     for c in (state.get("choices") or [])
                     if isinstance(c, dict) and c.get("active", False)
                 ],
-                reward=0.0,  # UI state does not provide reward directly
-                game_ended=state.get("gameState") != "running",
+                reward=0.0,
+                game_ended=game_state_raw != "running",
+                game_state=game_state_raw,
             )
 
             if not current_state.choices and not current_state.game_ended:
@@ -518,13 +522,15 @@ class QMBridge:
                 if isinstance(c, dict) and c.get("active", False)
             ]
 
+            game_state_raw = state.get("gameState", "running")
             new_state = QMBridgeState(
                 location_id=str(saving["locationId"]),
                 text=clean_qm_text(state.get("text", "")),
                 params_state=params_state,
                 choices=choices,
-                reward=0.0,  # UI state does not provide reward directly
-                game_ended=state.get("gameState") != "running",
+                reward=0.0,
+                game_ended=game_state_raw != "running",
+                game_state=game_state_raw,
             )
 
             self.state_history.append(new_state)

--- a/llm_quest_benchmark/schemas/bridge.py
+++ b/llm_quest_benchmark/schemas/bridge.py
@@ -12,4 +12,5 @@ class QMBridgeState:
     choices: list[dict[str, str]]  # [{id: str, text: str}]
     reward: float
     game_ended: bool
+    game_state: str = "running"  # "running" | "win" | "fail" | "dead" from TS engine
     params_state: list[str] = field(default_factory=list)

--- a/llm_quest_benchmark/schemas/config.py
+++ b/llm_quest_benchmark/schemas/config.py
@@ -65,7 +65,9 @@ class AgentConfig:
     runs: int = 1
     skip_single: bool = False
     debug: bool = False
-    benchmark_id: str | None = None  # Added to link runs to benchmarks
+    benchmark_id: str | None = None
+    memory_mode: str = "default"
+    compaction_interval: int = 10
 
     def __post_init__(self):
         self.system_template = normalize_template_name(self.system_template)
@@ -80,17 +82,16 @@ class AgentConfig:
             raise ValueError(f"Temperature must be between 0.0 and 2.0, got {self.temperature}")
         if self.runs < 1:
             raise ValueError(f"runs must be >= 1, got {self.runs}")
+        if self.memory_mode not in ("default", "full_transcript", "compaction"):
+            raise ValueError(f"Invalid memory_mode: {self.memory_mode}")
 
     @property
     def agent_id(self) -> str:
         """Generate a unique agent ID based on configuration values"""
         import hashlib
 
-        # Create a string with the key configuration values
-        config_str = f"{self.model}_{self.temperature}_{self.system_template}_{self.action_template}"
-        # Generate a short hash (first 8 characters)
+        config_str = f"{self.model}_{self.temperature}_{self.system_template}_{self.action_template}_{self.memory_mode}"
         hash_val = hashlib.md5(config_str.encode()).hexdigest()[:8]
-        # Include model and temperature in the ID for better readability
         return f"{self.model}_t{self.temperature}_{hash_val}"
 
 

--- a/llm_quest_benchmark/schemas/config.py
+++ b/llm_quest_benchmark/schemas/config.py
@@ -84,13 +84,16 @@ class AgentConfig:
             raise ValueError(f"runs must be >= 1, got {self.runs}")
         if self.memory_mode not in ("default", "full_transcript", "compaction"):
             raise ValueError(f"Invalid memory_mode: {self.memory_mode}")
+        if self.memory_mode == "compaction" and self.compaction_interval < 1:
+            raise ValueError(f"compaction_interval must be >= 1, got {self.compaction_interval}")
 
     @property
     def agent_id(self) -> str:
         """Generate a unique agent ID based on configuration values"""
         import hashlib
 
-        config_str = f"{self.model}_{self.temperature}_{self.system_template}_{self.action_template}_{self.memory_mode}"
+        interval_tag = f"_ci{self.compaction_interval}" if self.memory_mode == "compaction" else ""
+        config_str = f"{self.model}_{self.temperature}_{self.system_template}_{self.action_template}_{self.memory_mode}{interval_tag}"
         hash_val = hashlib.md5(config_str.encode()).hexdigest()[:8]
         return f"{self.model}_t{self.temperature}_{hash_val}"
 

--- a/llm_quest_benchmark/tests/environments/test_outcome_detection.py
+++ b/llm_quest_benchmark/tests/environments/test_outcome_detection.py
@@ -42,9 +42,7 @@ class TestQMBridgeStateGameState:
         assert state.game_state == "running"
 
     def test_default_game_state(self):
-        state = QMBridgeState(
-            location_id="1", text="", choices=[], reward=0.0, game_ended=False
-        )
+        state = QMBridgeState(location_id="1", text="", choices=[], reward=0.0, game_ended=False)
         assert state.game_state == "running"
 
 

--- a/llm_quest_benchmark/tests/environments/test_outcome_detection.py
+++ b/llm_quest_benchmark/tests/environments/test_outcome_detection.py
@@ -1,0 +1,130 @@
+"""Tests for game_state-based outcome detection.
+
+The TS engine provides authoritative gameState: "win" | "fail" | "dead" | "running".
+The environment must use this directly, not text heuristics.
+"""
+
+import logging
+
+import pytest
+
+from llm_quest_benchmark.schemas.bridge import QMBridgeState
+
+
+def _make_bridge_state(game_state: str = "running", text: str = "", location_id: str = "1") -> QMBridgeState:
+    return QMBridgeState(
+        location_id=location_id,
+        text=text,
+        choices=[{"id": "1", "text": "Go"}] if game_state == "running" else [],
+        reward=0.0,
+        game_ended=game_state != "running",
+        game_state=game_state,
+    )
+
+
+class TestQMBridgeStateGameState:
+    def test_win_state(self):
+        state = _make_bridge_state("win")
+        assert state.game_ended is True
+        assert state.game_state == "win"
+
+    def test_fail_state(self):
+        state = _make_bridge_state("fail")
+        assert state.game_ended is True
+        assert state.game_state == "fail"
+
+    def test_dead_state(self):
+        state = _make_bridge_state("dead")
+        assert state.game_ended is True
+        assert state.game_state == "dead"
+
+    def test_running_state(self):
+        state = _make_bridge_state("running")
+        assert state.game_ended is False
+        assert state.game_state == "running"
+
+    def test_default_game_state(self):
+        state = QMBridgeState(
+            location_id="1", text="", choices=[], reward=0.0, game_ended=False
+        )
+        assert state.game_state == "running"
+
+
+class TestEnvironmentOutcomeFromGameState:
+    """Verify the environment determines success from game_state, not text."""
+
+    def _make_env(self):
+        from llm_quest_benchmark.environments.qm import QMPlayerEnv
+
+        env = QMPlayerEnv.__new__(QMPlayerEnv)
+        env.debug = False
+        env.language = "eng"
+        env.logger = logging.getLogger("test_outcome")
+        env._current_state = {
+            "location_id": "1",
+            "text": "start",
+            "params_state": [],
+            "choices": [{"id": "1", "text": "Go"}],
+            "reward": 0.0,
+            "done": False,
+            "info": {},
+        }
+        return env
+
+    def _patch_bridge_step(self, env, game_state: str, text: str = ""):
+        """Replace bridge.step to return a controlled state."""
+
+        class FakeBridge:
+            state_history = [_make_bridge_state("running")]
+
+            def step(self, _action):
+                return _make_bridge_state(game_state, text=text)
+
+            def close(self):
+                pass
+
+        env.bridge = FakeBridge()
+
+    def test_win_is_success(self):
+        env = self._make_env()
+        self._patch_bridge_step(env, "win")
+        _, done, success, _ = env.step("1")
+        assert done is True
+        assert success is True
+
+    def test_fail_is_failure(self):
+        env = self._make_env()
+        self._patch_bridge_step(env, "fail")
+        _, done, success, _ = env.step("1")
+        assert done is True
+        assert success is False
+
+    def test_dead_is_failure(self):
+        env = self._make_env()
+        self._patch_bridge_step(env, "dead")
+        _, done, success, _ = env.step("1")
+        assert done is True
+        assert success is False
+
+    def test_win_with_misleading_failure_text(self):
+        """gameState=win must override misleading failure text."""
+        env = self._make_env()
+        self._patch_bridge_step(env, "win", text="mission failed completely, you died")
+        _, done, success, _ = env.step("1")
+        assert done is True
+        assert success is True
+
+    def test_fail_with_misleading_success_text(self):
+        """gameState=fail must override misleading success text like 'congratulations'."""
+        env = self._make_env()
+        self._patch_bridge_step(env, "fail", text="congratulations on your 10000 credits reward")
+        _, done, success, _ = env.step("1")
+        assert done is True
+        assert success is False
+
+    def test_running_is_not_done(self):
+        env = self._make_env()
+        self._patch_bridge_step(env, "running")
+        _, done, success, _ = env.step("1")
+        assert done is False
+        assert success is False

--- a/llm_quest_benchmark/tests/environments/test_outcome_detection.py
+++ b/llm_quest_benchmark/tests/environments/test_outcome_detection.py
@@ -6,8 +6,6 @@ The environment must use this directly, not text heuristics.
 
 import logging
 
-import pytest
-
 from llm_quest_benchmark.schemas.bridge import QMBridgeState
 
 


### PR DESCRIPTION
## Summary
- Add full_transcript and compaction memory modes for LLM agents to combat context amnesia (quest briefing lost after sliding window)
- Replace fragile text-heuristic outcome detection with TS engine's authoritative `gameState` ("win"/"fail"/"dead")
- Pin quest briefing in agent context across all memory modes

## Changes
- **Memory modes** (`llm_agent.py`): `default` (existing sliding window), `full_transcript` (all decisions in prompt), `compaction` (periodic LLM summarization)
- **Outcome detection** (`bridge.py`, `qm.py`, `schemas/bridge.py`): Pass `game_state` string through `QMBridgeState` instead of collapsing to boolean. Environment checks `game_state == "win"` directly - no more substring matching against "mission complete"/"congratulations"/credit patterns
- **Config** (`config.py`): `memory_mode` and `compaction_interval` fields on `AgentConfig`
- **Tests**: 11 new tests covering all game states including adversarial cases (win with failure text, fail with success text)

## Test plan
- [x] 100 unit tests pass
- [x] 16 integration tests pass
- [x] Manual verification: `win`, `fail`, `dead` states confirmed through full env+runner stack
- [x] Smoke test: random agent on Boat.qm shows `game_state=fail` in logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable memory modes for agents: default (sliding window), full transcript (complete history), and compaction (periodic LLM-generated summaries).
  * Improved quest outcome detection with refined pattern matching.

* **Bug Fixes**
  * Success detection now uses authoritative game state from the engine instead of heuristics.

* **Tests**
  * Added comprehensive outcome detection test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->