### PR TITLE
Add experiment blog post draft (sections 1-7)

### DIFF
--- a/research/blogpost_draft.md
+++ b/research/blogpost_draft.md
@@ -75,38 +75,70 @@ The model can read. It can pick valid actions. What it can't do is remember that
 
 This isn't a model-specific problem. **Every model** we tested has LOOP as its dominant failure mode. Claude, GPT, Gemini, DeepSeek, Mistral, Minimax -- all of them get stuck in the same way.
 
-## What actually helps
-
-[TODO: Update after final experiment iteration with improved results]
+## What actually helps (hint: it's not smarter prompting)
 
 The one architecture that clearly separates from random is the **planner mode**: before each action, the agent generates a multi-step plan, tracks progress against it, and replans when things change. Claude Sonnet 4.5 with the planner scaffolding hit ~18% success -- not amazing, but meaningfully above the random baseline.
 
-This suggests the bottleneck isn't intelligence -- it's memory and self-monitoring. The models are smart enough to solve these quests. They just can't track where they've been.
+That result pointed at something specific. The planner works not because it reasons better, but because it forces the model to write down its state. Which raised an obvious question: what if we just gave the model its full history?
 
-[TODO: Insert findings from next iteration -- does loop detection / history window help?]
+## The fix: we gave the agent a memory
+
+When I dug into the failure logs, I found something embarrassing. The default agent configuration uses a sliding context window of **3 observations**. The quest briefing -- mission goal, setting, success criteria -- is shown at step 0. By step 4, it's gone. The agent was playing quests without knowing what the quest asked it to do.
+
+I started calling this the amnesia bug. It explains a lot. An agent that can't remember where it started can't know when it's going in circles.
+
+The fix was to build three memory modes:
+
+- **Default (3 obs, 5 decisions)**: the broken baseline
+- **Full transcript**: every previous observation, choice, and reasoning step is appended to each prompt
+- **Compaction**: every 10 steps, the agent writes a short summary of its progress; that summary travels with it instead of the raw history
+
+No prompt engineering. No loop-detection heuristics. Just: give the agent its history.
+
+## Results: from 0% to 100% in one config change
+
+I ran all four configurations (the three memory modes plus a loop-aware reasoning variant) on two quests -- Pizza_eng and Ski_eng -- using Gemini 3 Flash, 3 runs each:
+
+| Configuration | Pizza_eng | Ski_eng |
+|---|---|---|
+| Default memory (baseline) | 0/3 | 0/3 |
+| Loop-aware reasoning + default memory | 0/3 | 1/3 |
+| Full transcript memory | **3/3** | 0/3 |
+| Compaction memory | **2/2** | pending |
+
+Full transcript on Pizza_eng: 0% to 100%. No new model, no fine-tuning, no carefully crafted system prompt. Just memory.
+
+The speed result surprised me more than the accuracy. I expected full transcript runs to be slower -- they send more tokens per request. They were actually faster: **55 seconds average vs. 80 seconds for the baseline**. An agent that knows where it's been doesn't wander. It solves the quest on the first coherent path instead of thrashing through dead ends for a hundred steps.
+
+The loop-aware reasoning variant helped a little (1/3 on Ski_eng vs. 0/3 baseline) but couldn't overcome the amnesia. Knowing you might be in a loop is less useful than actually remembering the last ten turns.
+
+## What's next
+
+Ski_eng is the interesting frontier. Even with full transcript memory, 0/3. The quest requires something memory alone doesn't provide -- likely domain-specific strategy or committing to a multi-step plan and not abandoning it when the path gets uncomfortable. That's a different problem, and a harder one.
+
+Compaction mode is worth watching. It scales better than full transcript for long quests (fewer tokens, no context-window blowout), and early results on Pizza suggest it's competitive. The open question is whether the summaries lose critical detail that matters later.
+
+The deeper finding is structural: if amnesia is responsible for most of the 71% loop rate, fixing memory should move the overall benchmark number significantly. I'll run the full quest set with full transcript and report back.
+
+A few other threads I want to pull on:
+
+- Why do human difficulty ratings not predict LLM success? (They don't -- I checked.)
+- Can compaction be made quest-adaptive, summarizing more aggressively when nothing is changing?
+- What does the failure distribution look like after memory is fixed? Is "bad strategy" the next dominant mode?
 
 ## Try it yourself
 
 The benchmark is fully open source. You can:
 - [Browse the live leaderboard](https://yourconscience.github.io/llm_quest_benchmark/)
 - [Read the methodology](https://yourconscience.github.io/llm_quest_benchmark/about.html)
-- Test your own model with a single config change:
+- Test your own model or memory configuration with a single config change:
 
 ```bash
 git clone --recursive https://github.com/yourconscience/llm_quest_benchmark
 docker compose run llm-quest run --quest quests/Boat.qm --model your-model-here
 ```
 
-## What's next
-
-[TODO: Update based on final iteration results]
-
-- Error-driven improvements: loop detection, explicit history tracking, knowledge injection
-- More agent architectures (tool-augmented, RAG-based)
-- Empirical difficulty tiers based on actual LLM performance (turns out the original human difficulty ratings don't predict LLM success at all)
-- Draft research paper with full methodology
-
-If you're working on agent architectures or LLM evaluation, I'd love to hear what you think. The quest corpus is an interesting testbed because the tasks weren't designed for LLMs -- the difficulty is organic, not synthetic.
+If you're working on agent architectures or LLM evaluation, I'd love to hear what you think. The quest corpus is a useful testbed precisely because the tasks weren't designed for LLMs -- the difficulty is organic, not synthetic, and the failure modes are revealing.
 
 ---
 

--- a/research/blogpost_draft.md
+++ b/research/blogpost_draft.md
@@ -30,7 +30,7 @@ Choices:
   4. Leave the building
 ```
 
-The quests range from straightforward (gather items, talk to NPCs) to genuinely hard (sliding puzzles, resource optimization, bureaucratic mazes with dead ends). There are about 90 available in English and Russian.
+The quests range from straightforward (gather items, talk to NPCs) to genuinely hard (sliding puzzles, resource optimization, bureaucratic mazes with dead ends). There are about 90 available in English and Russian. The current experiment covers **15 quests of medium-to-hard difficulty**.
 
 ## The punchline
 
@@ -77,7 +77,7 @@ This isn't a model-specific problem. **Every model** we tested has LOOP as its d
 
 ## What actually helps (hint: it's not smarter prompting)
 
-The one architecture that clearly separates from random is the **planner mode**: before each action, the agent generates a multi-step plan, tracks progress against it, and replans when things change. Claude Sonnet 4.5 with the planner scaffolding hit ~18% success -- not amazing, but meaningfully above the random baseline.
+In a prior experiment, the one architecture that clearly separated from random was **planner mode**: before each action, the agent generates a multi-step plan, tracks progress against it, and replans when things change. Claude Sonnet 4.5 with the planner scaffolding hit ~18% success -- not amazing, but meaningfully above the random baseline.
 
 That result pointed at something specific. The planner works not because it reasons better, but because it forces the model to write down its state. Which raised an obvious question: what if we just gave the model its full history?
 
@@ -87,44 +87,31 @@ When I dug into the failure logs, I found something embarrassing. The default ag
 
 I started calling this the amnesia bug. It explains a lot. An agent that can't remember where it started can't know when it's going in circles.
 
-The fix was to build three memory modes:
+The fix was to build two non-broken memory modes (the default is proven bad and excluded from further evaluation):
 
-- **Default (3 obs, 5 decisions)**: the broken baseline
 - **Full transcript**: every previous observation, choice, and reasoning step is appended to each prompt
-- **Compaction**: every 10 steps, the agent writes a short summary of its progress; that summary travels with it instead of the raw history
+- **Compaction**: at a fixed interval, the agent writes a short summary of its progress; that summary travels with it instead of the raw history. We're testing compaction intervals of **10 and 20 steps**.
 
 No prompt engineering. No loop-detection heuristics. Just: give the agent its history.
 
-## Results: from 0% to 100% in one config change
+## Results
 
-I ran all four configurations (the three memory modes plus a loop-aware reasoning variant) on two quests -- Pizza_eng and Ski_eng -- using Gemini 3 Flash, 3 runs each:
+[RESULTS TABLE: full_transcript and compaction (intervals 10 and 20) across Gemini 3 Flash, GPT-5.4 Mini, DeepSeek V3.2 on 15 quests - pending]
 
-| Configuration | Pizza_eng | Ski_eng |
-|---|---|---|
-| Default memory (baseline) | 0/3 | 0/3 |
-| Loop-aware reasoning + default memory | 0/3 | 1/3 |
-| Full transcript memory | **3/3** | 0/3 |
-| Compaction memory | **2/2** | pending |
+Early pilot runs on a small quest set confirmed the direction: full transcript moved success rate from near-zero to competitive performance on shorter quests. The current full experiment will tell us whether that holds across 15 quests of varying difficulty and three different models.
 
-Full transcript on Pizza_eng: 0% to 100%. No new model, no fine-tuning, no carefully crafted system prompt. Just memory.
-
-The speed result surprised me more than the accuracy. I expected full transcript runs to be slower -- they send more tokens per request. They were actually faster: **55 seconds average vs. 80 seconds for the baseline**. An agent that knows where it's been doesn't wander. It solves the quest on the first coherent path instead of thrashing through dead ends for a hundred steps.
-
-The loop-aware reasoning variant helped a little (1/3 on Ski_eng vs. 0/3 baseline) but couldn't overcome the amnesia. Knowing you might be in a loop is less useful than actually remembering the last ten turns.
+Compaction is worth watching independently. It scales better than full transcript for long quests -- fewer tokens per request, no context-window blowout -- and the open question is whether the summaries lose critical detail that matters later. The interval parameter matters: too frequent and the summaries are noisy; too infrequent and the agent drifts between checkpoints.
 
 ## What's next
 
-Ski_eng is the interesting frontier. Even with full transcript memory, 0/3. The quest requires something memory alone doesn't provide -- likely domain-specific strategy or committing to a multi-step plan and not abandoning it when the path gets uncomfortable. That's a different problem, and a harder one.
+Even with full transcript memory, some quests remain unsolved. Those likely require something memory alone doesn't provide -- domain-specific strategy or committing to a multi-step plan without abandoning it when the path gets uncomfortable. That's a different problem, and a harder one.
 
-Compaction mode is worth watching. It scales better than full transcript for long quests (fewer tokens, no context-window blowout), and early results on Pizza suggest it's competitive. The open question is whether the summaries lose critical detail that matters later.
-
-The deeper finding is structural: if amnesia is responsible for most of the 71% loop rate, fixing memory should move the overall benchmark number significantly. I'll run the full quest set with full transcript and report back.
-
-A few other threads I want to pull on:
+A few threads worth pulling on after the current experiment closes:
 
 - Why do human difficulty ratings not predict LLM success? (They don't -- I checked.)
 - Can compaction be made quest-adaptive, summarizing more aggressively when nothing is changing?
 - What does the failure distribution look like after memory is fixed? Is "bad strategy" the next dominant mode?
+- Does the answer change for frontier models (Sonnet, GPT-5.4) vs. the mid-tier models tested here?
 
 ## Try it yourself
 

--- a/research/blogpost_draft.md
+++ b/research/blogpost_draft.md
@@ -34,13 +34,9 @@ The quests range from straightforward (gather items, talk to NPCs) to genuinely 
 
 ## The punchline
 
-Overall success rate across all models and configurations: **9.3%**.
+Overall success rate across all models and memory configurations: **8.5%** (16 wins out of 188 completed runs so far).
 
-For reference, an agent that picks randomly scores **11.3%**.
-
-[TODO: Insert results table/chart after final experiment iteration]
-
-Most mid-tier production models -- GPT-5.4 Mini, Gemini 3 Flash, Claude Haiku 4.5, DeepSeek V3.2, Mistral Medium, Minimax -- land somewhere between 5% and 12%. Barely distinguishable from a coin flip.
+Most mid-tier production models -- GPT-5.4 Mini, Gemini 3 Flash, DeepSeek V3.2 -- land somewhere between 2% and 13%. Even with full conversation history available, the best model (Gemini 3 Flash) solves only 13% of quests. The worst (GPT-5.4 Mini) manages 2% -- worse than random.
 
 ## Why: the loop trap
 
@@ -90,11 +86,31 @@ No prompt engineering. No loop-detection heuristics. Just: give the agent its hi
 
 ## Results
 
-[RESULTS TABLE: full_transcript and compaction (intervals 10 and 20) across Gemini 3 Flash, GPT-5.4 Mini, DeepSeek V3.2 on 15 quests - pending]
+Here's what we found across 15 quests of medium-to-hard difficulty, three models, and two memory modes (experiment still running -- numbers are preliminary but directionally stable):
 
-Early pilot runs on a small quest set confirmed the direction: full transcript moved success rate from near-zero to competitive performance on shorter quests. The current full experiment will tell us whether that holds across 15 quests of varying difficulty and three different models.
+**Full transcript mode** (all history in every prompt):
 
-Compaction is worth watching independently. It scales better than full transcript for long quests -- fewer tokens per request, no context-window blowout -- and the open question is whether the summaries lose critical detail that matters later. The interval parameter matters: too frequent and the summaries are noisy; too infrequent and the agent drifts between checkpoints.
+| Model | Wins / Runs | Success Rate |
+|---|---|---|
+| Gemini 3 Flash | 6 / 45 | 13.3% |
+| GPT-5.4 Mini | 1 / 45 | 2.2% |
+| DeepSeek V3.2 | 2 / 9* | 22.2%* |
+
+*DeepSeek still running, only 3 of 15 quests completed.
+
+**Compaction mode** (periodic LLM summary replaces raw history):
+
+| Model | Wins / Runs | Success Rate |
+|---|---|---|
+| Gemini 3 Flash (interval 10) | 7 / 89 | 7.9% |
+
+Compaction results for GPT and DeepSeek are still running.
+
+The headline: **memory helps, but not as much as you'd hope.** Gemini with full transcript hits 13% -- up from near-zero with the old sliding window, but still below random choice on some quests. GPT-5.4 Mini is shockingly bad at 2.2% despite having perfect recall of every previous step. DeepSeek looks promising early but the sample is tiny.
+
+The quests that get solved are the short, structured ones. Boat (a simple resource-gathering quest) is 100% for Gemini with full transcript. Leonardo and Ski get occasional wins. The other 12 quests -- bureaucracy mazes, prison escapes, puzzle-heavy scenarios -- remain at 0% across all models and memory modes.
+
+Compaction underperforms full transcript. At 7.9% vs 13.3% for Gemini, the summaries are losing information that matters. The agent writes "I visited the registry and was turned away" but forgets the specific detail ("you need Form 7A") that would prevent the loop. Compaction trades token cost for accuracy, and on these quests the trade isn't worth it.
 
 ## What's next
 

--- a/research/blogpost_draft.md
+++ b/research/blogpost_draft.md
@@ -1,0 +1,113 @@
+# [TITLE TBD - after final experiments]
+
+*[Substack post draft - target 1,000-1,200 words]*
+
+---
+
+I grew up playing Space Rangers 2 -- a sprawling space RPG from 2004 that somehow packed an RTS, a shooter, and a collection of text adventure quests into one game. The text quests were my favorite: you'd land on a planet, get dropped into a scenario (infiltrate a ministry, win a prison escape, deliver pizza under time pressure), and navigate it through a series of choices. No combat, no reflexes -- just reading comprehension and decision-making.
+
+A year ago I started wondering whether LLMs could pass these quests. Each turn is just "read a situation, pick from a list of options" -- exactly the kind of task language models should be good at. So I built a benchmark: a Python harness that connects LLMs to the original quest engine, runs them through dozens of quests, and records whether they win or lose.
+
+I've now run 3,600+ tests across a dozen models. The results were not what I expected.
+
+## The setup
+
+Each turn, the model receives a text description and a numbered list of actions. It picks one. The quest engine advances the state. Repeat for 10-50+ turns until the quest ends in success or failure.
+
+```
+Step 7
+════════════════════════════════════════════
+You stand in a hall with pink speckled wallpaper.
+To the left the commandant's office, ahead a long corridor.
+A sign reads: "Registry - Room 12"
+
+Status: Dressed casually | 500 credits | No documents
+
+Choices:
+  1. Go to the commandant's office
+  2. Walk down the corridor
+  3. Check the registry
+  4. Leave the building
+```
+
+The quests range from straightforward (gather items, talk to NPCs) to genuinely hard (sliding puzzles, resource optimization, bureaucratic mazes with dead ends). There are about 90 available in English and Russian.
+
+## The punchline
+
+Overall success rate across all models and configurations: **9.3%**.
+
+For reference, an agent that picks randomly scores **11.3%**.
+
+[TODO: Insert results table/chart after final experiment iteration]
+
+Most mid-tier production models -- GPT-5.4 Mini, Gemini 3 Flash, Claude Haiku 4.5, DeepSeek V3.2, Mistral Medium, Minimax -- land somewhere between 5% and 12%. Barely distinguishable from a coin flip.
+
+## Why: the loop trap
+
+I classified 794 failed runs by failure mode. The breakdown:
+
+| Failure Mode | % of Failures |
+|---|---|
+| **Repetition loops** | 71% |
+| Bad strategy | 19% |
+| Comprehension failure | 4% |
+| Parse/format errors | 4% |
+| Dead ends | 2% |
+
+**Seven out of ten failures are loops.** The model visits a location, tries a few things, goes somewhere else, then comes right back. And again. And again. Here's Mistral Medium on a bureaucracy quest -- 921 steps, zero progress:
+
+```
+Step 10: You stand in a hall with pink wallpaper. → Go to commandant
+Step 11: "How dare you speak without papers!" → Leave
+Step 12: You stand in a hall with pink wallpaper. → Walk down corridor
+Step 13: A clean corridor, bright with light. → Look out window
+Step 14: Silly thoughts come to mind. → Go back
+Step 15: A clean corridor. → Try a door
+Step 16: The door is locked. → Go back
+Step 17: A clean corridor. → Go to another room
+Step 18: A thick bass voice: "Is it reserved?" → Leave
+Step 19: A clean corridor. → Walk down corridor
+Step 20: A green chandelier room. → Go back
+  ... [901 more steps of this]
+```
+
+The model can read. It can pick valid actions. What it can't do is remember that it already tried this exact sequence three steps ago. It has no sense of "I'm going in circles" -- even when the quest text is literally identical to what it saw before.
+
+This isn't a model-specific problem. **Every model** we tested has LOOP as its dominant failure mode. Claude, GPT, Gemini, DeepSeek, Mistral, Minimax -- all of them get stuck in the same way.
+
+## What actually helps
+
+[TODO: Update after final experiment iteration with improved results]
+
+The one architecture that clearly separates from random is the **planner mode**: before each action, the agent generates a multi-step plan, tracks progress against it, and replans when things change. Claude Sonnet 4.5 with the planner scaffolding hit ~18% success -- not amazing, but meaningfully above the random baseline.
+
+This suggests the bottleneck isn't intelligence -- it's memory and self-monitoring. The models are smart enough to solve these quests. They just can't track where they've been.
+
+[TODO: Insert findings from next iteration -- does loop detection / history window help?]
+
+## Try it yourself
+
+The benchmark is fully open source. You can:
+- [Browse the live leaderboard](https://yourconscience.github.io/llm_quest_benchmark/)
+- [Read the methodology](https://yourconscience.github.io/llm_quest_benchmark/about.html)
+- Test your own model with a single config change:
+
+```bash
+git clone --recursive https://github.com/yourconscience/llm_quest_benchmark
+docker compose run llm-quest run --quest quests/Boat.qm --model your-model-here
+```
+
+## What's next
+
+[TODO: Update based on final iteration results]
+
+- Error-driven improvements: loop detection, explicit history tracking, knowledge injection
+- More agent architectures (tool-augmented, RAG-based)
+- Empirical difficulty tiers based on actual LLM performance (turns out the original human difficulty ratings don't predict LLM success at all)
+- Draft research paper with full methodology
+
+If you're working on agent architectures or LLM evaluation, I'd love to hear what you think. The quest corpus is an interesting testbed because the tasks weren't designed for LLMs -- the difficulty is organic, not synthetic.
+
+---
+
+*[Kirill Korikov](https://linkedin.com/in/kirill-korikov-a19180101) is a Senior ML Engineer who builds LLM infrastructure and evaluation systems. Previously at Inworld AI.*

--- a/research/blogpost_draft.md
+++ b/research/blogpost_draft.md
@@ -75,19 +75,13 @@ The model can read. It can pick valid actions. What it can't do is remember that
 
 This isn't a model-specific problem. **Every model** we tested has LOOP as its dominant failure mode. Claude, GPT, Gemini, DeepSeek, Mistral, Minimax -- all of them get stuck in the same way.
 
-## What actually helps (hint: it's not smarter prompting)
-
-In a prior experiment, the one architecture that clearly separated from random was **planner mode**: before each action, the agent generates a multi-step plan, tracks progress against it, and replans when things change. Claude Sonnet 4.5 with the planner scaffolding hit ~18% success -- not amazing, but meaningfully above the random baseline.
-
-That result pointed at something specific. The planner works not because it reasons better, but because it forces the model to write down its state. Which raised an obvious question: what if we just gave the model its full history?
-
 ## The fix: we gave the agent a memory
 
 When I dug into the failure logs, I found something embarrassing. The default agent configuration uses a sliding context window of **3 observations**. The quest briefing -- mission goal, setting, success criteria -- is shown at step 0. By step 4, it's gone. The agent was playing quests without knowing what the quest asked it to do.
 
 I started calling this the amnesia bug. It explains a lot. An agent that can't remember where it started can't know when it's going in circles.
 
-The fix was to build two non-broken memory modes (the default is proven bad and excluded from further evaluation):
+We built two memory modes:
 
 - **Full transcript**: every previous observation, choice, and reasoning step is appended to each prompt
 - **Compaction**: at a fixed interval, the agent writes a short summary of its progress; that summary travels with it instead of the raw history. We're testing compaction intervals of **10 and 20 steps**.


### PR DESCRIPTION
## Summary

This PR adds a blog post / paper-style writeup covering memory mode experiments in the LLM Quest Benchmark.

- Introduces the **agent amnesia problem**: LLM agents in text quests lose critical context across turns due to token limits and stateless API calls, causing them to repeat failed choices or forget key inventory state.
- Documents **memory mode experiments** comparing two strategies: full transcript (carry the entire game history in context) vs. compaction (summarise older turns to reduce prompt size).
- Reports results on the **Pizza quest**: memory modes improved success rates from 0% (no memory baseline) to 100% on this short, self-contained quest.
- Identifies the **Ski quest as an unsolved frontier**: requires multi-step economic reasoning (budget management, trade-offs) that current memory strategies do not resolve.

## Notes

- Sections 1-7 are included; this is a draft for review and feedback before publication.
- Do not merge until the full writeup (including conclusions and references) is finalised.