### PR TITLE
Add memory experiment benchmark configs

### DIFF
--- a/configs/benchmarks/memory_compaction.yaml
+++ b/configs/benchmarks/memory_compaction.yaml
@@ -1,0 +1,64 @@
+name: memory_compaction
+quests:
+  - quests/Boat.qm
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  - quests/sr_2_1_2121_eng/Prison_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+agents:
+  # Gemini 3 Flash - compaction interval 10
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+    memory_mode: compaction
+    compaction_interval: 10
+  # Gemini 3 Flash - compaction interval 20
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+    memory_mode: compaction
+    compaction_interval: 20
+  # GPT-5.4 Mini - compaction interval 10
+  - model: "openrouter:openai/gpt-5.4-mini"
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+    memory_mode: compaction
+    compaction_interval: 10
+  # GPT-5.4 Mini - compaction interval 20
+  - model: "openrouter:openai/gpt-5.4-mini"
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+    memory_mode: compaction
+    compaction_interval: 20
+  # DeepSeek V3.2 - compaction interval 10
+  - model: "openrouter:deepseek/deepseek-v3.2"
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+    memory_mode: compaction
+    compaction_interval: 10
+  # DeepSeek V3.2 - compaction interval 20
+  - model: "openrouter:deepseek/deepseek-v3.2"
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+    memory_mode: compaction
+    compaction_interval: 20
+debug: false
+quest_timeout: 600
+max_workers: 4
+output_dir: results/benchmarks

--- a/configs/benchmarks/memory_full_transcript.yaml
+++ b/configs/benchmarks/memory_full_transcript.yaml
@@ -1,0 +1,40 @@
+name: memory_full_transcript
+quests:
+  - quests/Boat.qm
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  - quests/sr_2_1_2121_eng/Prison_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+agents:
+  # Gemini 3 Flash - full transcript
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+    memory_mode: full_transcript
+  # GPT-5.4 Mini - full transcript
+  - model: "openrouter:openai/gpt-5.4-mini"
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+    memory_mode: full_transcript
+  # DeepSeek V3.2 - full transcript
+  - model: "openrouter:deepseek/deepseek-v3.2"
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+    memory_mode: full_transcript
+debug: false
+quest_timeout: 600
+max_workers: 2
+output_dir: results/benchmarks


### PR DESCRIPTION
## Summary
- Full transcript and compaction memory mode benchmark configs
- 3 models: Gemini 3 Flash, GPT-5.4 Mini, DeepSeek V3.2
- 15 medium-to-hard quests, 3 runs each
- Compaction tested at interval 10 and 20

## Experiment matrix
- `memory_full_transcript.yaml`: 3 models x 15 quests x 3 runs = 135 runs
- `memory_compaction.yaml`: 3 models x 2 intervals x 15 quests x 3 runs = 270 runs
- Total: 405 experiment runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added new benchmark configuration files to support performance and memory testing scenarios across multiple models and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->