### PR TITLE
Exp4: memo variation templates and raised truncation limits

### DIFF
--- a/configs/benchmarks/exp4_compaction_no_memo.yaml
+++ b/configs/benchmarks/exp4_compaction_no_memo.yaml
@@ -1,0 +1,35 @@
+name: exp4_compaction_no_memo
+quests:
+  # Easy (>50% success)
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  # Medium (10-50%)
+  - quests/sr_2_1_2121_eng/Pilot_eng.qm
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+  # Hard (<2%)
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  # Unrated (0% so far or untested)
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Disk_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Player_eng.qm
+  - quests/sr_2_1_2121_eng/Shashki_eng.qm
+  - quests/sr_2_1_2121_eng/Sortirovka1_eng.qm
+agents:
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: reasoning
+    temperature: 0.4
+    runs: 2
+    memory_mode: compaction
+    compaction_interval: 50
+debug: false
+quest_timeout: 600
+max_workers: 2
+output_dir: results/benchmarks

--- a/configs/benchmarks/exp4_memo_cot.yaml
+++ b/configs/benchmarks/exp4_memo_cot.yaml
@@ -1,0 +1,35 @@
+name: exp4_memo_cot
+quests:
+  # Easy (>50% success)
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  # Medium (10-50%)
+  - quests/sr_2_1_2121_eng/Pilot_eng.qm
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+  # Hard (<2%)
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  # Unrated (0% so far or untested)
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Disk_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Player_eng.qm
+  - quests/sr_2_1_2121_eng/Shashki_eng.qm
+  - quests/sr_2_1_2121_eng/Sortirovka1_eng.qm
+agents:
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: memo_cot
+    temperature: 0.4
+    runs: 2
+    memory_mode: compaction
+    compaction_interval: 50
+debug: false
+quest_timeout: 600
+max_workers: 2
+output_dir: results/benchmarks

--- a/configs/benchmarks/exp4_memo_extended.yaml
+++ b/configs/benchmarks/exp4_memo_extended.yaml
@@ -1,0 +1,35 @@
+name: exp4_memo_extended
+quests:
+  # Easy (>50% success)
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  # Medium (10-50%)
+  - quests/sr_2_1_2121_eng/Pilot_eng.qm
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+  # Hard (<2%)
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  # Unrated (0% so far or untested)
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Disk_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Player_eng.qm
+  - quests/sr_2_1_2121_eng/Shashki_eng.qm
+  - quests/sr_2_1_2121_eng/Sortirovka1_eng.qm
+agents:
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: memo_extended
+    temperature: 0.4
+    runs: 2
+    memory_mode: compaction
+    compaction_interval: 50
+debug: false
+quest_timeout: 600
+max_workers: 2
+output_dir: results/benchmarks

--- a/configs/benchmarks/exp4_memo_structured.yaml
+++ b/configs/benchmarks/exp4_memo_structured.yaml
@@ -1,0 +1,35 @@
+name: exp4_memo_structured
+quests:
+  # Easy (>50% success)
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  # Medium (10-50%)
+  - quests/sr_2_1_2121_eng/Pilot_eng.qm
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+  # Hard (<2%)
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  # Unrated (0% so far or untested)
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Disk_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Player_eng.qm
+  - quests/sr_2_1_2121_eng/Shashki_eng.qm
+  - quests/sr_2_1_2121_eng/Sortirovka1_eng.qm
+agents:
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: memo_structured
+    temperature: 0.4
+    runs: 2
+    memory_mode: compaction
+    compaction_interval: 50
+debug: false
+quest_timeout: 600
+max_workers: 2
+output_dir: results/benchmarks

--- a/docs/EXPERIMENTS_LOG.md
+++ b/docs/EXPERIMENTS_LOG.md
@@ -63,6 +63,59 @@ Two arms, 2 runs per quest:
 
 First run attempt took 10+ hours and only completed 36% of runs. Root cause: OpenAI Python SDK default read timeout is 600s with 2 retries. When OpenRouter connections stalled, a single API call could block for 16-32 minutes. Fix: set `max_retries=0` on SDK client (our own retry wrapper handles retries) and reduce timeout from 600s to 30s.
 
+### Results (re-run with timeout fix, 65 min each)
+
+| Arm | Wins | Rate | Cost | Won quests |
+|---|---|---|---|---|
+| no_loop_breaker (full_transcript + reasoning) | 2/36 | 5.6% | $4.46 | Ski, Disk |
+| stateful_compact (compaction + 20w memo) | 6/36 | 16.7% | $3.27 | Pilot x2, Disk, Election, Sortirovka1 x2 |
+
+### Failure analysis
+
+- **Memo field empty 100% of steps in no_loop_breaker arm** - reasoning.jinja doesn't instruct memo usage
+- **stateful_compact 3x better**: memo kept signals salient (e.g. "Hogger is greedy" in Pilot), enabled numeric dashboards in Sortirovka1
+- **31% fewer prompt tokens** with compaction vs full_transcript, zero parse regressions
+- **Root causes of remaining failures**: numeric optimization blindness (Pizza, Banket), spatial puzzle inability (Codebox, Shashki), health race undetected (Badday skipped bell mechanic), RNG-dependent outcomes (Disk riddle randomization)
+
+## Exp 4: Memo Variations (2026-04-28)
+
+**Branch**: `exp4-memo-variations` (PR #26)
+**Model**: Gemini 3 Flash Preview (via OpenRouter)
+**Quests**: Same 18 quests as exp3
+**Hypothesis**: Memo quality is the bottleneck. Test whether more space, structured format, or more compute improves on the 20-word baseline.
+
+### Design
+
+Four arms, 2 runs per quest, all using compaction mode (interval 50):
+
+| Arm | Template | Memo budget | Reasoning budget | Tests |
+|---|---|---|---|---|
+| compaction_no_memo | reasoning.jinja | none | 25w | ablation: is memo or compaction the key? |
+| memo_extended | memo_extended.jinja | 50w generic | 50w | is space the bottleneck? |
+| memo_structured | memo_structured.jinja | 50w structured (HP:X Money:Y Trend:+/-) | 50w | does format help? |
+| memo_cot | memo_cot.jinja | 30w + 100w thinking scratchpad | N/A | does compute help? |
+
+Code change: raised memo truncation from 120/160 chars to 350 chars, reasoning storage from 150 to 800 chars.
+
 ### Results
 
-_Pending re-run with timeout fix._
+| Arm | Wins | Rate | Cost | Time | Won quests |
+|---|---|---|---|---|---|
+| **exp3 baseline: stateful_compact (20w memo)** | **6/36** | **16.7%** | **$3.27** | **65m** | **Pilot x2, Disk, Election, Sortirovka1 x2** |
+| compaction_no_memo (ablation) | 2/36 | 5.6% | $2.23 | 68m | Pizza, Disk |
+| memo_extended (50w generic) | 2/36 | 5.6% | $4.28 | 89m | Pilot, Election |
+| memo_structured (50w format) | 1/36 | 2.8% | $3.91 | 82m | Pizza |
+| memo_cot (100w thinking) | 1/36 | 2.8% | $3.15 | 83m | Election |
+
+### Findings
+
+1. **Original 20-word stateful_compact remains the clear winner.** None of the exp4 variations improved on it.
+2. **Compaction alone = no memo.** compaction_no_memo matched full_transcript baseline exactly (5.6%), confirming memo is the active ingredient.
+3. **More space doesn't help.** memo_extended (50w) = 5.6%, same as no-memo baselines. The bottleneck isn't memo size.
+4. **Structure hurts.** Rigid format instructions constrained the model instead of helping it (2.8%).
+5. **More compute doesn't help.** 100-word thinking scratchpad performed worst despite most output tokens (2.8%).
+6. **Conciseness wins.** The 20-word constraint forced maximally selective state tracking - the right pressure.
+
+### Conclusion
+
+The memo improvement curve is not monotonic: 0 words (5.6%) -> 20 words (16.7%) -> 50 words (5.6%) -> 50 words structured (2.8%). The sweet spot is a short, unconstrained memo. Next improvements should target agent architecture (planner, tools) or knowledge injection, not memo format.

--- a/docs/EXPERIMENTS_LOG.md
+++ b/docs/EXPERIMENTS_LOG.md
@@ -119,3 +119,102 @@ Code change: raised memo truncation from 120/160 chars to 350 chars, reasoning s
 ### Conclusion
 
 The memo improvement curve is not monotonic: 0 words (5.6%) -> 20 words (16.7%) -> 50 words (5.6%) -> 50 words structured (2.8%). The sweet spot is a short, unconstrained memo. Next improvements should target agent architecture (planner, tools) or knowledge injection, not memo format.
+
+## Next Plan: Baseline Replication + Unified Tools
+
+### Decisions
+
+- Exp 5 is a pure replication of the current best architecture: `stateful_compact` with a 20-word memo, compaction mode, same 18-quest set, same Gemini 3 Flash Preview model, 5 runs per quest.
+- Do not add a 30-word memo arm to Exp 5. That would mix replication with prompt tuning and make variance harder to interpret.
+- Tools must be evaluated as an always-enabled architecture on the full quest set, not selectively enabled by quest. The benchmark should test a general agent mode, not quest-specific routing.
+- First unified-tools run should be cheap: 2 runs per quest across the same 18 quests. Scale only if it does not clearly hurt relative to the Exp 5 baseline.
+- Planner experiments are postponed until tool/planner memory propagation is fixed and verified.
+
+### Required fix before planner or tool experiments
+
+`PlannerAgent` and `ToolAgent` inherit from `LLMAgent`, but current factory and prompt construction do not give them the same memory surface as the winning baseline.
+
+Known issue:
+
+- `agent_factory.create_agent()` passes `memory_mode` and `compaction_interval` only to plain `LLMAgent`.
+- `PlannerAgent` and `ToolAgent` build prompts from raw `state`, while plain `LLMAgent` uses `_build_contextual_state(state)` to inject the quest briefing, full transcript, compaction summary, recent steps, and memo history.
+
+Fix requirement:
+
+- Pass `memory_mode` and `compaction_interval` into `PlannerAgent` and `ToolAgent`.
+- Ensure planner/tool prompts receive the same contextual state block as the baseline when `memory_mode` is `full_transcript` or `compaction`.
+- Add focused tests proving `create_agent(..., action_template="tool_augmented", memory_mode="compaction")` and planner equivalent preserve that setting and include contextual memory in prompts.
+
+### Exp 5: Baseline variance
+
+Goal: measure variance of the current best architecture.
+
+Config:
+
+- Model: `openrouter:google/gemini-3-flash-preview`
+- Template: `stateful_compact`
+- Memory mode: `compaction`
+- Compaction interval: `50`
+- Runs: `5`
+- Quests: same 18 quests from Exp 3 / Exp 4
+
+Primary readout:
+
+- Overall success rate and Wilson interval.
+- Per-quest wins out of 5.
+- Cost and wall-clock time.
+- Whether previously solved quests remain solved: `Pilot`, `Disk`, `Election`, `Sortirovka1`.
+
+Decision after Exp 5:
+
+- If the 20-word baseline collapses under 5 runs per quest, prioritize variance analysis before new architecture claims.
+- If it remains meaningfully above no-memo/full-transcript baselines, use it as the control for Exp 6.
+
+### Exp 6: Unified tools screen
+
+Goal: test whether a general always-on tool architecture improves quest completion without quest-specific routing.
+
+Architecture:
+
+- Base memory architecture: same as Exp 5 (`stateful_compact`, compaction, 20-word memo behavior).
+- Agent mode: tool-augmented.
+- Tools available on every quest:
+  - `calculator(expression)`: deterministic arithmetic for totals, deltas, percentages, linear constraints, and simple comparisons.
+  - `scratchpad(operation, content)`: one persistent run-local free-form note blob for board states, coordinates, inventories, discovered rules, failed branches, and candidate plans.
+  - `quest_history(query)`: existing run-local search over prior observations and selected actions.
+
+Tool constraints:
+
+- No quest-name-specific tools.
+- No hardcoded solvers for `Codebox`, `Shashki`, `Depth`, or any other quest.
+- Tools may be useful for board and spatial quests only through generic arithmetic, scratchpad state tracking, and history lookup.
+- Scratchpad API stays minimal: `read` returns the current note; `write_replace` replaces it with a concise updated note. No append mode initially.
+- Tool use is optional per decision, but the tool-capable architecture is always enabled for all 18 quests.
+- Keep max tool calls small, initially 1 per selection pass unless there is a concrete reason to allow 2.
+
+Screening config:
+
+- Model: `openrouter:google/gemini-3-flash-preview`
+- Quests: same 18 quests as Exp 5
+- Runs: `2`
+- Memory mode: `compaction`
+- Compaction interval: `50`
+
+Primary readout:
+
+- Overall success rate vs Exp 5 per-quest rates.
+- Tool-call frequency per quest.
+- Parse/default rate.
+- Token and cost overhead.
+- Quests where tools appear to hurt previously stable wins.
+
+Scale-up rule:
+
+- Run a 5-run version only if the 2-run screen is not obviously worse on success rate, parse rate, and cost.
+
+### Later work
+
+- Test planner only after memory propagation is fixed and the unified-tools screen is understood.
+- After identifying a winning architecture, rerun across multiple models.
+- Expand quest set and consider Russian versions only after the architecture question is clearer.
+- Remove or mark impossible/pathological quests based on empirical evidence, not before the core architecture comparison is stable.

--- a/llm_quest_benchmark/agents/llm_agent.py
+++ b/llm_quest_benchmark/agents/llm_agent.py
@@ -458,7 +458,7 @@ class LLMAgent(QuestPlayer):
                 if chosen:
                     line += f"\n  You chose: {chosen}"
                 if reasoning:
-                    line += f"\n  Reasoning: {reasoning[:150]}"
+                    line += f"\n  Reasoning: {reasoning[:800]}"
                 state_notes = entry.get("memo", "")
                 if state_notes:
                     line += f"\n  State: {state_notes[:350]}"
@@ -600,7 +600,7 @@ class LLMAgent(QuestPlayer):
             if state_notes:
                 line += f"\n  State: {state_notes[:350]}"
             if reasoning:
-                line += f"\n  Reasoning: {reasoning[:150]}"
+                line += f"\n  Reasoning: {reasoning[:800]}"
             lines.append(line)
         return "\n\n".join(lines)
 
@@ -664,8 +664,8 @@ class LLMAgent(QuestPlayer):
                     "step": self._step_count,
                     "observation": state_snippet if self._memory_mode == "compaction" else state.strip()[:400],
                     "choice_text": selected_text,
-                    "reasoning": (response.reasoning or "")[:150],
-                    "memo": (response.memo or "")[:350],
+                    "reasoning": (response.reasoning or "")[:800],
+                    "memo": (response.memo or "").strip()[:350] or None,
                     "action": action,
                 }
             )

--- a/llm_quest_benchmark/agents/llm_agent.py
+++ b/llm_quest_benchmark/agents/llm_agent.py
@@ -461,7 +461,7 @@ class LLMAgent(QuestPlayer):
                     line += f"\n  Reasoning: {reasoning[:150]}"
                 state_notes = entry.get("memo", "")
                 if state_notes:
-                    line += f"\n  State: {state_notes[:120]}"
+                    line += f"\n  State: {state_notes[:350]}"
                 lines.append(line)
             blocks.append("=== QUEST TRANSCRIPT ===\n" + "\n\n".join(lines))
 
@@ -496,7 +496,7 @@ class LLMAgent(QuestPlayer):
                         line += f"\n  You chose: {chosen}"
                     state_notes = entry.get("memo", "")
                     if state_notes:
-                        line += f"\n  State: {state_notes[:120]}"
+                        line += f"\n  State: {state_notes[:350]}"
                     lines.append(line)
                 blocks.append("=== RECENT STEPS ===\n" + "\n\n".join(lines))
 
@@ -598,9 +598,9 @@ class LLMAgent(QuestPlayer):
             if chosen:
                 line += f"\n  Chose: {chosen}"
             if state_notes:
-                line += f"\n  State: {state_notes[:120]}"
+                line += f"\n  State: {state_notes[:350]}"
             if reasoning:
-                line += f"\n  Reasoning: {reasoning[:100]}"
+                line += f"\n  Reasoning: {reasoning[:150]}"
             lines.append(line)
         return "\n\n".join(lines)
 
@@ -649,7 +649,7 @@ class LLMAgent(QuestPlayer):
                 "action": action,
                 "choice": selected_text,
                 "parse_mode": response.parse_mode or "unknown",
-                "memo": (response.memo or "").strip()[:160] or None,
+                "memo": (response.memo or "").strip()[:350] or None,
             }
         )
         if len(self._decision_history) > 40:
@@ -665,7 +665,7 @@ class LLMAgent(QuestPlayer):
                     "observation": state_snippet if self._memory_mode == "compaction" else state.strip()[:400],
                     "choice_text": selected_text,
                     "reasoning": (response.reasoning or "")[:150],
-                    "memo": (response.memo or "")[:120],
+                    "memo": (response.memo or "")[:350],
                     "action": action,
                 }
             )

--- a/llm_quest_benchmark/prompt_templates/memo_cot.jinja
+++ b/llm_quest_benchmark/prompt_templates/memo_cot.jinja
@@ -1,0 +1,18 @@
+Current story state:
+{{ observation }}
+
+Available actions:
+{% for choice in choices %}
+{{ loop.index }}. {{ choice.text }}
+{% endfor %}
+
+Goal: maximize chances to complete the mission successfully.
+Think step by step before choosing. In your "thinking" field:
+- Compute any math or scores visible in the observation.
+- If in combat, estimate turns to win vs turns to survive. Change tactics if losing.
+- If solving a puzzle, write out the current board state and work through the logic.
+- Compare each action's likely outcome. Identify which advances the mission.
+- Reference your memo from prior turns for continuity.
+
+Return ONLY valid JSON (no markdown/code fences), exactly:
+{"thinking":"<max 100 words: work through the problem step by step>","memo":"<max 30 words: key state to carry forward>","result":<action_number>}

--- a/llm_quest_benchmark/prompt_templates/memo_extended.jinja
+++ b/llm_quest_benchmark/prompt_templates/memo_extended.jinja
@@ -1,0 +1,18 @@
+Current story state:
+{{ observation }}
+
+Available actions:
+{% for choice in choices %}
+{{ loop.index }}. {{ choice.text }}
+{% endfor %}
+
+Goal: maximize chances to complete the mission successfully.
+Guidelines:
+1. Write down important state in "memo": inventory, health, money, codes, NPC names, quest phase, puzzle state.
+2. Prefer actions that keep progress alive and gather useful information.
+3. Avoid choices that abandon, surrender, or prematurely end the quest.
+4. Prioritize the core mission objective over side quests.
+5. Reference your memo from prior turns to make consistent decisions.
+
+Return ONLY valid JSON (no markdown/code fences), exactly:
+{"memo":"<max 50 words: write down key state to remember>","reasoning":"<max 50 words>","result":<action_number>}

--- a/llm_quest_benchmark/prompt_templates/memo_structured.jinja
+++ b/llm_quest_benchmark/prompt_templates/memo_structured.jinja
@@ -1,0 +1,18 @@
+Current story state:
+{{ observation }}
+
+Available actions:
+{% for choice in choices %}
+{{ loop.index }}. {{ choice.text }}
+{% endfor %}
+
+Goal: maximize chances to complete the mission successfully.
+Guidelines:
+1. Maintain structured memo using this format: HP:X Money:Y Items:[list] Board:[state] Phase:[description] Trend:[+/-/=]. Track ALL numbers visible in the story. For grids or puzzles, maintain a compact board representation.
+2. Always note whether your situation is improving (+), declining (-), or stable (=). If declining, change strategy.
+3. Avoid choices that abandon, surrender, or prematurely end the quest.
+4. Reference your memo from prior turns to make consistent decisions.
+5. If a location has interactive elements you haven't tried, flag them as unresolved.
+
+Return ONLY valid JSON (no markdown/code fences), exactly:
+{"memo":"<max 50 words: structured state per format above>","reasoning":"<max 50 words>","result":<action_number>}


### PR DESCRIPTION
## Summary
- Added Exp 4 memo-variation templates and configs:
  - `memo_extended` (50-word generic memo)
  - `memo_structured` (50-word structured state format)
  - `memo_cot` (100-word thinking + 30-word memo)
  - `compaction_no_memo` ablation config
- Raised memo truncation from 120/160 chars to 350 chars and reasoning storage to 800 chars so extended variants are logged instead of clipped.
- Updated `docs/EXPERIMENTS_LOG.md` with final Exp 4 results and the next experiment plan.

## Exp 4 Results
Compared against the Exp 3 winner: `stateful_compact` with 20-word memo, 6/36 wins (16.7%).

| Arm | Wins | Rate | Cost | Time | Won quests |
|---|---:|---:|---:|---:|---|
| Exp 3 baseline: stateful_compact (20w memo) | 6/36 | 16.7% | $3.27 | 65m | Pilot x2, Disk, Election, Sortirovka1 x2 |
| compaction_no_memo | 2/36 | 5.6% | $2.23 | 68m | Pizza, Disk |
| memo_extended | 2/36 | 5.6% | $4.28 | 89m | Pilot, Election |
| memo_structured | 1/36 | 2.8% | $3.91 | 82m | Pizza |
| memo_cot | 1/36 | 2.8% | $3.15 | 83m | Election |

## Findings
- The original 20-word `stateful_compact` prompt remains the winner.
- Compaction without memo falls back to baseline-level performance, so memo is the active ingredient.
- More memo space did not help.
- Rigid structure hurt.
- Extra thinking budget did not help.
- Next work should move to variance measurement and agent architecture, not more memo-format tuning.

## Next Plan
Documented in `docs/EXPERIMENTS_LOG.md`:

- Exp 5: pure 20-word `stateful_compact` replication, same 18 quests, Gemini 3 Flash Preview, 5 runs per quest.
- Before planner/tool experiments: fix memory propagation so `PlannerAgent` and `ToolAgent` receive the same compaction/full-transcript context as `LLMAgent`.
- Exp 6: cheap unified-tools screen, always enabled across all 18 quests, 2 runs per quest.
- Initial tools: `calculator(expression)`, minimal `scratchpad(read|write_replace)`, and existing `quest_history(query)`.
- No quest-specific tools or hardcoded board/depth solvers.

## Test plan
- [x] Smoke tested memo_cot and memo_structured on Disk quest
- [x] Ran all 4 Exp 4 configs (144 runs total)
- [x] Compared with Exp 3 baselines
- [x] `git diff --check`
