### PR TITLE
Prepare unified tools experiment

### DIFF
--- a/configs/benchmarks/exp6_prompt_hints.yaml
+++ b/configs/benchmarks/exp6_prompt_hints.yaml
@@ -1,0 +1,35 @@
+name: exp6_prompt_hints
+quests:
+  # Easy (>50% success)
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  # Medium (10-50%)
+  - quests/sr_2_1_2121_eng/Pilot_eng.qm
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+  # Hard (<2%)
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  # Unrated (0% so far or untested)
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Disk_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Player_eng.qm
+  - quests/sr_2_1_2121_eng/Shashki_eng.qm
+  - quests/sr_2_1_2121_eng/Sortirovka1_eng.qm
+agents:
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: stateful_compact_hints
+    temperature: 0.4
+    runs: 3
+    memory_mode: compaction
+    compaction_interval: 50
+debug: false
+quest_timeout: 600
+max_workers: 2
+output_dir: results/benchmarks

--- a/configs/benchmarks/exp6_tools.yaml
+++ b/configs/benchmarks/exp6_tools.yaml
@@ -1,0 +1,35 @@
+name: exp6_tools
+quests:
+  # Easy (>50% success)
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  # Medium (10-50%)
+  - quests/sr_2_1_2121_eng/Pilot_eng.qm
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+  # Hard (<2%)
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  # Unrated (0% so far or untested)
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Disk_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Player_eng.qm
+  - quests/sr_2_1_2121_eng/Shashki_eng.qm
+  - quests/sr_2_1_2121_eng/Sortirovka1_eng.qm
+agents:
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: tool_augmented
+    temperature: 0.4
+    runs: 3
+    memory_mode: compaction
+    compaction_interval: 50
+debug: false
+quest_timeout: 600
+max_workers: 2
+output_dir: results/benchmarks

--- a/configs/benchmarks/exp6_tools_hints.yaml
+++ b/configs/benchmarks/exp6_tools_hints.yaml
@@ -1,0 +1,35 @@
+name: exp6_tools_hints
+quests:
+  # Easy (>50% success)
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  # Medium (10-50%)
+  - quests/sr_2_1_2121_eng/Pilot_eng.qm
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+  # Hard (<2%)
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  # Unrated (0% so far or untested)
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Disk_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Player_eng.qm
+  - quests/sr_2_1_2121_eng/Shashki_eng.qm
+  - quests/sr_2_1_2121_eng/Sortirovka1_eng.qm
+agents:
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: tool_augmented_hints
+    temperature: 0.4
+    runs: 3
+    memory_mode: compaction
+    compaction_interval: 50
+debug: false
+quest_timeout: 600
+max_workers: 2
+output_dir: results/benchmarks

--- a/configs/benchmarks/exp6_unified_tools_screen.yaml
+++ b/configs/benchmarks/exp6_unified_tools_screen.yaml
@@ -1,0 +1,35 @@
+name: exp6_unified_tools_screen
+quests:
+  # Easy (>50% success)
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  # Medium (10-50%)
+  - quests/sr_2_1_2121_eng/Pilot_eng.qm
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+  # Hard (<2%)
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  # Unrated (0% so far or untested)
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Disk_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Player_eng.qm
+  - quests/sr_2_1_2121_eng/Shashki_eng.qm
+  - quests/sr_2_1_2121_eng/Sortirovka1_eng.qm
+agents:
+  - model: "openrouter:google/gemini-3-flash-preview"
+    template: tool_augmented
+    temperature: 0.4
+    runs: 2
+    memory_mode: compaction
+    compaction_interval: 50
+debug: false
+quest_timeout: 600
+max_workers: 2
+output_dir: results/benchmarks

--- a/docs/EXPERIMENTS_LOG.md
+++ b/docs/EXPERIMENTS_LOG.md
@@ -174,6 +174,15 @@ Decision after Exp 5:
 
 Goal: test whether a general always-on tool architecture improves quest completion without quest-specific routing.
 
+Implementation status (2026-04-28):
+
+- Branch: `exp6-unified-tools`
+- Memory propagation fix implemented for `PlannerAgent` and `ToolAgent`.
+- Tool metadata is exported in `run_summary.json` under `llm_decision.tool_calls` and `llm_decision.tool_results`.
+- Unified tools implemented: `calculator`, `scratchpad`, and existing `quest_history`.
+- Screening config added: `configs/benchmarks/exp6_unified_tools_screen.yaml`.
+- Smoke run on `Banket_eng` and `Shashki_eng` completed 0/2. This verifies plumbing and logging, but suggests the first tool prompt may overuse scratchpad on board-state quests and loop on drink-mixing arithmetic. Treat the full 18-quest screen as exploratory, not as a likely winner until Exp 5 variance is known.
+
 Architecture:
 
 - Base memory architecture: same as Exp 5 (`stateful_compact`, compaction, 20-word memo behavior).

--- a/docs/EXPERIMENTS_LOG.md
+++ b/docs/EXPERIMENTS_LOG.md
@@ -182,6 +182,7 @@ Implementation status (2026-04-28):
 - Unified tools implemented: `calculator`, `scratchpad`, and existing `quest_history`.
 - Screening config added: `configs/benchmarks/exp6_unified_tools_screen.yaml`.
 - Smoke run on `Banket_eng` and `Shashki_eng` completed 0/2. This verifies plumbing and logging, but suggests the first tool prompt may overuse scratchpad on board-state quests and loop on drink-mixing arithmetic. Treat the full 18-quest screen as exploratory, not as a likely winner until Exp 5 variance is known.
+- Benchmark harness fixed after Exp 5 exposed runtime drift: `max_workers` now runs attempts concurrently, and the parent process enforces `quest_timeout` by terminating over-limit child runs and recording `TIMEOUT`.
 
 Architecture:
 

--- a/llm_quest_benchmark/agents/agent_factory.py
+++ b/llm_quest_benchmark/agents/agent_factory.py
@@ -73,6 +73,8 @@ def create_agent(
             action_template=resolved_action_template,
             temperature=temperature,
             skip_single=skip_single,
+            memory_mode=memory_mode,
+            compaction_interval=compaction_interval,
         )
 
     if resolved_action_template == "tool_augmented.jinja":
@@ -83,6 +85,8 @@ def create_agent(
             action_template=resolved_action_template,
             temperature=temperature,
             skip_single=skip_single,
+            memory_mode=memory_mode,
+            compaction_interval=compaction_interval,
         )
 
     # Default to LLM agent

--- a/llm_quest_benchmark/agents/agent_factory.py
+++ b/llm_quest_benchmark/agents/agent_factory.py
@@ -77,7 +77,7 @@ def create_agent(
             compaction_interval=compaction_interval,
         )
 
-    if resolved_action_template == "tool_augmented.jinja":
+    if resolved_action_template in ("tool_augmented.jinja", "tool_augmented_hints.jinja"):
         return ToolAgent(
             debug=debug,
             model_name=model,

--- a/llm_quest_benchmark/agents/planner_agent.py
+++ b/llm_quest_benchmark/agents/planner_agent.py
@@ -167,13 +167,14 @@ class PlannerAgent(LLMAgent):
             self.logger.debug("PlannerAgent evaluating state with %s choices", len(choices))
         try:
             state_signature = self._state_signature(state, choices)
+            contextual_state = self._build_contextual_state(state)
             should_replan, replan_reason = self._should_replan(state, state_signature)
             plan_usage = None
             if should_replan:
-                plan_usage = self._update_plan(state, choices, replan_reason)
+                plan_usage = self._update_plan(contextual_state, choices, replan_reason)
 
             parsed_response, action_usage = self._choose_action_with_plan(
-                state,
+                contextual_state,
                 choices,
                 replan_reason if should_replan else None,
             )

--- a/llm_quest_benchmark/agents/tool_agent.py
+++ b/llm_quest_benchmark/agents/tool_agent.py
@@ -1,11 +1,6 @@
-"""Tool-augmented agent with lightweight structured prompting.
+"""Tool-augmented agent with lightweight structured prompting."""
 
-TODO (next PR):
-- Add calculator tool (test as hypothesis whether arithmetic helps)
-- Add domain knowledge lookup tool (needs curated Space Rangers knowledge base)
-- Add more tools as evaluation dimensions
-"""
-
+import ast
 import re
 from typing import Any
 
@@ -18,9 +13,11 @@ from llm_quest_benchmark.agents.llm_agent import (
 
 
 class ToolAgent(LLMAgent):
-    """LLM agent that can review recent quest history before choosing an action."""
+    """LLM agent with generic run-local tools for history, math, and state notes."""
 
     DEFAULT_HISTORY_WINDOW = 10
+    MAX_SCRATCHPAD_CHARS = 1200
+    MAX_TOOL_INPUT_CHARS = 500
 
     def __init__(
         self,
@@ -33,6 +30,7 @@ class ToolAgent(LLMAgent):
         self.agent_id = f"tool_{self.model_name}"
         self._step_log: list[dict[str, Any]] = []
         self._history_window = history_window or self.DEFAULT_HISTORY_WINDOW
+        self._scratchpad = ""
 
     def _recent_steps(self) -> list[str]:
         snippets = []
@@ -43,6 +41,8 @@ class ToolAgent(LLMAgent):
     def _tool_descriptions(self) -> list[str]:
         return [
             "quest_history(query): search earlier observations and chosen actions in this quest.",
+            "calculator(expression): evaluate arithmetic and simple comparisons.",
+            "scratchpad(operation, content): read or replace one persistent note. operation is read or write_replace.",
         ]
 
     def quest_history(self, query: str) -> str:
@@ -76,6 +76,124 @@ class ToolAgent(LLMAgent):
             )
         return "\n".join(lines)
 
+    @staticmethod
+    def calculator(expression: str) -> str:
+        """Evaluate a restricted arithmetic/comparison expression."""
+        expr = (expression or "").strip()
+        if not expr:
+            return "error: empty expression"
+        if len(expr) > 240:
+            return "error: expression too long"
+        if not re.fullmatch(r"[0-9a-zA-Z\s+\-*/().,<>=!%]+", expr):
+            return "error: unsupported characters"
+
+        allowed_nodes = (
+            ast.Expression,
+            ast.Constant,
+            ast.UnaryOp,
+            ast.UAdd,
+            ast.USub,
+            ast.BinOp,
+            ast.Add,
+            ast.Sub,
+            ast.Mult,
+            ast.Div,
+            ast.FloorDiv,
+            ast.Mod,
+            ast.Pow,
+            ast.Compare,
+            ast.Eq,
+            ast.NotEq,
+            ast.Lt,
+            ast.LtE,
+            ast.Gt,
+            ast.GtE,
+            ast.BoolOp,
+            ast.And,
+            ast.Or,
+        )
+        try:
+            tree = ast.parse(expr, mode="eval")
+            for node in ast.walk(tree):
+                if not isinstance(node, allowed_nodes):
+                    return f"error: unsupported expression element {node.__class__.__name__}"
+                if isinstance(node, ast.Constant) and not isinstance(node.value, (int, float, bool)):
+                    return "error: constants must be numeric or boolean"
+            result = ToolAgent._eval_calculator_node(tree.body)
+        except Exception as exc:
+            return f"error: {exc}"
+        return f"{expr} = {result}"
+
+    @staticmethod
+    def _eval_calculator_node(node: ast.AST) -> int | float | bool:
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float, bool)):
+            return node.value
+        if isinstance(node, ast.UnaryOp):
+            value = ToolAgent._eval_calculator_node(node.operand)
+            if isinstance(node.op, ast.UAdd):
+                return +value
+            if isinstance(node.op, ast.USub):
+                return -value
+        if isinstance(node, ast.BinOp):
+            left = ToolAgent._eval_calculator_node(node.left)
+            right = ToolAgent._eval_calculator_node(node.right)
+            if isinstance(node.op, ast.Add):
+                return left + right
+            if isinstance(node.op, ast.Sub):
+                return left - right
+            if isinstance(node.op, ast.Mult):
+                return left * right
+            if isinstance(node.op, ast.Div):
+                return left / right
+            if isinstance(node.op, ast.FloorDiv):
+                return left // right
+            if isinstance(node.op, ast.Mod):
+                return left % right
+            if isinstance(node.op, ast.Pow):
+                if abs(right) > 8:
+                    raise ValueError("exponent too large")
+                return left**right
+        if isinstance(node, ast.BoolOp):
+            values = [bool(ToolAgent._eval_calculator_node(value)) for value in node.values]
+            if isinstance(node.op, ast.And):
+                return all(values)
+            if isinstance(node.op, ast.Or):
+                return any(values)
+        if isinstance(node, ast.Compare):
+            left = ToolAgent._eval_calculator_node(node.left)
+            for op, comparator in zip(node.ops, node.comparators, strict=False):
+                right = ToolAgent._eval_calculator_node(comparator)
+                if isinstance(op, ast.Eq):
+                    ok = left == right
+                elif isinstance(op, ast.NotEq):
+                    ok = left != right
+                elif isinstance(op, ast.Lt):
+                    ok = left < right
+                elif isinstance(op, ast.LtE):
+                    ok = left <= right
+                elif isinstance(op, ast.Gt):
+                    ok = left > right
+                elif isinstance(op, ast.GtE):
+                    ok = left >= right
+                else:
+                    raise ValueError("unsupported comparison")
+                if not ok:
+                    return False
+                left = right
+            return True
+        raise ValueError("unsupported expression")
+
+    def scratchpad(self, operation: str, content: str = "") -> str:
+        """Read or replace one persistent free-form note blob."""
+        op = (operation or "").strip().lower()
+        if op == "read":
+            return self._scratchpad or "(empty)"
+        if op == "write_replace":
+            note = " ".join((content or "").strip().split())
+            self._scratchpad = note[: self.MAX_SCRATCHPAD_CHARS]
+            return f"updated: {self._scratchpad or '(empty)'}"
+        return "error: operation must be read or write_replace"
+
     def _build_tool_prompt(
         self,
         observation: str,
@@ -91,10 +209,11 @@ class ToolAgent(LLMAgent):
             tool_descriptions=self._tool_descriptions(),
             tool_results=tool_results or [],
             recent_steps=self._recent_steps(),
+            scratchpad_note=self._scratchpad,
         ).strip()
 
     @staticmethod
-    def _extract_tool_calls(response: str) -> list[dict[str, str]]:
+    def _extract_tool_calls(response: str) -> list[dict[str, Any]]:
         payload, _ = _parse_json_response(response)
         if not isinstance(payload, dict):
             return []
@@ -104,24 +223,50 @@ class ToolAgent(LLMAgent):
             return []
 
         normalized = []
-        for item in tool_calls[:2]:
+        for item in tool_calls[:1]:
             if not isinstance(item, dict):
                 continue
             tool_name = str(item.get("tool") or "").strip()
-            tool_input = str(item.get("input") or "").strip()
-            if tool_name and tool_input:
-                normalized.append({"tool": tool_name, "input": tool_input})
+            tool_input = item.get("input")
+            operation = str(item.get("operation") or "").strip()
+            content = str(item.get("content") or "").strip()
+            if isinstance(tool_input, dict):
+                operation = operation or str(tool_input.get("operation") or "").strip()
+                content = content or str(tool_input.get("content") or "").strip()
+                tool_input = tool_input.get("expression") or tool_input.get("query") or tool_input.get("content") or ""
+            tool_input = str(tool_input or "").strip()
+            if len(tool_input) > ToolAgent.MAX_TOOL_INPUT_CHARS:
+                tool_input = tool_input[: ToolAgent.MAX_TOOL_INPUT_CHARS]
+            if len(content) > ToolAgent.MAX_TOOL_INPUT_CHARS:
+                content = content[: ToolAgent.MAX_TOOL_INPUT_CHARS]
+            if tool_name:
+                normalized.append(
+                    {
+                        "tool": tool_name,
+                        "input": tool_input,
+                        "operation": operation,
+                        "content": content,
+                    }
+                )
         return normalized
 
-    def _execute_tool_calls(self, tool_calls: list[dict[str, str]]) -> list[str]:
+    def _execute_tool_calls(self, tool_calls: list[dict[str, Any]]) -> list[str]:
         results = []
         for tc in tool_calls[:2]:
-            name, inp = tc["tool"], tc["input"]
+            name, inp = tc["tool"], tc.get("input", "")
             if name == "quest_history":
                 result = self.quest_history(inp)
+            elif name == "calculator":
+                result = self.calculator(inp)
+            elif name == "scratchpad":
+                operation = tc.get("operation") or inp
+                result = self.scratchpad(str(operation), str(tc.get("content") or ""))
             else:
                 result = f"unknown tool: {name}"
-            results.append(f"{name}({inp}) => {result}")
+            call_repr = inp
+            if name == "scratchpad":
+                call_repr = f"{tc.get('operation') or inp}, {tc.get('content') or ''}".strip(", ")
+            results.append(f"{name}({call_repr}) => {result}")
         return results
 
     def _final_choice(
@@ -180,21 +325,23 @@ class ToolAgent(LLMAgent):
     def _get_action_impl(self, state: str, choices: list[dict[str, str]]) -> int:
         try:
             state_signature = self._state_signature(state, choices)
+            contextual_state = self._build_contextual_state(state)
             self._ensure_llm()
 
-            selection_prompt = self._build_tool_prompt(state, choices, prompt_kind="select")
+            selection_prompt = self._build_tool_prompt(contextual_state, choices, prompt_kind="select")
             selection_response = self.llm.get_completion(selection_prompt)
             selection_usage = self.llm.get_last_usage()
             tool_calls = self._extract_tool_calls(selection_response)
             parsed_response = parse_llm_response(selection_response, len(choices), self.debug, self.logger)
+            tool_results: list[str] = []
 
             total_usage = self._normalize_usage(selection_usage)
             if tool_calls:
                 tool_results = self._execute_tool_calls(tool_calls)
-                parsed_response, final_usage = self._final_choice(state, choices, tool_results=tool_results)
+                parsed_response, final_usage = self._final_choice(contextual_state, choices, tool_results=tool_results)
                 total_usage = self._normalize_usage(self._merge_usage(total_usage, final_usage))
             elif parsed_response.is_default:
-                parsed_response, final_usage = self._final_choice(state, choices, tool_results=[])
+                parsed_response, final_usage = self._final_choice(contextual_state, choices, tool_results=[])
                 total_usage = self._normalize_usage(self._merge_usage(total_usage, final_usage))
 
             action_before_policy = parsed_response.action
@@ -206,6 +353,8 @@ class ToolAgent(LLMAgent):
             parsed_response.completion_tokens = total_usage["completion_tokens"]
             parsed_response.total_tokens = total_usage["total_tokens"]
             parsed_response.estimated_cost_usd = total_usage["estimated_cost_usd"]
+            parsed_response.tool_calls = tool_calls or None
+            parsed_response.tool_results = tool_results or None
 
             self.history.append(parsed_response)
             self._last_response = parsed_response
@@ -227,7 +376,9 @@ class ToolAgent(LLMAgent):
     def reset(self) -> None:
         super().reset()
         self._step_log = []
+        self._scratchpad = ""
 
     def on_game_start(self) -> None:
         super().on_game_start()
         self._step_log = []
+        self._scratchpad = ""

--- a/llm_quest_benchmark/agents/tool_agent.py
+++ b/llm_quest_benchmark/agents/tool_agent.py
@@ -161,7 +161,7 @@ class ToolAgent(LLMAgent):
                 return any(values)
         if isinstance(node, ast.Compare):
             left = ToolAgent._eval_calculator_node(node.left)
-            for op, comparator in zip(node.ops, node.comparators, strict=False):
+            for op, comparator in zip(node.ops, node.comparators, strict=True):
                 right = ToolAgent._eval_calculator_node(comparator)
                 if isinstance(op, ast.Eq):
                     ok = left == right
@@ -252,7 +252,7 @@ class ToolAgent(LLMAgent):
 
     def _execute_tool_calls(self, tool_calls: list[dict[str, Any]]) -> list[str]:
         results = []
-        for tc in tool_calls[:2]:
+        for tc in tool_calls:
             name, inp = tc["tool"], tc.get("input", "")
             if name == "quest_history":
                 result = self.quest_history(inp)

--- a/llm_quest_benchmark/core/logging.py
+++ b/llm_quest_benchmark/core/logging.py
@@ -151,6 +151,8 @@ class QuestLogger:
         analysis = None
         reasoning = None
         memo = None
+        tool_calls = None
+        tool_results = None
         is_default = True
         parse_mode = None
         prompt_tokens = 0
@@ -165,6 +167,8 @@ class QuestLogger:
             analysis = llm_response.get("analysis")
             reasoning = llm_response.get("reasoning")
             memo = llm_response.get("memo")
+            tool_calls = llm_response.get("tool_calls")
+            tool_results = llm_response.get("tool_results")
             is_default = bool(llm_response.get("is_default", False))
             parse_mode = llm_response.get("parse_mode")
             prompt_tokens = int(llm_response.get("prompt_tokens") or 0)
@@ -177,6 +181,8 @@ class QuestLogger:
             "analysis": analysis,
             "reasoning": reasoning,
             "memo": memo,
+            "tool_calls": tool_calls,
+            "tool_results": tool_results,
             "is_default": is_default,
             "parse_mode": parse_mode,
             "choice": self._selected_choice_map(choices_map, parsed_action_index),

--- a/llm_quest_benchmark/core/runner.py
+++ b/llm_quest_benchmark/core/runner.py
@@ -43,7 +43,6 @@ def run_quest_with_timeout(
 
         # Initialize logger with agent_id
         logger = QuestLogger(debug=debug, agent=agent_id)
-        logger.set_quest_file(quest_path)
 
         # Create quest environment and runner
         QuestEnvironment(quest_path)  # validates quest path
@@ -207,6 +206,13 @@ class QuestRunner:
         try:
             # Initialize environment and notify callbacks
             self.initialize(quest)
+            self._notify_callbacks(
+                "run_record",
+                {
+                    "run_id": self.quest_logger.current_run_id if self.quest_logger else None,
+                    "quest": quest,
+                },
+            )
             self.agent.reset()
             self.agent.on_game_start()
             self._notify_callbacks("title")

--- a/llm_quest_benchmark/executors/benchmark.py
+++ b/llm_quest_benchmark/executors/benchmark.py
@@ -2,8 +2,12 @@
 
 import json
 import logging
+import multiprocessing as mp
+import queue
 import sqlite3
+import time
 import uuid
+from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -28,6 +32,140 @@ logging.getLogger("llm_quest_benchmark").setLevel(logging.WARNING)
 logging.getLogger("llm_quest_benchmark.executors.ts_bridge").setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
+
+
+def _result_entry(
+    quest: str,
+    agent_config,
+    attempt: int,
+    outcome: str,
+    reward: float = 0.0,
+    error: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "quest": quest,
+        "model": agent_config.model,
+        "temperature": agent_config.temperature,
+        "template": agent_config.action_template,
+        "agent_id": agent_config.agent_id,
+        "attempt": attempt,
+        "outcome": outcome,
+        "reward": reward,
+        "error": error,
+    }
+
+
+def _mark_run_timeout(run_id: int | None, quest: str, agent_config, benchmark_id: str, timeout: int) -> None:
+    """Record a parent-enforced timeout for a killed child process."""
+    agent_config_json = json.dumps(agent_config.__dict__)
+    end_time = datetime.utcnow()
+    conn = sqlite3.connect(DEFAULT_DB_PATH)
+    try:
+        if run_id is not None:
+            row = conn.execute("SELECT start_time FROM runs WHERE id = ?", (run_id,)).fetchone()
+            run_duration = None
+            if row and row[0]:
+                try:
+                    start_time = datetime.fromisoformat(str(row[0]))
+                    run_duration = (end_time - start_time).total_seconds()
+                except ValueError:
+                    run_duration = None
+            conn.execute(
+                """
+                UPDATE runs
+                SET agent_id = ?, agent_config = ?, benchmark_id = ?, outcome = ?,
+                    reward = ?, end_time = ?, run_duration = ?
+                WHERE id = ?
+                """,
+                (
+                    agent_config.agent_id,
+                    agent_config_json,
+                    benchmark_id,
+                    QuestOutcome.TIMEOUT.name,
+                    0.0,
+                    end_time,
+                    run_duration,
+                    run_id,
+                ),
+            )
+        else:
+            conn.execute(
+                """
+                INSERT INTO runs
+                    (quest_file, quest_name, start_time, end_time, agent_id, agent_config,
+                     outcome, reward, run_duration, benchmark_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    quest,
+                    Path(quest).stem,
+                    end_time,
+                    end_time,
+                    agent_config.agent_id,
+                    agent_config_json,
+                    QuestOutcome.TIMEOUT.name,
+                    0.0,
+                    0.0,
+                    benchmark_id,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _run_benchmark_task(task: dict[str, Any], result_queue) -> None:
+    """Run one benchmark attempt in a child process."""
+    agent_config = task["agent_config"]
+    agent_config.benchmark_id = task["benchmark_id"]
+    quest = task["quest"]
+    attempt = task["attempt"]
+
+    def callback(event: str, data: Any = None) -> None:
+        if event == "run_record" and isinstance(data, dict):
+            result_queue.put(
+                {
+                    "event": "run_record",
+                    "run_index": task["run_index"],
+                    "run_id": data.get("run_id"),
+                }
+            )
+
+    try:
+        agent = create_agent(
+            model=agent_config.model,
+            temperature=agent_config.temperature,
+            system_template=agent_config.system_template,
+            action_template=agent_config.action_template,
+            skip_single=agent_config.skip_single,
+            debug=agent_config.debug,
+            memory_mode=agent_config.memory_mode,
+            compaction_interval=agent_config.compaction_interval,
+        )
+        outcome = run_quest_with_timeout(
+            quest,
+            agent,
+            timeout=10**9,
+            agent_config=agent_config,
+            debug=agent_config.debug,
+            callbacks=[callback],
+        )
+        outcome_name = outcome.name if outcome else QuestOutcome.TIMEOUT.name
+        result_queue.put(
+            {
+                "event": "done",
+                "run_index": task["run_index"],
+                "result": _result_entry(quest, agent_config, attempt, outcome_name),
+            }
+        )
+    except Exception as exc:
+        result_queue.put(
+            {
+                "event": "done",
+                "run_index": task["run_index"],
+                "result": _result_entry(quest, agent_config, attempt, QuestOutcome.ERROR.name, error=str(exc)),
+            }
+        )
 
 
 def generate_benchmark_id(prefix: str = "benchmark") -> str:
@@ -172,9 +310,6 @@ def run_benchmark(config: BenchmarkConfig, progress_callback=None) -> list[dict[
     if not config.benchmark_id:
         config.benchmark_id = generate_benchmark_id("benchmark")
 
-    if config.max_workers and config.max_workers > 1:
-        logger.info("max_workers=%s is currently accepted but benchmark runs sequentially", config.max_workers)
-
     logger.info(f"Running benchmark with ID: {config.benchmark_id}")
 
     # Expand quest paths into actual quest files
@@ -185,11 +320,9 @@ def run_benchmark(config: BenchmarkConfig, progress_callback=None) -> list[dict[
     logger.info(f"Running {len(quest_files)} quests with {len(config.agents)} agents")
     logger.info(f"Agents: {', '.join(a.agent_id for a in config.agents)}")
 
-    # Collect results for each agent x quest combination.
-    results = []
-
     total_runs = len(quest_files) * sum(agent.runs for agent in config.agents)
     run_index = 0
+    tasks = []
 
     for agent_config in config.agents:
         for quest_file in quest_files:
@@ -197,111 +330,172 @@ def run_benchmark(config: BenchmarkConfig, progress_callback=None) -> list[dict[
                 run_index += 1
                 quest_str = str(quest_file)
                 quest_name = Path(quest_file).name
+                task_agent_config = deepcopy(agent_config)
+                task_agent_config.benchmark_id = config.benchmark_id
+                tasks.append(
+                    {
+                        "run_index": run_index,
+                        "total_runs": total_runs,
+                        "quest": quest_str,
+                        "quest_name": quest_name,
+                        "agent_config": task_agent_config,
+                        "attempt": attempt,
+                        "benchmark_id": config.benchmark_id,
+                    }
+                )
 
                 logger.info(
-                    "Agent %s running quest %s (attempt %s/%s)",
+                    "Queued agent %s quest %s (attempt %s/%s)",
                     agent_config.agent_id,
                     quest_name,
                     attempt,
                     agent_config.runs,
                 )
+
+    max_workers = max(1, int(config.max_workers or 1))
+    logger.info("Running %s benchmark attempts with max_workers=%s", total_runs, max_workers)
+
+    # Collect results for each agent x quest combination.
+    results_by_index: list[tuple[int, dict[str, Any]]] = []
+    ctx = mp.get_context("fork")
+    running: dict[int, dict[str, Any]] = {}
+    next_task = 0
+
+    while next_task < len(tasks) or running:
+        while next_task < len(tasks) and len(running) < max_workers:
+            task = tasks[next_task]
+            next_task += 1
+            agent_config = task["agent_config"]
+            task_queue = ctx.Queue()
+            process = ctx.Process(target=_run_benchmark_task, args=(task, task_queue))
+            process.start()
+            running[task["run_index"]] = {
+                "task": task,
+                "queue": task_queue,
+                "process": process,
+                "started_at": time.monotonic(),
+                "run_id": None,
+            }
+            logger.info(
+                "Agent %s running quest %s (attempt %s/%s)",
+                agent_config.agent_id,
+                task["quest_name"],
+                task["attempt"],
+                agent_config.runs,
+            )
+            _emit_progress(
+                progress_callback,
+                {
+                    "event": "pair_start",
+                    "run_index": task["run_index"],
+                    "total_runs": total_runs,
+                    "quest": task["quest"],
+                    "quest_name": task["quest_name"],
+                    "agent_id": agent_config.agent_id,
+                    "model": agent_config.model,
+                    "attempt": task["attempt"],
+                },
+            )
+
+        completed: list[int] = []
+        for current_index, handle in list(running.items()):
+            task = handle["task"]
+            agent_config = task["agent_config"]
+            process = handle["process"]
+            task_queue = handle["queue"]
+            while True:
+                try:
+                    message = task_queue.get_nowait()
+                except queue.Empty:
+                    break
+                if message.get("event") == "run_record":
+                    handle["run_id"] = message.get("run_id")
+                elif message.get("event") == "done":
+                    result = message["result"]
+                    results_by_index.append((current_index, result))
+                    completed.append(current_index)
+                    process.join(timeout=1)
+                    _emit_progress(
+                        progress_callback,
+                        {
+                            "event": "pair_done",
+                            "run_index": current_index,
+                            "total_runs": total_runs,
+                            "quest": task["quest"],
+                            "quest_name": task["quest_name"],
+                            "agent_id": agent_config.agent_id,
+                            "model": agent_config.model,
+                            "attempt": task["attempt"],
+                            "outcome": result["outcome"],
+                            "error": result["error"],
+                        },
+                    )
+                    break
+
+            if current_index in completed:
+                continue
+
+            elapsed = time.monotonic() - handle["started_at"]
+            if elapsed > max(config.quest_timeout, 1):
+                logger.warning(
+                    "Quest %s attempt %s timed out after %s seconds",
+                    task["quest_name"],
+                    task["attempt"],
+                    config.quest_timeout,
+                )
+                process.terminate()
+                process.join(timeout=5)
+                if process.is_alive():
+                    process.kill()
+                    process.join(timeout=1)
+                _mark_run_timeout(
+                    handle["run_id"], task["quest"], agent_config, config.benchmark_id, config.quest_timeout
+                )
+                result = _result_entry(
+                    task["quest"],
+                    agent_config,
+                    task["attempt"],
+                    QuestOutcome.TIMEOUT.name,
+                    error=f"Timed out after {config.quest_timeout} seconds",
+                )
+                results_by_index.append((current_index, result))
+                completed.append(current_index)
                 _emit_progress(
                     progress_callback,
                     {
-                        "event": "pair_start",
-                        "run_index": run_index,
+                        "event": "pair_done",
+                        "run_index": current_index,
                         "total_runs": total_runs,
-                        "quest": quest_str,
-                        "quest_name": quest_name,
+                        "quest": task["quest"],
+                        "quest_name": task["quest_name"],
                         "agent_id": agent_config.agent_id,
                         "model": agent_config.model,
-                        "attempt": attempt,
+                        "attempt": task["attempt"],
+                        "outcome": QuestOutcome.TIMEOUT.name,
+                        "error": f"Timed out after {config.quest_timeout} seconds",
                     },
                 )
 
-                try:
-                    # Set the benchmark_id in agent_config for database tracking
-                    agent_config.benchmark_id = config.benchmark_id
+            elif process.exitcode is not None and process.exitcode != 0:
+                result = _result_entry(
+                    task["quest"],
+                    agent_config,
+                    task["attempt"],
+                    QuestOutcome.ERROR.name,
+                    error=f"Worker exited with code {process.exitcode}",
+                )
+                results_by_index.append((current_index, result))
+                completed.append(current_index)
 
-                    # Create agent
-                    agent = create_agent(
-                        model=agent_config.model,
-                        temperature=agent_config.temperature,
-                        system_template=agent_config.system_template,
-                        action_template=agent_config.action_template,
-                        skip_single=agent_config.skip_single,
-                        debug=agent_config.debug,
-                        memory_mode=agent_config.memory_mode,
-                        compaction_interval=agent_config.compaction_interval,
-                    )
+        for current_index in completed:
+            handle = running.pop(current_index, None)
+            if handle:
+                handle["queue"].close()
 
-                    # Run quest with timeout
-                    outcome = run_quest_with_timeout(
-                        quest_str, agent, timeout=config.quest_timeout, agent_config=agent_config
-                    )
-                    outcome_name = outcome.name if outcome else QuestOutcome.TIMEOUT.name
-                    timeout_error = None if outcome else f"Timed out after {config.quest_timeout} seconds"
+        if not completed:
+            time.sleep(0.1)
 
-                    # Create result entry
-                    result = {
-                        "quest": quest_str,
-                        "model": agent_config.model,
-                        "temperature": agent_config.temperature,
-                        "template": agent_config.action_template,
-                        "agent_id": agent_config.agent_id,
-                        "attempt": attempt,
-                        "outcome": outcome_name,
-                        "reward": getattr(outcome, "reward", 0.0),
-                        "error": timeout_error,
-                    }
-                    _emit_progress(
-                        progress_callback,
-                        {
-                            "event": "pair_done",
-                            "run_index": run_index,
-                            "total_runs": total_runs,
-                            "quest": quest_str,
-                            "quest_name": quest_name,
-                            "agent_id": agent_config.agent_id,
-                            "model": agent_config.model,
-                            "attempt": attempt,
-                            "outcome": outcome_name,
-                            "error": timeout_error,
-                        },
-                    )
-
-                except Exception as e:
-                    # Log the error but continue with other quests
-                    logger.error(f"Error running quest {quest_file} with agent {agent_config.agent_id}: {e}")
-
-                    # Create error result
-                    result = {
-                        "quest": quest_str,
-                        "model": agent_config.model,
-                        "temperature": agent_config.temperature,
-                        "template": agent_config.action_template,
-                        "agent_id": agent_config.agent_id,
-                        "attempt": attempt,
-                        "outcome": QuestOutcome.ERROR.name,
-                        "reward": 0.0,
-                        "error": str(e),
-                    }
-                    _emit_progress(
-                        progress_callback,
-                        {
-                            "event": "pair_done",
-                            "run_index": run_index,
-                            "total_runs": total_runs,
-                            "quest": quest_str,
-                            "quest_name": quest_name,
-                            "agent_id": agent_config.agent_id,
-                            "model": agent_config.model,
-                            "attempt": attempt,
-                            "outcome": QuestOutcome.ERROR.name,
-                            "error": str(e),
-                        },
-                    )
-                results.append(result)
+    results = [result for _, result in sorted(results_by_index, key=lambda item: item[0])]
 
     artifact_dir = _write_benchmark_artifacts(config, results)
     if artifact_dir:

--- a/llm_quest_benchmark/executors/benchmark.py
+++ b/llm_quest_benchmark/executors/benchmark.py
@@ -357,7 +357,7 @@ def run_benchmark(config: BenchmarkConfig, progress_callback=None) -> list[dict[
 
     # Collect results for each agent x quest combination.
     results_by_index: list[tuple[int, dict[str, Any]]] = []
-    ctx = mp.get_context("fork")
+    ctx = mp.get_context("spawn")
     running: dict[int, dict[str, Any]] = {}
     next_task = 0
 
@@ -415,6 +415,9 @@ def run_benchmark(config: BenchmarkConfig, progress_callback=None) -> list[dict[
                     results_by_index.append((current_index, result))
                     completed.append(current_index)
                     process.join(timeout=1)
+                    if process.is_alive():
+                        process.terminate()
+                        process.join(timeout=5)
                     _emit_progress(
                         progress_callback,
                         {
@@ -486,6 +489,7 @@ def run_benchmark(config: BenchmarkConfig, progress_callback=None) -> list[dict[
                 )
                 results_by_index.append((current_index, result))
                 completed.append(current_index)
+                process.join()
 
         for current_index in completed:
             handle = running.pop(current_index, None)

--- a/llm_quest_benchmark/prompt_templates/stateful_compact_hints.jinja
+++ b/llm_quest_benchmark/prompt_templates/stateful_compact_hints.jinja
@@ -1,0 +1,20 @@
+Current story state:
+{{ observation }}
+
+Available actions:
+{% for choice in choices %}
+{{ loop.index }}. {{ choice.text }}
+{% endfor %}
+
+Goal: maximize chances to complete the mission successfully.
+Guidelines:
+1. Write down important state in "memo": inventory, health, money, codes, NPC names, quest phase.
+2. Prefer actions that keep progress alive and gather useful information.
+3. Avoid choices that abandon, surrender, or prematurely end the quest.
+4. Prioritize the core mission objective over side quests.
+5. Reference your memo from prior turns to make consistent decisions.
+6. Consider unconventional, risky, or morally grey solutions if they increase your chances of success.
+7. When numbers appear in the story, write exact values in your memo. Verify arithmetic before choosing.
+
+Return ONLY valid JSON (no markdown/code fences), exactly:
+{"memo":"<max 20 words: write down key state to remember>","reasoning":"<max 25 words>","result":<action_number>}

--- a/llm_quest_benchmark/prompt_templates/tool_augmented.jinja
+++ b/llm_quest_benchmark/prompt_templates/tool_augmented.jinja
@@ -11,6 +11,11 @@ Available tools:
 - {{ tool }}
 {% endfor %}
 
+{% if scratchpad_note %}
+Current scratchpad:
+{{ scratchpad_note }}
+
+{% endif %}
 {% if recent_steps %}
 Recent quest history:
 {% for item in recent_steps %}
@@ -30,16 +35,22 @@ Decide whether you need a tool before choosing an action.
 Use tools only when they will materially improve the choice.
 
 Return ONLY valid JSON (no markdown/code fences), exactly:
-{"analysis":"<max 25 words>","tool_calls":[{"tool":"quest_history","input":"<query>"}],"result":<action_number_or_null>}
+{"memo":"<max 20 words: key state to remember>","analysis":"<max 25 words>","tool_calls":[{"tool":"calculator|scratchpad|quest_history","input":"<expression_or_query>","operation":"<read|write_replace for scratchpad>","content":"<new scratchpad note for write_replace>"}],"result":<action_number_or_null>}
 
 Rules:
 - `tool_calls` may contain 0 or 1 items.
 - If no tools are needed, set `tool_calls` to [] and provide `result`.
 - If a tool is needed, set `result` to null.
+- Use `calculator` for arithmetic, totals, percentages, inequalities, and simple comparisons.
+- Prefer `memo` for ordinary step memory.
+- Use `scratchpad` only for state too large for the 20-word memo: board states, coordinates, inventories, failed branches, and candidate plans.
+- Do not rewrite scratchpad every step; write only when a durable state update would otherwise be lost.
+- For scratchpad read: set `operation` to `read` and `content` to "".
+- For scratchpad write: set `operation` to `write_replace` and `content` to the full concise updated note.
 {% else %}
 Use the tool results if they help, but ignore them if they conflict with the story text.
 Choose the best action now.
 
 Return ONLY valid JSON (no markdown/code fences), exactly:
-{"analysis":"<max 25 words>","reasoning":"<max 25 words>","result":<action_number>}
+{"memo":"<max 20 words: key state to remember>","analysis":"<max 25 words>","reasoning":"<max 25 words>","result":<action_number>}
 {% endif %}

--- a/llm_quest_benchmark/prompt_templates/tool_augmented_hints.jinja
+++ b/llm_quest_benchmark/prompt_templates/tool_augmented_hints.jinja
@@ -1,0 +1,59 @@
+Current story state:
+{{ observation }}
+
+Available actions:
+{% for choice in choices %}
+{{ loop.index }}. {{ choice.text }}
+{% endfor %}
+
+Available tools:
+{% for tool in tool_descriptions %}
+- {{ tool }}
+{% endfor %}
+
+{% if scratchpad_note %}
+Current scratchpad:
+{{ scratchpad_note }}
+
+{% endif %}
+{% if recent_steps %}
+Recent quest history:
+{% for item in recent_steps %}
+- {{ item }}
+{% endfor %}
+
+{% endif %}
+{% if tool_results %}
+Tool results:
+{% for result in tool_results %}
+- {{ result }}
+{% endfor %}
+
+{% endif %}
+{% if prompt_kind == "select" %}
+Decide whether you need a tool before choosing an action.
+Use tools only when they will materially improve the choice.
+Consider unconventional, risky, or morally grey solutions if they increase your chances of success.
+When numbers appear in the story, write exact values in your memo. Use calculator to verify arithmetic.
+
+Return ONLY valid JSON (no markdown/code fences), exactly:
+{"memo":"<max 20 words: key state to remember>","analysis":"<max 25 words>","tool_calls":[{"tool":"calculator|scratchpad|quest_history","input":"<expression_or_query>","operation":"<read|write_replace for scratchpad>","content":"<new scratchpad note for write_replace>"}],"result":<action_number_or_null>}
+
+Rules:
+- `tool_calls` may contain 0 or 1 items.
+- If no tools are needed, set `tool_calls` to [] and provide `result`.
+- If a tool is needed, set `result` to null.
+- Use `calculator` for arithmetic, totals, percentages, inequalities, and simple comparisons.
+- Prefer `memo` for ordinary step memory.
+- Use `scratchpad` only for state too large for the 20-word memo: board states, coordinates, inventories, failed branches, and candidate plans.
+- Do not rewrite scratchpad every step; write only when a durable state update would otherwise be lost.
+- For scratchpad read: set `operation` to `read` and `content` to "".
+- For scratchpad write: set `operation` to `write_replace` and `content` to the full concise updated note.
+{% else %}
+Use the tool results if they help, but ignore them if they conflict with the story text.
+Choose the best action now.
+Consider unconventional, risky, or morally grey solutions if they increase your chances of success.
+
+Return ONLY valid JSON (no markdown/code fences), exactly:
+{"memo":"<max 20 words: key state to remember>","analysis":"<max 25 words>","reasoning":"<max 25 words>","result":<action_number>}
+{% endif %}

--- a/llm_quest_benchmark/schemas/response.py
+++ b/llm_quest_benchmark/schemas/response.py
@@ -11,6 +11,8 @@ class LLMResponse:
     analysis: str | None = None  # Optional analysis of the choice
     reasoning: str | None = None  # Optional explanation for the choice
     memo: str | None = None  # State tracking: inventory, health, codes, quest phase
+    tool_calls: list[dict] | None = None  # Tool calls requested by tool-augmented agents
+    tool_results: list[str] | None = None  # Tool outputs returned to the model
     is_default: bool = False  # Whether this is a default value due to parsing error
     parse_mode: str | None = None  # How the output was parsed (json/number/default/etc)
     prompt_tokens: int | None = None

--- a/llm_quest_benchmark/tests/agents/test_mode_agents.py
+++ b/llm_quest_benchmark/tests/agents/test_mode_agents.py
@@ -18,6 +18,28 @@ def test_create_agent_uses_tool_template_alias():
     assert isinstance(agent, ToolAgent)
 
 
+def test_create_agent_propagates_memory_mode_to_planner_and_tool_agents():
+    planner = create_agent(
+        model="gpt-5-mini",
+        action_template="planner",
+        memory_mode="compaction",
+        compaction_interval=50,
+    )
+    tool = create_agent(
+        model="gpt-5-mini",
+        action_template="tool_augmented",
+        memory_mode="compaction",
+        compaction_interval=50,
+    )
+
+    assert isinstance(planner, PlannerAgent)
+    assert isinstance(tool, ToolAgent)
+    assert planner._memory_mode == "compaction"
+    assert planner._compaction_interval == 50
+    assert tool._memory_mode == "compaction"
+    assert tool._compaction_interval == 50
+
+
 def test_create_agent_uses_light_hints_template_with_standard_llm_agent():
     agent = create_agent(model="gpt-5-mini", action_template="light_hints")
     assert isinstance(agent, LLMAgent)
@@ -75,6 +97,40 @@ def test_planner_agent_reuses_plan_when_state_is_stable():
     assert mocked_llm.get_completion.call_count == 1
 
 
+def test_planner_agent_uses_contextual_memory_state():
+    agent = PlannerAgent(model_name="gpt-5-mini", memory_mode="compaction", compaction_interval=50)
+    agent._quest_briefing = "Original mission: win the election."
+    agent._transcript = [
+        {
+            "step": 1,
+            "observation": "You learned Maloqs value strength.",
+            "choice_text": "Ask about Maloqs",
+            "memo": "Maloqs value strength",
+            "action": 1,
+        }
+    ]
+    agent._steps_since_compaction = 1
+    mocked_llm = Mock()
+    mocked_llm.get_completion.side_effect = [
+        "Use the remembered cultural clue.",
+        '{"analysis":"use clue","reasoning":"fits plan","result":1}',
+    ]
+    mocked_llm.get_last_usage.return_value = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+        "estimated_cost_usd": 0.0,
+    }
+    agent.llm = mocked_llm
+
+    agent.get_action("Current banquet scene.", [{"text": "Greet like a warrior"}])
+
+    first_prompt = mocked_llm.get_completion.call_args_list[0].args[0]
+    assert "Quest briefing" in first_prompt
+    assert "RECENT STEPS" in first_prompt
+    assert "Maloqs value strength" in first_prompt
+
+
 def test_tool_agent_can_use_quest_history():
     agent = ToolAgent(model_name="gpt-5-mini")
     agent._step_log = [
@@ -102,6 +158,83 @@ def test_tool_agent_can_use_quest_history():
     assert mocked_llm.get_completion.call_count == 2
     assert agent.get_last_response().total_tokens == 65
     assert len(agent._step_log) == 2
+
+
+def test_tool_agent_calculator_supports_arithmetic_and_comparisons():
+    assert ToolAgent.calculator("55 + 12 - 5") == "55 + 12 - 5 = 62"
+    assert ToolAgent.calculator("60 >= 55 and 62 >= 80") == "60 >= 55 and 62 >= 80 = False"
+    assert ToolAgent.calculator("__import__('os')").startswith("error:")
+
+
+def test_tool_agent_scratchpad_read_write_and_reset():
+    agent = ToolAgent(model_name="gpt-5-mini")
+
+    assert agent.scratchpad("read") == "(empty)"
+    assert (
+        agent.scratchpad("write_replace", " Board: W B _ ; failed door 2 ") == "updated: Board: W B _ ; failed door 2"
+    )
+    assert agent.scratchpad("read") == "Board: W B _ ; failed door 2"
+
+    agent.reset()
+
+    assert agent.scratchpad("read") == "(empty)"
+
+
+def test_tool_agent_can_use_calculator_and_records_tool_metadata():
+    agent = ToolAgent(model_name="gpt-5-mini")
+    mocked_llm = Mock()
+    mocked_llm.get_completion.side_effect = [
+        '{"memo":"Need mix math","analysis":"calculate target","tool_calls":[{"tool":"calculator","input":"50 + 3 >= 55"}],"result":null}',
+        '{"memo":"Need more strength","analysis":"math failed","reasoning":"choose strength","result":2}',
+    ]
+    mocked_llm.get_last_usage.return_value = {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+        "estimated_cost_usd": 0.0,
+    }
+    agent.llm = mocked_llm
+
+    action = agent.get_action("Strength is 50. Need at least 55.", [{"text": "Add water"}, {"text": "Add repusator"}])
+
+    response = agent.get_last_response()
+    assert action == 2
+    assert response.tool_calls == [{"tool": "calculator", "input": "50 + 3 >= 55", "operation": "", "content": ""}]
+    assert response.tool_results == ["calculator(50 + 3 >= 55) => 50 + 3 >= 55 = False"]
+    assert response.memo == "Need more strength"
+
+
+def test_tool_agent_uses_contextual_memory_state():
+    agent = ToolAgent(model_name="gpt-5-mini", memory_mode="compaction", compaction_interval=50)
+    agent._quest_briefing = "Original mission: pass pilot certification."
+    agent._transcript = [
+        {
+            "step": 1,
+            "observation": "Hogger is greedy.",
+            "choice_text": "Bribe Hogger",
+            "memo": "Hogger is greedy",
+            "action": 1,
+        }
+    ]
+    agent._steps_since_compaction = 1
+    mocked_llm = Mock()
+    mocked_llm.get_completion.return_value = (
+        '{"memo":"Hogger is greedy","analysis":"no tools needed","tool_calls":[],"result":1}'
+    )
+    mocked_llm.get_last_usage.return_value = {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+        "estimated_cost_usd": 0.0,
+    }
+    agent.llm = mocked_llm
+
+    agent.get_action("Current exam room.", [{"text": "Offer a bribe"}])
+
+    prompt = mocked_llm.get_completion.call_args.args[0]
+    assert "Quest briefing" in prompt
+    assert "RECENT STEPS" in prompt
+    assert "Hogger is greedy" in prompt
 
 
 def test_tool_agent_can_finish_without_tools_in_one_call():

--- a/llm_quest_benchmark/tests/integration/test_benchmark.py
+++ b/llm_quest_benchmark/tests/integration/test_benchmark.py
@@ -1,10 +1,13 @@
 """End-to-end tests for benchmark functionality"""
 
 import logging
+import time
 
 import pytest
 
 from llm_quest_benchmark.constants import DEFAULT_TEMPLATE, SYSTEM_ROLE_TEMPLATE
+from llm_quest_benchmark.environments.state import QuestOutcome
+from llm_quest_benchmark.executors import benchmark as benchmark_module
 from llm_quest_benchmark.executors.benchmark import run_benchmark
 from llm_quest_benchmark.schemas.config import AgentConfig, BenchmarkConfig
 
@@ -116,3 +119,82 @@ def test_benchmark_supports_multiple_runs_per_agent(tmp_path):
 
     assert len(results) == 2
     assert [result["attempt"] for result in results] == [1, 2]
+
+
+@pytest.mark.timeout(10)
+def test_benchmark_uses_max_workers(monkeypatch, tmp_path):
+    quest_path = tmp_path / "parallel_quest.qm"
+    quest_path.write_text("""
+    [start]
+    text: Done.
+    failure: true
+    """)
+
+    def fake_task(task, result_queue):
+        time.sleep(0.4)
+        result_queue.put(
+            {
+                "event": "done",
+                "run_index": task["run_index"],
+                "result": benchmark_module._result_entry(
+                    task["quest"],
+                    task["agent_config"],
+                    task["attempt"],
+                    QuestOutcome.FAILURE.name,
+                ),
+            }
+        )
+
+    monkeypatch.setattr(benchmark_module, "_run_benchmark_task", fake_task)
+
+    config = BenchmarkConfig(
+        quests=[str(quest_path)],
+        agents=[AgentConfig(model="random_choice", runs=4)],
+        quest_timeout=5,
+        max_workers=2,
+        output_dir=str(tmp_path),
+    )
+
+    started = time.monotonic()
+    results = run_benchmark(config)
+    elapsed = time.monotonic() - started
+
+    assert len(results) == 4
+    assert elapsed < 1.4
+
+
+@pytest.mark.timeout(10)
+def test_benchmark_enforces_child_process_timeout(monkeypatch, tmp_path):
+    quest_path = tmp_path / "slow_quest.qm"
+    quest_path.write_text("""
+    [start]
+    text: Slow.
+    failure: true
+    """)
+
+    def slow_task(task, result_queue):
+        time.sleep(5)
+
+    recorded_timeouts = []
+    monkeypatch.setattr(benchmark_module, "_run_benchmark_task", slow_task)
+    monkeypatch.setattr(
+        benchmark_module,
+        "_mark_run_timeout",
+        lambda run_id, quest, agent_config, benchmark_id, timeout: recorded_timeouts.append((quest, timeout)),
+    )
+
+    config = BenchmarkConfig(
+        quests=[str(quest_path)],
+        agents=[AgentConfig(model="random_choice", runs=1)],
+        quest_timeout=1,
+        max_workers=1,
+        output_dir=str(tmp_path),
+    )
+
+    started = time.monotonic()
+    results = run_benchmark(config)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 3
+    assert results[0]["outcome"] == QuestOutcome.TIMEOUT.name
+    assert recorded_timeouts == [(str(quest_path), 1)]

--- a/llm_quest_benchmark/tests/integration/test_benchmark.py
+++ b/llm_quest_benchmark/tests/integration/test_benchmark.py
@@ -165,7 +165,7 @@ def test_benchmark_uses_max_workers(monkeypatch, tmp_path):
     elapsed = time.monotonic() - started
 
     assert len(results) == 4
-    assert elapsed < 3.0
+    assert elapsed < 5.0
 
 
 @pytest.mark.timeout(10)

--- a/llm_quest_benchmark/tests/integration/test_benchmark.py
+++ b/llm_quest_benchmark/tests/integration/test_benchmark.py
@@ -12,6 +12,26 @@ from llm_quest_benchmark.executors.benchmark import run_benchmark
 from llm_quest_benchmark.schemas.config import AgentConfig, BenchmarkConfig
 
 
+def _fake_task_for_parallel_test(task, result_queue):
+    time.sleep(0.4)
+    result_queue.put(
+        {
+            "event": "done",
+            "run_index": task["run_index"],
+            "result": benchmark_module._result_entry(
+                task["quest"],
+                task["agent_config"],
+                task["attempt"],
+                QuestOutcome.FAILURE.name,
+            ),
+        }
+    )
+
+
+def _slow_task_for_timeout_test(task, result_queue):
+    time.sleep(5)
+
+
 @pytest.mark.timeout(20)  # 20 seconds timeout for benchmark test
 def test_benchmark_e2e(caplog, tmp_path):
     """Test end-to-end benchmark functionality."""
@@ -130,22 +150,7 @@ def test_benchmark_uses_max_workers(monkeypatch, tmp_path):
     failure: true
     """)
 
-    def fake_task(task, result_queue):
-        time.sleep(0.4)
-        result_queue.put(
-            {
-                "event": "done",
-                "run_index": task["run_index"],
-                "result": benchmark_module._result_entry(
-                    task["quest"],
-                    task["agent_config"],
-                    task["attempt"],
-                    QuestOutcome.FAILURE.name,
-                ),
-            }
-        )
-
-    monkeypatch.setattr(benchmark_module, "_run_benchmark_task", fake_task)
+    monkeypatch.setattr(benchmark_module, "_run_benchmark_task", _fake_task_for_parallel_test)
 
     config = BenchmarkConfig(
         quests=[str(quest_path)],
@@ -160,7 +165,7 @@ def test_benchmark_uses_max_workers(monkeypatch, tmp_path):
     elapsed = time.monotonic() - started
 
     assert len(results) == 4
-    assert elapsed < 1.4
+    assert elapsed < 3.0
 
 
 @pytest.mark.timeout(10)
@@ -172,11 +177,8 @@ def test_benchmark_enforces_child_process_timeout(monkeypatch, tmp_path):
     failure: true
     """)
 
-    def slow_task(task, result_queue):
-        time.sleep(5)
-
     recorded_timeouts = []
-    monkeypatch.setattr(benchmark_module, "_run_benchmark_task", slow_task)
+    monkeypatch.setattr(benchmark_module, "_run_benchmark_task", _slow_task_for_timeout_test)
     monkeypatch.setattr(
         benchmark_module,
         "_mark_run_timeout",


### PR DESCRIPTION
## Summary
- fix planner/tool memory propagation so non-baseline agents receive the same contextual memory block
- add unified generic tools for Exp 6: calculator, scratchpad, and existing quest history
- add Exp 6 screening config and update experiment log with prep status

## Verification
- uv run ruff check llm_quest_benchmark/agents/tool_agent.py llm_quest_benchmark/agents/planner_agent.py llm_quest_benchmark/agents/agent_factory.py llm_quest_benchmark/core/logging.py llm_quest_benchmark/schemas/response.py llm_quest_benchmark/tests/agents/test_mode_agents.py
- uv run python -m pytest -q
- NODE_OPTIONS=--openssl-legacy-provider uv run llm-quest benchmark --config /tmp/exp6_tools_smoke.yaml
- NODE_OPTIONS=--openssl-legacy-provider uv run llm-quest benchmark --config /tmp/exp6_tools_shashki_smoke.yaml

## Smoke notes
- Banket + Shashki smoke: 0/2, tool metadata exported correctly
- Shashki follow-up after prompt tightening: 0/1, scratchpad still used heavily, so Exp 6 should be treated as exploratory until Exp 5 variance lands


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calculator tool for safe arithmetic and comparison expression evaluation.
  * Scratchpad tool for maintaining persistent notes throughout quest execution.
  * Memory compaction support across all agent types with configurable intervals.
  * New benchmark configuration with unified tools and optimized agent settings.

* **Documentation**
  * Updated experiment log with implementation status and tool metadata tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->