### PR TITLE
fix: share EN data on RU quest cards

### DIFF
--- a/llm_quest_benchmark/tests/test_play_quest_index.py
+++ b/llm_quest_benchmark/tests/test_play_quest_index.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QUEST_INDEX_PATH = REPO_ROOT / "site" / "play" / "quest-index.json"
+
+
+def test_ru_quests_share_canonical_en_card_data():
+    index = json.loads(QUEST_INDEX_PATH.read_text(encoding="utf-8"))
+    quests = {quest["id"]: quest for quest in index["quests"]}
+
+    ru_quests = [quest for quest in quests.values() if quest.get("lang") == "ru"]
+    assert ru_quests
+
+    for ru_quest in ru_quests:
+        canonical_id = ru_quest.get("canonical_id")
+        assert canonical_id, f"{ru_quest['id']} should point at canonical EN data"
+        assert canonical_id in quests, f"{ru_quest['id']} points at missing {canonical_id}"
+
+        en_quest = quests[canonical_id]
+        assert ru_quest["win_rate"] == en_quest["win_rate"], ru_quest["id"]
+        assert ru_quest["total_runs"] == en_quest["total_runs"], ru_quest["id"]

--- a/scripts/build_cohort_data.py
+++ b/scripts/build_cohort_data.py
@@ -434,7 +434,6 @@ def main() -> None:
                     **quest_entry,
                     "id": ru_quest_id,
                     "lang": "ru",
-                    "canonical_id": quest_name,
                 }
             )
 

--- a/scripts/build_cohort_data.py
+++ b/scripts/build_cohort_data.py
@@ -16,6 +16,8 @@ from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 
+from llm_quest_benchmark.core.quest_lang import EN_TO_RU_QUEST_MAP
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DB_PATH = REPO_ROOT / "metrics.db"
 OUT_DIR = REPO_ROOT / "site" / "play"
@@ -400,7 +402,9 @@ def main() -> None:
     finally:
         conn.close()
 
-    # Build quest-index.json from generated cohort files
+    # Build quest-index.json from generated cohort files. RU quest cards reuse
+    # canonical EN metrics so the language toggle presents the same recorded AI
+    # data end to end while loading localized quest text.
     print("\nBuilding quest-index.json...")
     index_quests = []
     for quest_name in TARGET_QUESTS:
@@ -410,17 +414,29 @@ def main() -> None:
             continue
         cohort = json.loads(cohort_path.read_text(encoding="utf-8"))
         meta = QUEST_METADATA.get(quest_name, {})
-        index_quests.append(
-            {
-                "id": quest_name,
-                "title": meta.get("title", quest_name),
-                "difficulty": meta.get("difficulty", "unknown"),
-                "description": meta.get("description", ""),
-                "stepsRange": meta.get("stepsRange", ""),
-                "win_rate": cohort.get("win_rate", 0.0),
-                "total_runs": cohort.get("total_runs", 0),
-            }
-        )
+        quest_entry = {
+            "id": quest_name,
+            "lang": "en",
+            "canonical_id": quest_name,
+            "title": meta.get("title", quest_name),
+            "difficulty": meta.get("difficulty", "unknown"),
+            "description": meta.get("description", ""),
+            "stepsRange": meta.get("stepsRange", ""),
+            "win_rate": cohort.get("win_rate", 0.0),
+            "total_runs": cohort.get("total_runs", 0),
+        }
+        index_quests.append(quest_entry)
+
+        ru_quest_id = EN_TO_RU_QUEST_MAP.get(quest_name)
+        if ru_quest_id:
+            index_quests.append(
+                {
+                    **quest_entry,
+                    "id": ru_quest_id,
+                    "lang": "ru",
+                    "canonical_id": quest_name,
+                }
+            )
 
     index_path = OUT_DIR / "quest-index.json"
     index_path.write_text(

--- a/site/play/app.js
+++ b/site/play/app.js
@@ -401,6 +401,7 @@ function QuestPlay({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [player, setPlayer] = useState(null);
+  const [canonicalPlayer, setCanonicalPlayer] = useState(null);
   const [gameState, setGameState] = useState(null);
   const [stepHistory, setStepHistory] = useState([]);
   const [stepNum, setStepNum] = useState(0);
@@ -418,7 +419,16 @@ function QuestPlay({
       const qm = QMEngine.parse(Buffer.from(ungzipped));
       const p = new QMEngine.QMPlayer(qm, questEngineLang(quest));
       p.start();
+      return loadCanonicalPlayer(quest, p, controller.signal).then(canonical => ({
+        p,
+        canonical
+      }));
+    }).then(({
+      p,
+      canonical
+    }) => {
       setPlayer(p);
+      setCanonicalPlayer(canonical);
       setGameState(p.getState());
       setStepNum(1);
       setLoading(false);
@@ -447,9 +457,15 @@ function QuestPlay({
     });
     return bestKey;
   }
+  function canonicalChoiceNorm(choice) {
+    if (!canonicalPlayer) return normalizeChoice(choice.text);
+    const canonicalState = canonicalPlayer.getState();
+    const canonicalChoice = (canonicalState.choices || []).find(c => c.jumpId === choice.jumpId);
+    return normalizeChoice(canonicalChoice && canonicalChoice.text || choice.text);
+  }
   function handleChoice(choice, activeChoices) {
     const locationId = player.getSaving().locationId;
-    const choiceNorm = normalizeChoice(choice.text);
+    const choiceNorm = canonicalChoiceNorm(choice);
     const cohortLoc = getCohortLoc(locationId);
     const isBranching = activeChoices.length >= 2;
     const majority = isBranching && cohortLoc ? getMajorityChoice(cohortLoc) : null;
@@ -461,8 +477,12 @@ function QuestPlay({
       cohortLoc: isBranching ? cohortLoc : null,
       playerChoiceNorm: isBranching ? choiceNorm : null
     }]);
-    setStepHistory(prev => [...prev, player.getSaving()]);
+    setStepHistory(prev => [...prev, {
+      player: player.getSaving(),
+      canonicalPlayer: canonicalPlayer ? canonicalPlayer.getSaving() : null
+    }]);
     player.performJump(choice.jumpId);
+    if (canonicalPlayer) canonicalPlayer.performJump(choice.jumpId);
     const nextState = player.getState();
     const gs = nextState.gameState;
     const isTerminal = gs === 'win' || gs === 'fail' || gs === 'dead';
@@ -477,7 +497,10 @@ function QuestPlay({
   function handleBack() {
     if (stepHistory.length === 0) return;
     const prevSaving = stepHistory[stepHistory.length - 1];
-    player.loadSaving(prevSaving);
+    player.loadSaving(prevSaving.player || prevSaving);
+    if (canonicalPlayer && prevSaving.canonicalPlayer) {
+      canonicalPlayer.loadSaving(prevSaving.canonicalPlayer);
+    }
     setStepHistory(prev => prev.slice(0, -1));
     setGameState(player.getState());
     setStepNum(n => Math.max(1, n - 1));
@@ -520,6 +543,7 @@ function QuestPlay({
       path: path,
       onPlayAgain: () => {
         player.start();
+        if (canonicalPlayer) canonicalPlayer.loadSaving(player.getSaving());
         setGameState(player.getState());
         setStepNum(1);
         setPath([]);
@@ -595,6 +619,21 @@ function QuestPlay({
 
 function questEngineLang(quest) {
   return quest.lang === 'ru' ? 'rus' : 'eng';
+}
+function loadCanonicalPlayer(quest, player, signal) {
+  if (!quest.canonical_id || quest.canonical_id === quest.id) {
+    return Promise.resolve(null);
+  }
+  return fetch('play/quests/' + quest.canonical_id + '.qm.gz', {
+    signal
+  }).then(r => r.ok ? r.arrayBuffer() : null).then(buf => {
+    if (!buf) return null;
+    const ungzipped = pako.ungzip(new Uint8Array(buf));
+    const qm = QMEngine.parse(Buffer.from(ungzipped));
+    const canonical = new QMEngine.QMPlayer(qm, 'eng');
+    canonical.loadSaving(player.getSaving());
+    return canonical;
+  }).catch(() => null);
 }
 
 // ---- QuestSelect ----

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -314,6 +314,7 @@ function QuestPlay({ quest, cohortData, onQuit }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [player, setPlayer] = useState(null);
+  const [canonicalPlayer, setCanonicalPlayer] = useState(null);
   const [gameState, setGameState] = useState(null);
   const [stepHistory, setStepHistory] = useState([]);
   const [stepNum, setStepNum] = useState(0);
@@ -332,7 +333,11 @@ function QuestPlay({ quest, cohortData, onQuit }) {
         const qm = QMEngine.parse(Buffer.from(ungzipped));
         const p = new QMEngine.QMPlayer(qm, questEngineLang(quest));
         p.start();
+        return loadCanonicalPlayer(quest, p, controller.signal).then(canonical => ({ p, canonical }));
+      })
+      .then(({ p, canonical }) => {
         setPlayer(p);
+        setCanonicalPlayer(canonical);
         setGameState(p.getState());
         setStepNum(1);
         setLoading(false);
@@ -362,9 +367,16 @@ function QuestPlay({ quest, cohortData, onQuit }) {
     return bestKey;
   }
 
+  function canonicalChoiceNorm(choice) {
+    if (!canonicalPlayer) return normalizeChoice(choice.text);
+    const canonicalState = canonicalPlayer.getState();
+    const canonicalChoice = (canonicalState.choices || []).find(c => c.jumpId === choice.jumpId);
+    return normalizeChoice((canonicalChoice && canonicalChoice.text) || choice.text);
+  }
+
   function handleChoice(choice, activeChoices) {
     const locationId = player.getSaving().locationId;
-    const choiceNorm = normalizeChoice(choice.text);
+    const choiceNorm = canonicalChoiceNorm(choice);
     const cohortLoc = getCohortLoc(locationId);
     const isBranching = activeChoices.length >= 2;
     const majority = (isBranching && cohortLoc) ? getMajorityChoice(cohortLoc) : null;
@@ -378,8 +390,12 @@ function QuestPlay({ quest, cohortData, onQuit }) {
       playerChoiceNorm: isBranching ? choiceNorm : null,
     }]);
 
-    setStepHistory(prev => [...prev, player.getSaving()]);
+    setStepHistory(prev => [...prev, {
+      player: player.getSaving(),
+      canonicalPlayer: canonicalPlayer ? canonicalPlayer.getSaving() : null,
+    }]);
     player.performJump(choice.jumpId);
+    if (canonicalPlayer) canonicalPlayer.performJump(choice.jumpId);
 
     const nextState = player.getState();
     const gs = nextState.gameState;
@@ -397,7 +413,10 @@ function QuestPlay({ quest, cohortData, onQuit }) {
   function handleBack() {
     if (stepHistory.length === 0) return;
     const prevSaving = stepHistory[stepHistory.length - 1];
-    player.loadSaving(prevSaving);
+    player.loadSaving(prevSaving.player || prevSaving);
+    if (canonicalPlayer && prevSaving.canonicalPlayer) {
+      canonicalPlayer.loadSaving(prevSaving.canonicalPlayer);
+    }
     setStepHistory(prev => prev.slice(0, -1));
     setGameState(player.getState());
     setStepNum(n => Math.max(1, n - 1));
@@ -432,6 +451,7 @@ function QuestPlay({ quest, cohortData, onQuit }) {
         path={path}
         onPlayAgain={() => {
           player.start();
+          if (canonicalPlayer) canonicalPlayer.loadSaving(player.getSaving());
           setGameState(player.getState());
           setStepNum(1);
           setPath([]);
@@ -497,6 +517,23 @@ function QuestPlay({ quest, cohortData, onQuit }) {
 
 function questEngineLang(quest) {
   return (quest.lang === 'ru') ? 'rus' : 'eng';
+}
+
+function loadCanonicalPlayer(quest, player, signal) {
+  if (!quest.canonical_id || quest.canonical_id === quest.id) {
+    return Promise.resolve(null);
+  }
+  return fetch('play/quests/' + quest.canonical_id + '.qm.gz', { signal })
+    .then(r => r.ok ? r.arrayBuffer() : null)
+    .then(buf => {
+      if (!buf) return null;
+      const ungzipped = pako.ungzip(new Uint8Array(buf));
+      const qm = QMEngine.parse(Buffer.from(ungzipped));
+      const canonical = new QMEngine.QMPlayer(qm, 'eng');
+      canonical.loadSaving(player.getSaving());
+      return canonical;
+    })
+    .catch(() => null);
 }
 
 // ---- QuestSelect ----

--- a/site/play/quest-index.json
+++ b/site/play/quest-index.json
@@ -12,8 +12,30 @@
       "total_runs": 272
     },
     {
+      "id": "Banket_ru",
+      "lang": "ru",
+      "canonical_id": "Banket_eng",
+      "title": "Banquet",
+      "difficulty": "medium",
+      "description": "Navigate the politics of an interstellar banquet.",
+      "stepsRange": "15-25",
+      "win_rate": 0.0,
+      "total_runs": 272
+    },
+    {
       "id": "Badday_eng",
       "lang": "en",
+      "canonical_id": "Badday_eng",
+      "title": "Bad Day",
+      "difficulty": "hard",
+      "description": "Survive a day when everything goes wrong.",
+      "stepsRange": "20-40",
+      "win_rate": 0.2175,
+      "total_runs": 285
+    },
+    {
+      "id": "Badday_ru",
+      "lang": "ru",
       "canonical_id": "Badday_eng",
       "title": "Bad Day",
       "difficulty": "hard",
@@ -34,8 +56,30 @@
       "total_runs": 297
     },
     {
+      "id": "Pizza_ru",
+      "lang": "ru",
+      "canonical_id": "Pizza_eng",
+      "title": "Pizza Delivery",
+      "difficulty": "medium",
+      "description": "Deliver a pizza across a hostile space station.",
+      "stepsRange": "15-30",
+      "win_rate": 0.1717,
+      "total_runs": 297
+    },
+    {
       "id": "Borzukhan_eng",
       "lang": "en",
+      "canonical_id": "Borzukhan_eng",
+      "title": "Borzukhan",
+      "difficulty": "hard",
+      "description": "Infiltrate a fortified enemy base.",
+      "stepsRange": "20-40",
+      "win_rate": 0.1667,
+      "total_runs": 6
+    },
+    {
+      "id": "Borzukhan_ru",
+      "lang": "ru",
       "canonical_id": "Borzukhan_eng",
       "title": "Borzukhan",
       "difficulty": "hard",
@@ -56,8 +100,30 @@
       "total_runs": 293
     },
     {
+      "id": "Ski_ru",
+      "lang": "ru",
+      "canonical_id": "Ski_eng",
+      "title": "Ski Resort",
+      "difficulty": "medium",
+      "description": "Manage a ski resort on an alien planet.",
+      "stepsRange": "15-25",
+      "win_rate": 0.0751,
+      "total_runs": 293
+    },
+    {
       "id": "Election_eng",
       "lang": "en",
+      "canonical_id": "Election_eng",
+      "title": "Election",
+      "difficulty": "hard",
+      "description": "Win a planetary election campaign.",
+      "stepsRange": "25-50",
+      "win_rate": 0.042,
+      "total_runs": 286
+    },
+    {
+      "id": "Election_ru",
+      "lang": "ru",
       "canonical_id": "Election_eng",
       "title": "Election",
       "difficulty": "hard",
@@ -78,8 +144,30 @@
       "total_runs": 284
     },
     {
+      "id": "Robots_ru",
+      "lang": "ru",
+      "canonical_id": "Robots_eng",
+      "title": "Robots",
+      "difficulty": "hard",
+      "description": "Survive a robot uprising on a space station.",
+      "stepsRange": "20-40",
+      "win_rate": 0.0106,
+      "total_runs": 284
+    },
+    {
       "id": "Leonardo_eng",
       "lang": "en",
+      "canonical_id": "Leonardo_eng",
+      "title": "Leonardo",
+      "difficulty": "hard",
+      "description": "Solve mysteries in a Renaissance-themed quest.",
+      "stepsRange": "20-40",
+      "win_rate": 0.0251,
+      "total_runs": 279
+    },
+    {
+      "id": "Leonardo_ru",
+      "lang": "ru",
       "canonical_id": "Leonardo_eng",
       "title": "Leonardo",
       "difficulty": "hard",
@@ -100,8 +188,30 @@
       "total_runs": 271
     },
     {
+      "id": "Depth_ru",
+      "lang": "ru",
+      "canonical_id": "Depth_eng",
+      "title": "Depth",
+      "difficulty": "medium",
+      "description": "Explore the depths of an underwater facility.",
+      "stepsRange": "15-30",
+      "win_rate": 0.0,
+      "total_runs": 271
+    },
+    {
       "id": "Edelweiss_eng",
       "lang": "en",
+      "canonical_id": "Edelweiss_eng",
+      "title": "Edelweiss",
+      "difficulty": "medium",
+      "description": "Navigate a mountain expedition gone wrong.",
+      "stepsRange": "15-30",
+      "win_rate": 0.0,
+      "total_runs": 271
+    },
+    {
+      "id": "Edelweiss_ru",
+      "lang": "ru",
       "canonical_id": "Edelweiss_eng",
       "title": "Edelweiss",
       "difficulty": "medium",
@@ -122,8 +232,30 @@
       "total_runs": 269
     },
     {
+      "id": "Ministry_ru",
+      "lang": "ru",
+      "canonical_id": "Ministry_eng",
+      "title": "Ministry",
+      "difficulty": "hard",
+      "description": "Navigate bureaucratic intrigue at a space ministry.",
+      "stepsRange": "20-35",
+      "win_rate": 0.0037,
+      "total_runs": 269
+    },
+    {
       "id": "Foncers_eng",
       "lang": "en",
+      "canonical_id": "Foncers_eng",
+      "title": "Foncers",
+      "difficulty": "medium",
+      "description": "Compete in an underground racing league.",
+      "stepsRange": "10-20",
+      "win_rate": 0.0,
+      "total_runs": 269
+    },
+    {
+      "id": "Foncers_ru",
+      "lang": "ru",
       "canonical_id": "Foncers_eng",
       "title": "Foncers",
       "difficulty": "medium",
@@ -144,6 +276,17 @@
       "total_runs": 265
     },
     {
+      "id": "Driver_ru",
+      "lang": "ru",
+      "canonical_id": "Driver_eng",
+      "title": "Driver",
+      "difficulty": "hard",
+      "description": "Complete a dangerous cargo delivery run.",
+      "stepsRange": "25-50",
+      "win_rate": 0.0,
+      "total_runs": 265
+    },
+    {
       "id": "Codebox_eng",
       "lang": "en",
       "canonical_id": "Codebox_eng",
@@ -155,8 +298,30 @@
       "total_runs": 265
     },
     {
+      "id": "Codebox_ru",
+      "lang": "ru",
+      "canonical_id": "Codebox_eng",
+      "title": "Code Box",
+      "difficulty": "easy",
+      "description": "Crack codes and solve puzzles.",
+      "stepsRange": "5-15",
+      "win_rate": 0.0,
+      "total_runs": 265
+    },
+    {
       "id": "Pilot_eng",
       "lang": "en",
+      "canonical_id": "Pilot_eng",
+      "title": "Pilot",
+      "difficulty": "medium",
+      "description": "Pass the pilot certification exam.",
+      "stepsRange": "10-20",
+      "win_rate": 0.0899,
+      "total_runs": 89
+    },
+    {
+      "id": "Pilot_ru",
+      "lang": "ru",
       "canonical_id": "Pilot_eng",
       "title": "Pilot",
       "difficulty": "medium",
@@ -188,8 +353,30 @@
       "total_runs": 71
     },
     {
+      "id": "Sortirovka1_ru",
+      "lang": "ru",
+      "canonical_id": "Sortirovka1_eng",
+      "title": "Sorting",
+      "difficulty": "easy",
+      "description": "Sort items in a warehouse puzzle.",
+      "stepsRange": "5-10",
+      "win_rate": 0.0282,
+      "total_runs": 71
+    },
+    {
       "id": "Shashki_eng",
       "lang": "en",
+      "canonical_id": "Shashki_eng",
+      "title": "Checkers",
+      "difficulty": "easy",
+      "description": "Play a game of space checkers.",
+      "stepsRange": "5-10",
+      "win_rate": 0.0435,
+      "total_runs": 69
+    },
+    {
+      "id": "Shashki_ru",
+      "lang": "ru",
       "canonical_id": "Shashki_eng",
       "title": "Checkers",
       "difficulty": "easy",
@@ -210,193 +397,6 @@
       "total_runs": 69
     },
     {
-      "id": "Banket_ru",
-      "lang": "ru",
-      "canonical_id": "Banket_eng",
-      "title": "Banquet",
-      "difficulty": "medium",
-      "description": "Navigate the politics of an interstellar banquet.",
-      "stepsRange": "15-25",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Badday_ru",
-      "lang": "ru",
-      "canonical_id": "Badday_eng",
-      "title": "Bad Day",
-      "difficulty": "hard",
-      "description": "Survive a day when everything goes wrong.",
-      "stepsRange": "20-40",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Pizza_ru",
-      "lang": "ru",
-      "canonical_id": "Pizza_eng",
-      "title": "Pizza Delivery",
-      "difficulty": "medium",
-      "description": "Deliver a pizza across a hostile space station.",
-      "stepsRange": "15-30",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Borzukhan_ru",
-      "lang": "ru",
-      "canonical_id": "Borzukhan_eng",
-      "title": "Borzukhan",
-      "difficulty": "hard",
-      "description": "Infiltrate a fortified enemy base.",
-      "stepsRange": "20-40",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Ski_ru",
-      "lang": "ru",
-      "canonical_id": "Ski_eng",
-      "title": "Ski Resort",
-      "difficulty": "medium",
-      "description": "Manage a ski resort on an alien planet.",
-      "stepsRange": "15-25",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Election_ru",
-      "lang": "ru",
-      "canonical_id": "Election_eng",
-      "title": "Election",
-      "difficulty": "hard",
-      "description": "Win a planetary election campaign.",
-      "stepsRange": "25-50",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Robots_ru",
-      "lang": "ru",
-      "canonical_id": "Robots_eng",
-      "title": "Robots",
-      "difficulty": "hard",
-      "description": "Survive a robot uprising on a space station.",
-      "stepsRange": "20-40",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Leonardo_ru",
-      "lang": "ru",
-      "canonical_id": "Leonardo_eng",
-      "title": "Leonardo",
-      "difficulty": "hard",
-      "description": "Solve mysteries in a Renaissance-themed quest.",
-      "stepsRange": "20-40",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Depth_ru",
-      "lang": "ru",
-      "canonical_id": "Depth_eng",
-      "title": "Depth",
-      "difficulty": "medium",
-      "description": "Explore the depths of an underwater facility.",
-      "stepsRange": "15-30",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Edelweiss_ru",
-      "lang": "ru",
-      "canonical_id": "Edelweiss_eng",
-      "title": "Edelweiss",
-      "difficulty": "medium",
-      "description": "Navigate a mountain expedition gone wrong.",
-      "stepsRange": "15-30",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Ministry_ru",
-      "lang": "ru",
-      "canonical_id": "Ministry_eng",
-      "title": "Ministry",
-      "difficulty": "hard",
-      "description": "Navigate bureaucratic intrigue at a space ministry.",
-      "stepsRange": "20-35",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Foncers_ru",
-      "lang": "ru",
-      "canonical_id": "Foncers_eng",
-      "title": "Foncers",
-      "difficulty": "medium",
-      "description": "Compete in an underground racing league.",
-      "stepsRange": "10-20",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Driver_ru",
-      "lang": "ru",
-      "canonical_id": "Driver_eng",
-      "title": "Driver",
-      "difficulty": "hard",
-      "description": "Complete a dangerous cargo delivery run.",
-      "stepsRange": "25-50",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Codebox_ru",
-      "lang": "ru",
-      "canonical_id": "Codebox_eng",
-      "title": "Code Box",
-      "difficulty": "easy",
-      "description": "Crack codes and solve puzzles.",
-      "stepsRange": "5-15",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Pilot_ru",
-      "lang": "ru",
-      "canonical_id": "Pilot_eng",
-      "title": "Pilot",
-      "difficulty": "medium",
-      "description": "Pass the pilot certification exam.",
-      "stepsRange": "10-20",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Sortirovka1_ru",
-      "lang": "ru",
-      "canonical_id": "Sortirovka1_eng",
-      "title": "Sorting",
-      "difficulty": "easy",
-      "description": "Sort items in a warehouse puzzle.",
-      "stepsRange": "5-10",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
-      "id": "Shashki_ru",
-      "lang": "ru",
-      "canonical_id": "Shashki_eng",
-      "title": "Checkers",
-      "difficulty": "easy",
-      "description": "Play a game of space checkers.",
-      "stepsRange": "5-10",
-      "win_rate": null,
-      "total_runs": 0
-    },
-    {
       "id": "Player_ru",
       "lang": "ru",
       "canonical_id": "Player_eng",
@@ -404,8 +404,8 @@
       "difficulty": "easy",
       "description": "A simple introductory quest.",
       "stepsRange": "5-10",
-      "win_rate": null,
-      "total_runs": 0
+      "win_rate": 0.0,
+      "total_runs": 69
     }
   ]
 }


### PR DESCRIPTION
## Summary
- make RU quest cards reuse canonical EN `win_rate` and `total_runs`
- update cohort data generator so regenerated `quest-index.json` keeps RU cards mapped to EN recorded data
- add regression test that every RU quest shares its canonical EN card data

## Tests
- `uv run ruff check .`
- `uv run pytest llm_quest_benchmark/tests/test_play_quest_index.py llm_quest_benchmark/tests/test_quest_lang.py -q`
