### PR TITLE
Sort quests by AI win rate, replace difficulty badges

### DIFF
--- a/site/play/app.js
+++ b/site/play/app.js
@@ -174,25 +174,13 @@ function normalizeChoice(text) {
 function stripClr(s) {
   return String(s == null ? '' : s).replace(/<clr>|<clrEnd>|<\/clr>/g, '');
 }
-function diffColor(diff) {
-  if (diff === 'easy') return 'var(--green)';
-  if (diff === 'medium') return 'var(--orange)';
+function winRateColor(rate) {
+  if (rate > 0.15) return 'var(--green)';
+  if (rate > 0) return 'var(--orange)';
   return 'var(--red)';
 }
-function diffLabel(diff) {
-  return diff.charAt(0).toUpperCase() + diff.slice(1);
-}
 function sortQuests(quests) {
-  const order = {
-    easy: 0,
-    medium: 1,
-    hard: 2
-  };
-  return [...quests].sort((a, b) => {
-    const da = order[a.difficulty] ?? 3;
-    const db = order[b.difficulty] ?? 3;
-    return da !== db ? da - db : a.title.localeCompare(b.title);
-  });
+  return [...quests].sort((a, b) => (b.win_rate || 0) - (a.win_rate || 0));
 }
 const PLAY_URL = 'https://yourconscience.github.io/llm_quest_benchmark/play.html';
 const SHARE_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';
@@ -914,12 +902,17 @@ function QuestSelect({
     style: {
       margin: 0
     }
-  }, q.title), /*#__PURE__*/React.createElement("span", {
+  }, q.title), q.win_rate != null ? /*#__PURE__*/React.createElement("span", {
     className: "diff-badge",
     style: {
-      color: diffColor(q.difficulty)
+      color: winRateColor(q.win_rate)
     }
-  }, diffLabel(q.difficulty))), /*#__PURE__*/React.createElement("p", {
+  }, Math.round(q.win_rate * 100), "%") : /*#__PURE__*/React.createElement("span", {
+    className: "diff-badge",
+    style: {
+      color: 'var(--muted)'
+    }
+  }, "--")), /*#__PURE__*/React.createElement("p", {
     style: {
       color: 'var(--muted)',
       fontSize: '0.88rem',
@@ -930,21 +923,9 @@ function QuestSelect({
     style: {
       fontSize: '0.82rem',
       color: 'var(--muted)',
-      marginBottom: '0.25rem'
-    }
-  }, "~", q.stepsRange, " steps"), q.win_rate != null ? /*#__PURE__*/React.createElement("div", {
-    style: {
-      fontSize: '0.82rem',
-      color: 'var(--muted)',
       marginBottom: '0.75rem'
     }
-  }, "AI win rate: ", Math.round((q.win_rate || 0) * 100), "%") : /*#__PURE__*/React.createElement("div", {
-    style: {
-      fontSize: '0.82rem',
-      color: 'var(--muted)',
-      marginBottom: '0.75rem'
-    }
-  }, "No AI data yet"), /*#__PURE__*/React.createElement("button", {
+  }, "~", q.stepsRange, " steps"), /*#__PURE__*/React.createElement("button", {
     className: "btn btn-sm btn-outline-primary",
     style: {
       marginTop: 'auto'

--- a/site/play/app.js
+++ b/site/play/app.js
@@ -180,7 +180,10 @@ function winRateColor(rate) {
   return 'var(--red)';
 }
 function sortQuests(quests) {
-  return [...quests].sort((a, b) => (b.win_rate || 0) - (a.win_rate || 0));
+  return [...quests].sort((a, b) => {
+    const diff = (b.win_rate || 0) - (a.win_rate || 0);
+    return diff !== 0 ? diff : a.title.localeCompare(b.title);
+  });
 }
 const PLAY_URL = 'https://yourconscience.github.io/llm_quest_benchmark/play.html';
 const SHARE_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -145,7 +145,10 @@ function winRateColor(rate) {
 }
 
 function sortQuests(quests) {
-  return [...quests].sort((a, b) => (b.win_rate || 0) - (a.win_rate || 0));
+  return [...quests].sort((a, b) => {
+    const diff = (b.win_rate || 0) - (a.win_rate || 0);
+    return diff !== 0 ? diff : a.title.localeCompare(b.title);
+  });
 }
 
 const PLAY_URL = 'https://yourconscience.github.io/llm_quest_benchmark/play.html';

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -138,23 +138,14 @@ function stripClr(s) {
   return String(s == null ? '' : s).replace(/<clr>|<clrEnd>|<\/clr>/g, '');
 }
 
-function diffColor(diff) {
-  if (diff === 'easy') return 'var(--green)';
-  if (diff === 'medium') return 'var(--orange)';
+function winRateColor(rate) {
+  if (rate > 0.15) return 'var(--green)';
+  if (rate > 0) return 'var(--orange)';
   return 'var(--red)';
 }
 
-function diffLabel(diff) {
-  return diff.charAt(0).toUpperCase() + diff.slice(1);
-}
-
 function sortQuests(quests) {
-  const order = { easy: 0, medium: 1, hard: 2 };
-  return [...quests].sort((a, b) => {
-    const da = order[a.difficulty] ?? 3;
-    const db = order[b.difficulty] ?? 3;
-    return da !== db ? da - db : a.title.localeCompare(b.title);
-  });
+  return [...quests].sort((a, b) => (b.win_rate || 0) - (a.win_rate || 0));
 }
 
 const PLAY_URL = 'https://yourconscience.github.io/llm_quest_benchmark/play.html';
@@ -787,19 +778,14 @@ function QuestSelect({ onSelectQuest, lang, onLangChange }) {
               <div className="quest-card h-100" style={{ display: 'flex', flexDirection: 'column' }} onClick={() => onSelectQuest(q)}>
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
                   <h5 style={{ margin: 0 }}>{q.title}</h5>
-                  <span className="diff-badge" style={{ color: diffColor(q.difficulty) }}>{diffLabel(q.difficulty)}</span>
+                  {q.win_rate != null ? (
+                    <span className="diff-badge" style={{ color: winRateColor(q.win_rate) }}>{Math.round(q.win_rate * 100)}%</span>
+                  ) : (
+                    <span className="diff-badge" style={{ color: 'var(--muted)' }}>--</span>
+                  )}
                 </div>
                 <p style={{ color: 'var(--muted)', fontSize: '0.88rem', marginBottom: '0.5rem', flexGrow: 1 }}>{q.description}</p>
-                <div style={{ fontSize: '0.82rem', color: 'var(--muted)', marginBottom: '0.25rem' }}>~{q.stepsRange} steps</div>
-                {q.win_rate != null ? (
-                  <div style={{ fontSize: '0.82rem', color: 'var(--muted)', marginBottom: '0.75rem' }}>
-                    AI win rate: {Math.round((q.win_rate || 0) * 100)}%
-                  </div>
-                ) : (
-                  <div style={{ fontSize: '0.82rem', color: 'var(--muted)', marginBottom: '0.75rem' }}>
-                    No AI data yet
-                  </div>
-                )}
+                <div style={{ fontSize: '0.82rem', color: 'var(--muted)', marginBottom: '0.75rem' }}>~{q.stepsRange} steps</div>
                 <button className="btn btn-sm btn-outline-primary" style={{ marginTop: 'auto' }} onClick={e => { e.stopPropagation(); onSelectQuest(q); }}>
                   Play
                 </button>


### PR DESCRIPTION
## Summary
- Sort quest cards by AI win rate (highest first) instead of easy/medium/hard
- Badge shows win rate % with color: green (>15%), orange (1-15%), red (0%)
- Removed original difficulty labels that didn't match actual AI performance

## Test plan
- [ ] Check quest order matches win rate descending
- [ ] Verify badge colors: Bad Day (22%, green), Pizza Delivery (17%, green), Pilot (9%, orange), Banquet (0%, red)