### PR TITLE
Show quest ending narrative on result screen

### DIFF
--- a/site/play/app.js
+++ b/site/play/app.js
@@ -484,6 +484,7 @@ function EndScreen({
   cohortWinRate,
   path,
   questTitle,
+  endText,
   onPlayAgain,
   onTryAnother
 }) {
@@ -517,7 +518,17 @@ function EndScreen({
       color: 'var(--muted)',
       marginBottom: '1.5rem'
     }
-  }, "AI cohort: ", Math.round(cohortWinRate * 100), "% won this quest."), /*#__PURE__*/React.createElement("h5", {
+  }, "AI cohort: ", Math.round(cohortWinRate * 100), "% won this quest."), endText && /*#__PURE__*/React.createElement("div", {
+    className: "card-table",
+    style: {
+      marginBottom: '1.5rem',
+      textAlign: 'left',
+      padding: '1rem 1.25rem',
+      lineHeight: 1.7
+    }
+  }, /*#__PURE__*/React.createElement(QuestTags, {
+    str: endText
+  })), /*#__PURE__*/React.createElement("h5", {
     style: {
       textAlign: 'left',
       marginBottom: '0.5rem'
@@ -582,6 +593,7 @@ function QuestPlay({
   const [stepNum, setStepNum] = useState(0);
   const [path, setPath] = useState([]);
   const [ended, setEnded] = useState(null);
+  const [endText, setEndText] = useState('');
   const [obsKey, setObsKey] = useState(0);
   useEffect(() => {
     const controller = new AbortController();
@@ -663,6 +675,7 @@ function QuestPlay({
     const isTerminal = gs === 'win' || gs === 'fail' || gs === 'dead';
     if (isTerminal) {
       setEnded(gs);
+      setEndText(nextState.text || '');
     } else {
       setGameState(player.getState());
       setStepNum(n => n + 1);
@@ -717,6 +730,7 @@ function QuestPlay({
       cohortWinRate: cohortData ? cohortData.win_rate : null,
       path: path,
       questTitle: quest.title || quest.id,
+      endText: endText,
       onPlayAgain: () => {
         player.start();
         if (canonicalPlayer) canonicalPlayer.loadSaving(player.getSaving());
@@ -725,6 +739,7 @@ function QuestPlay({
         setPath([]);
         setStepHistory([]);
         setEnded(null);
+        setEndText('');
         setObsKey(k => k + 1);
       },
       onTryAnother: onQuit

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -424,7 +424,7 @@ async function shareResult(canvas, questTitle, outcomeLabel) {
 
 // ---- EndScreen ----
 
-function EndScreen({ outcome, cohortWinRate, path, questTitle, onPlayAgain, onTryAnother }) {
+function EndScreen({ outcome, cohortWinRate, path, questTitle, endText, onPlayAgain, onTryAnother }) {
   const [shareStatus, setShareStatus] = useState('');
   const outcomeLabel = { win: 'SUCCESS', fail: 'FAILURE', dead: 'DEAD' }[outcome] || 'FAILURE';
   const branchingSteps = path.filter(e => e.agreed !== null);
@@ -448,6 +448,11 @@ function EndScreen({ outcome, cohortWinRate, path, questTitle, onPlayAgain, onTr
         <p style={{ color: 'var(--muted)', marginBottom: '1.5rem' }}>
           AI cohort: {Math.round(cohortWinRate * 100)}% won this quest.
         </p>
+      )}
+      {endText && (
+        <div className="card-table" style={{ marginBottom: '1.5rem', textAlign: 'left', padding: '1rem 1.25rem', lineHeight: 1.7 }}>
+          <QuestTags str={endText} />
+        </div>
       )}
       <h5 style={{ textAlign: 'left', marginBottom: '0.5rem' }}>Your path</h5>
       <div className="card-table" style={{ marginBottom: '1.5rem' }}>
@@ -498,6 +503,7 @@ function QuestPlay({ quest, cohortData, onQuit }) {
   const [stepNum, setStepNum] = useState(0);
   const [path, setPath] = useState([]);
   const [ended, setEnded] = useState(null);
+  const [endText, setEndText] = useState('');
   const [obsKey, setObsKey] = useState(0);
 
   useEffect(() => {
@@ -581,6 +587,7 @@ function QuestPlay({ quest, cohortData, onQuit }) {
 
     if (isTerminal) {
       setEnded(gs);
+      setEndText(nextState.text || '');
     } else {
       setGameState(player.getState());
       setStepNum(n => n + 1);
@@ -628,6 +635,7 @@ function QuestPlay({ quest, cohortData, onQuit }) {
         cohortWinRate={cohortData ? cohortData.win_rate : null}
         path={path}
         questTitle={quest.title || quest.id}
+        endText={endText}
         onPlayAgain={() => {
           player.start();
           if (canonicalPlayer) canonicalPlayer.loadSaving(player.getSaving());
@@ -636,6 +644,7 @@ function QuestPlay({ quest, cohortData, onQuit }) {
           setPath([]);
           setStepHistory([]);
           setEnded(null);
+          setEndText('');
           setObsKey(k => k + 1);
         }}
         onTryAnother={onQuit}


### PR DESCRIPTION
## Summary
- Display the quest's ending text (win/fail/dead narrative) on the result screen
- Uses QuestTags for proper formatting of colored/styled text from the quest engine
- The terminal state text was being discarded - now stored and passed to EndScreen

## Test plan
- [ ] Play Disk quest to failure, verify failure explanation text appears above "Your path"
- [ ] Play a quest to success, verify success text appears
- [ ] Click Play Again, verify text resets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quest completion messages are now displayed on the end screen when reaching terminal game states (victory, defeat, or death). Terminal output text appears in a formatted section above your quest path summary, providing context on your adventure outcome. Messages reset when starting a new game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->