### PR TITLE
Add decision history on end screen, improve sharing

### DIFF
--- a/site/play/app.js
+++ b/site/play/app.js
@@ -440,7 +440,7 @@ function downloadCanvas(canvas, filename) {
 }
 async function copyShareText(text, url) {
   if (!navigator.clipboard || !navigator.clipboard.writeText) return false;
-  await navigator.clipboard.writeText(text + '\n' + url);
+  await navigator.clipboard.writeText(url ? text + '\n' + url : text);
   return true;
 }
 async function shareResult(canvas, questTitle, outcomeLabel) {
@@ -516,8 +516,13 @@ function EndScreen({
     const text = buildShareText(questTitle, outcomeLabel, path, cohortWinRate);
     const canvas = renderShareCard(questTitle, outcomeLabel, path.length, aiAgreeRate, cohortWinRate);
     if (navigator.share) {
-      const blob = canvas.toDataURL('image/png');
-      fetch(blob).then(r => r.blob()).then(b => {
+      canvas.toBlob(b => {
+        if (!b) {
+          navigator.share({
+            text
+          }).then(() => setShareStatus('Shared!')).catch(() => {});
+          return;
+        }
         const file = new File([b], 'quest-result.png', {
           type: 'image/png'
         });
@@ -532,7 +537,7 @@ function EndScreen({
             text
           }).then(() => setShareStatus('Shared!')).catch(() => {});
         }
-      });
+      }, 'image/png');
       return;
     }
     copyShareText(text, '').then(ok => {

--- a/site/play/app.js
+++ b/site/play/app.js
@@ -479,12 +479,27 @@ async function shareResult(canvas, questTitle, outcomeLabel) {
 
 // ---- EndScreen ----
 
+function buildShareText(questTitle, outcomeLabel, path, cohortWinRate) {
+  const branchingSteps = path.filter(e => e.agreed !== null);
+  const squares = branchingSteps.map(e => e.agreed ? '\u{1F7E9}' : '\u{1F7E5}').join('');
+  const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
+  const aiPct = cohortWinRate != null ? Math.round(cohortWinRate * 100) : null;
+  let lines = [];
+  lines.push('LLM-Quest Benchmark: ' + questTitle);
+  lines.push(outcomeLabel + ' in ' + path.length + ' steps');
+  if (squares) lines.push(squares + ' ' + agreeCount + '/' + branchingSteps.length + ' AI agreed');
+  if (aiPct != null) lines.push('AI cohort win rate: ' + aiPct + '%');
+  lines.push('');
+  lines.push(PLAY_URL);
+  return lines.join('\n');
+}
 function EndScreen({
   outcome,
   cohortWinRate,
   path,
   questTitle,
   endText,
+  families,
   onPlayAgain,
   onTryAnother
 }) {
@@ -498,14 +513,46 @@ function EndScreen({
   const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
   const aiAgreeRate = branchingSteps.length > 0 ? Math.round(agreeCount / branchingSteps.length * 100) : 0;
   function handleShare() {
-    setShareStatus('Preparing share card...');
+    const text = buildShareText(questTitle, outcomeLabel, path, cohortWinRate);
     const canvas = renderShareCard(questTitle, outcomeLabel, path.length, aiAgreeRate, cohortWinRate);
-    shareResult(canvas, questTitle, outcomeLabel).then(status => setShareStatus(status)).catch(() => setShareStatus('Sharing failed. Try downloading from another browser.'));
+    if (navigator.share) {
+      const blob = canvas.toDataURL('image/png');
+      fetch(blob).then(r => r.blob()).then(b => {
+        const file = new File([b], 'quest-result.png', {
+          type: 'image/png'
+        });
+        const shareData = {
+          text,
+          files: [file]
+        };
+        if (navigator.canShare && navigator.canShare(shareData)) {
+          navigator.share(shareData).then(() => setShareStatus('Shared!')).catch(() => {});
+        } else {
+          navigator.share({
+            text
+          }).then(() => setShareStatus('Shared!')).catch(() => {});
+        }
+      });
+      return;
+    }
+    copyShareText(text, '').then(ok => {
+      if (ok) {
+        setShareStatus('Copied to clipboard!');
+        downloadCanvas(canvas, 'quest-result.png');
+      } else {
+        downloadCanvas(canvas, 'quest-result.png');
+        setShareStatus('Downloaded image.');
+      }
+    });
   }
   return /*#__PURE__*/React.createElement("div", {
-    className: "container py-5 text-center",
+    className: "container py-5",
     style: {
       maxWidth: 700
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      textAlign: 'center'
     }
   }, /*#__PURE__*/React.createElement("div", {
     className: 'outcome-badge outcome-' + outcomeLabel,
@@ -518,7 +565,7 @@ function EndScreen({
       color: 'var(--muted)',
       marginBottom: '1.5rem'
     }
-  }, "AI cohort: ", Math.round(cohortWinRate * 100), "% won this quest."), endText && /*#__PURE__*/React.createElement("div", {
+  }, "AI cohort: ", Math.round(cohortWinRate * 100), "% won this quest.")), endText && /*#__PURE__*/React.createElement("div", {
     className: "card-table",
     style: {
       marginBottom: '1.5rem',
@@ -528,36 +575,16 @@ function EndScreen({
     }
   }, /*#__PURE__*/React.createElement(QuestTags, {
     str: endText
-  })), /*#__PURE__*/React.createElement("h5", {
-    style: {
-      textAlign: 'left',
-      marginBottom: '0.5rem'
-    }
-  }, "Your path"), /*#__PURE__*/React.createElement("div", {
-    className: "card-table",
-    style: {
-      marginBottom: '1.5rem'
-    }
-  }, /*#__PURE__*/React.createElement("table", {
-    className: "table table-sm path-table"
-  }, /*#__PURE__*/React.createElement("thead", null, /*#__PURE__*/React.createElement("tr", null, /*#__PURE__*/React.createElement("th", null, "Step"), /*#__PURE__*/React.createElement("th", null, "Choice"), /*#__PURE__*/React.createElement("th", null, "AI agreed?"))), /*#__PURE__*/React.createElement("tbody", null, path.map((entry, i) => /*#__PURE__*/React.createElement("tr", {
-    key: i
-  }, /*#__PURE__*/React.createElement("td", {
-    style: {
-      color: 'var(--muted)'
-    }
-  }, entry.step), /*#__PURE__*/React.createElement("td", null, entry.choiceText), /*#__PURE__*/React.createElement("td", null, entry.agreed === true && /*#__PURE__*/React.createElement("span", {
-    className: "agree-yes"
-  }, "Yes"), entry.agreed === false && /*#__PURE__*/React.createElement("span", {
-    className: "agree-no"
-  }, "No"), entry.agreed === null && /*#__PURE__*/React.createElement("span", {
-    className: "agree-no"
-  }, "-"))))))), /*#__PURE__*/React.createElement("div", {
+  })), /*#__PURE__*/React.createElement(DecisionHistory, {
+    path: path,
+    families: families
+  }), /*#__PURE__*/React.createElement("div", {
     style: {
       display: 'flex',
       gap: '0.75rem',
       justifyContent: 'center',
-      flexWrap: 'wrap'
+      flexWrap: 'wrap',
+      marginTop: '1.5rem'
     }
   }, /*#__PURE__*/React.createElement("button", {
     className: "btn btn-primary",
@@ -572,7 +599,8 @@ function EndScreen({
     style: {
       color: 'var(--muted)',
       fontSize: '0.9rem',
-      marginTop: '0.75rem'
+      marginTop: '0.75rem',
+      textAlign: 'center'
     }
   }, shareStatus));
 }
@@ -731,6 +759,7 @@ function QuestPlay({
       path: path,
       questTitle: quest.title || quest.id,
       endText: endText,
+      families: cohortData && cohortData.model_families || [],
       onPlayAgain: () => {
         player.start();
         if (canonicalPlayer) canonicalPlayer.loadSaving(player.getSaving());

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -386,7 +386,7 @@ function downloadCanvas(canvas, filename) {
 
 async function copyShareText(text, url) {
   if (!navigator.clipboard || !navigator.clipboard.writeText) return false;
-  await navigator.clipboard.writeText(text + '\n' + url);
+  await navigator.clipboard.writeText(url ? text + '\n' + url : text);
   return true;
 }
 
@@ -452,8 +452,8 @@ function EndScreen({ outcome, cohortWinRate, path, questTitle, endText, families
     const canvas = renderShareCard(questTitle, outcomeLabel, path.length, aiAgreeRate, cohortWinRate);
 
     if (navigator.share) {
-      const blob = canvas.toDataURL('image/png');
-      fetch(blob).then(r => r.blob()).then(b => {
+      canvas.toBlob(b => {
+        if (!b) { navigator.share({ text }).then(() => setShareStatus('Shared!')).catch(() => {}); return; }
         const file = new File([b], 'quest-result.png', { type: 'image/png' });
         const shareData = { text, files: [file] };
         if (navigator.canShare && navigator.canShare(shareData)) {
@@ -461,7 +461,7 @@ function EndScreen({ outcome, cohortWinRate, path, questTitle, endText, families
         } else {
           navigator.share({ text }).then(() => setShareStatus('Shared!')).catch(() => {});
         }
-      });
+      }, 'image/png');
       return;
     }
 

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -424,7 +424,23 @@ async function shareResult(canvas, questTitle, outcomeLabel) {
 
 // ---- EndScreen ----
 
-function EndScreen({ outcome, cohortWinRate, path, questTitle, endText, onPlayAgain, onTryAnother }) {
+function buildShareText(questTitle, outcomeLabel, path, cohortWinRate) {
+  const branchingSteps = path.filter(e => e.agreed !== null);
+  const squares = branchingSteps.map(e => e.agreed ? '\u{1F7E9}' : '\u{1F7E5}').join('');
+  const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
+  const aiPct = cohortWinRate != null ? Math.round(cohortWinRate * 100) : null;
+
+  let lines = [];
+  lines.push('LLM-Quest Benchmark: ' + questTitle);
+  lines.push(outcomeLabel + ' in ' + path.length + ' steps');
+  if (squares) lines.push(squares + ' ' + agreeCount + '/' + branchingSteps.length + ' AI agreed');
+  if (aiPct != null) lines.push('AI cohort win rate: ' + aiPct + '%');
+  lines.push('');
+  lines.push(PLAY_URL);
+  return lines.join('\n');
+}
+
+function EndScreen({ outcome, cohortWinRate, path, questTitle, endText, families, onPlayAgain, onTryAnother }) {
   const [shareStatus, setShareStatus] = useState('');
   const outcomeLabel = { win: 'SUCCESS', fail: 'FAILURE', dead: 'DEAD' }[outcome] || 'FAILURE';
   const branchingSteps = path.filter(e => e.agreed !== null);
@@ -432,60 +448,59 @@ function EndScreen({ outcome, cohortWinRate, path, questTitle, endText, onPlayAg
   const aiAgreeRate = branchingSteps.length > 0 ? Math.round((agreeCount / branchingSteps.length) * 100) : 0;
 
   function handleShare() {
-    setShareStatus('Preparing share card...');
+    const text = buildShareText(questTitle, outcomeLabel, path, cohortWinRate);
     const canvas = renderShareCard(questTitle, outcomeLabel, path.length, aiAgreeRate, cohortWinRate);
-    shareResult(canvas, questTitle, outcomeLabel)
-      .then(status => setShareStatus(status))
-      .catch(() => setShareStatus('Sharing failed. Try downloading from another browser.'));
+
+    if (navigator.share) {
+      const blob = canvas.toDataURL('image/png');
+      fetch(blob).then(r => r.blob()).then(b => {
+        const file = new File([b], 'quest-result.png', { type: 'image/png' });
+        const shareData = { text, files: [file] };
+        if (navigator.canShare && navigator.canShare(shareData)) {
+          navigator.share(shareData).then(() => setShareStatus('Shared!')).catch(() => {});
+        } else {
+          navigator.share({ text }).then(() => setShareStatus('Shared!')).catch(() => {});
+        }
+      });
+      return;
+    }
+
+    copyShareText(text, '').then(ok => {
+      if (ok) {
+        setShareStatus('Copied to clipboard!');
+        downloadCanvas(canvas, 'quest-result.png');
+      } else {
+        downloadCanvas(canvas, 'quest-result.png');
+        setShareStatus('Downloaded image.');
+      }
+    });
   }
 
   return (
-    <div className="container py-5 text-center" style={{ maxWidth: 700 }}>
-      <div className={'outcome-badge outcome-' + outcomeLabel} style={{ display: 'inline-block', marginBottom: '1rem' }}>
-        {outcomeLabel}
+    <div className="container py-5" style={{ maxWidth: 700 }}>
+      <div style={{ textAlign: 'center' }}>
+        <div className={'outcome-badge outcome-' + outcomeLabel} style={{ display: 'inline-block', marginBottom: '1rem' }}>
+          {outcomeLabel}
+        </div>
+        {cohortWinRate != null && (
+          <p style={{ color: 'var(--muted)', marginBottom: '1.5rem' }}>
+            AI cohort: {Math.round(cohortWinRate * 100)}% won this quest.
+          </p>
+        )}
       </div>
-      {cohortWinRate != null && (
-        <p style={{ color: 'var(--muted)', marginBottom: '1.5rem' }}>
-          AI cohort: {Math.round(cohortWinRate * 100)}% won this quest.
-        </p>
-      )}
       {endText && (
         <div className="card-table" style={{ marginBottom: '1.5rem', textAlign: 'left', padding: '1rem 1.25rem', lineHeight: 1.7 }}>
           <QuestTags str={endText} />
         </div>
       )}
-      <h5 style={{ textAlign: 'left', marginBottom: '0.5rem' }}>Your path</h5>
-      <div className="card-table" style={{ marginBottom: '1.5rem' }}>
-        <table className="table table-sm path-table">
-          <thead>
-            <tr>
-              <th>Step</th>
-              <th>Choice</th>
-              <th>AI agreed?</th>
-            </tr>
-          </thead>
-          <tbody>
-            {path.map((entry, i) => (
-              <tr key={i}>
-                <td style={{ color: 'var(--muted)' }}>{entry.step}</td>
-                <td>{entry.choiceText}</td>
-                <td>
-                  {entry.agreed === true && <span className="agree-yes">Yes</span>}
-                  {entry.agreed === false && <span className="agree-no">No</span>}
-                  {entry.agreed === null && <span className="agree-no">-</span>}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-      <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+      <DecisionHistory path={path} families={families} />
+      <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap', marginTop: '1.5rem' }}>
         <button className="btn btn-primary" onClick={onPlayAgain}>Play Again</button>
         <button className="btn btn-outline-secondary" onClick={onTryAnother}>Try Another Quest</button>
         <button className="btn btn-outline-info" onClick={handleShare}>Share Result</button>
       </div>
       {shareStatus && (
-        <p style={{ color: 'var(--muted)', fontSize: '0.9rem', marginTop: '0.75rem' }}>{shareStatus}</p>
+        <p style={{ color: 'var(--muted)', fontSize: '0.9rem', marginTop: '0.75rem', textAlign: 'center' }}>{shareStatus}</p>
       )}
     </div>
   );
@@ -636,6 +651,7 @@ function QuestPlay({ quest, cohortData, onQuit }) {
         path={path}
         questTitle={quest.title || quest.id}
         endText={endText}
+        families={(cohortData && cohortData.model_families) || []}
         onPlayAgain={() => {
           player.start();
           if (canonicalPlayer) canonicalPlayer.loadSaving(player.getSaving());


### PR DESCRIPTION
## Summary
- Show expandable DecisionHistory (with AI cohort bars) on the end screen, replacing the flat path table
- Wordle-style share text: colored squares for AI agreement, stats, and URL
- Share flow: Web Share API with image on mobile, clipboard + image download on desktop
- Removed the old path table from end screen (DecisionHistory replaces it)

## Test plan
- [ ] Play quest to end, verify Decision History appears with expandable cohort bars
- [ ] Click Share Result on mobile - verify text + image shared via native dialog
- [ ] Click Share Result on desktop - verify text copied to clipboard + image downloaded
- [ ] Paste shared text - should show colored squares and stats