### PR TITLE
data: update leaderboard with 21 models including Gemini-3-Flash

### DIFF
--- a/site/leaderboard.json
+++ b/site/leaderboard.json
@@ -1,11 +1,26 @@
 {
-  "generated": "2026-04-19T10:56:50.302405",
+  "generated": "2026-05-04T18:33:23.687324",
   "benchmark_id": "combined",
   "models": [
+    {
+      "id": "anthropic:claude-3-5-haiku-latest",
+      "provider": "anthropic",
+      "label": "Claude 3.5 Haiku Latest"
+    },
+    {
+      "id": "claude-haiku-4.5",
+      "provider": "anthropic",
+      "label": "Claude Haiku 4.5"
+    },
     {
       "id": "claude-sonnet-4-6",
       "provider": "anthropic",
       "label": "Claude Sonnet 4.6"
+    },
+    {
+      "id": "claude:claude-haiku-4-5-20251001",
+      "provider": "unknown",
+      "label": "Claude:Claude Haiku 4.5 20251001"
     },
     {
       "id": "deepseek-chat",
@@ -13,9 +28,29 @@
       "label": "DeepSeek"
     },
     {
+      "id": "deepseek-chat-v3-0324",
+      "provider": "deepseek",
+      "label": "DeepSeek Chat v3 0324"
+    },
+    {
+      "id": "deepseek-v3.2",
+      "provider": "deepseek",
+      "label": "DeepSeek v3.2"
+    },
+    {
+      "id": "deepseek-v4-flash",
+      "provider": "deepseek",
+      "label": "DeepSeek v4 Flash"
+    },
+    {
       "id": "gemini-2.5-flash",
       "provider": "google",
       "label": "Gemini 2.5 Flash"
+    },
+    {
+      "id": "gemini-3-flash-preview",
+      "provider": "google",
+      "label": "Gemini 3 Flash Preview"
     },
     {
       "id": "gpt-5.4",
@@ -28,9 +63,49 @@
       "label": "GPT-5.4 Mini"
     },
     {
+      "id": "llama-4-scout",
+      "provider": "meta-llama",
+      "label": "Llama 4 Scout"
+    },
+    {
+      "id": "minimax-m2.5",
+      "provider": "minimax",
+      "label": "Minimax m2.5"
+    },
+    {
+      "id": "mistral-large-2512",
+      "provider": "mistralai",
+      "label": "Mistral Large 2512"
+    },
+    {
+      "id": "mistral-medium-3.1",
+      "provider": "mistralai",
+      "label": "Mistral Medium 3.1"
+    },
+    {
+      "id": "mistral-small-2603",
+      "provider": "mistralai",
+      "label": "Mistral Small 2603"
+    },
+    {
       "id": "qwen-2.5-72b-instruct",
       "provider": "qwen",
       "label": "Qwen 2.5 72b Instruct"
+    },
+    {
+      "id": "qwen3-235b-a22b",
+      "provider": "qwen",
+      "label": "qwen3 235b a22b"
+    },
+    {
+      "id": "qwen3-30b-a3b",
+      "provider": "qwen",
+      "label": "qwen3 30b a3b"
+    },
+    {
+      "id": "qwen3.6-flash",
+      "provider": "qwen",
+      "label": "qwen3.6 Flash"
     }
   ],
   "modes": [
@@ -49,6 +124,34 @@
     {
       "id": "planner",
       "label": "Planner (D)"
+    },
+    {
+      "id": "tool_augmented",
+      "label": "Tool-aug (E)"
+    },
+    {
+      "id": "memo_cot",
+      "label": "memo_cot"
+    },
+    {
+      "id": "memo_extended",
+      "label": "memo_extended"
+    },
+    {
+      "id": "memo_structured",
+      "label": "memo_structured"
+    },
+    {
+      "id": "stateful_compact",
+      "label": "stateful_compact"
+    },
+    {
+      "id": "stateful_compact_hints",
+      "label": "stateful_compact_hints"
+    },
+    {
+      "id": "tool_augmented_hints",
+      "label": "tool_augmented_hints"
     }
   ],
   "quests": [
@@ -65,11 +168,23 @@
       "lang": "EN"
     },
     {
+      "id": "Borzukhan_eng",
+      "lang": "EN"
+    },
+    {
       "id": "Codebox_eng",
       "lang": "EN"
     },
     {
       "id": "Depth_eng",
+      "lang": "EN"
+    },
+    {
+      "id": "Diehard",
+      "lang": "RU"
+    },
+    {
+      "id": "Disk_eng",
       "lang": "EN"
     },
     {
@@ -89,7 +204,19 @@
       "lang": "EN"
     },
     {
+      "id": "Gobsaur",
+      "lang": "RU"
+    },
+    {
+      "id": "Hachball",
+      "lang": "RU"
+    },
+    {
       "id": "Leonardo_eng",
+      "lang": "EN"
+    },
+    {
+      "id": "Logic_eng",
       "lang": "EN"
     },
     {
@@ -97,7 +224,19 @@
       "lang": "EN"
     },
     {
+      "id": "Muzon_eng",
+      "lang": "EN"
+    },
+    {
+      "id": "Pilot_eng",
+      "lang": "EN"
+    },
+    {
       "id": "Pizza_eng",
+      "lang": "EN"
+    },
+    {
+      "id": "Player_eng",
       "lang": "EN"
     },
     {
@@ -109,11 +248,420 @@
       "lang": "EN"
     },
     {
+      "id": "Rush",
+      "lang": "RU"
+    },
+    {
+      "id": "Shashki_eng",
+      "lang": "EN"
+    },
+    {
       "id": "Ski_eng",
       "lang": "EN"
+    },
+    {
+      "id": "Sortirovka1_eng",
+      "lang": "EN"
+    },
+    {
+      "id": "Spy",
+      "lang": "RU"
+    },
+    {
+      "id": "Svarokok_eng",
+      "lang": "EN"
+    },
+    {
+      "id": "Tomb",
+      "lang": "RU"
     }
   ],
   "results": [
+    {
+      "model": "anthropic:claude-3-5-haiku-latest",
+      "mode": "stateful_compact",
+      "quest": "Disk_eng",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 8.333333333333334,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.7566137566137566
+    },
+    {
+      "model": "anthropic:claude-3-5-haiku-latest",
+      "mode": "stateful_compact",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 37.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.9458403458403458
+    },
+    {
+      "model": "anthropic:claude-3-5-haiku-latest",
+      "mode": "stateful_compact",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.9375
+    },
+    {
+      "model": "anthropic:claude-3-5-haiku-latest",
+      "mode": "stateful_compact",
+      "quest": "Pilot_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 8.666666666666666,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.7685185185185185
+    },
+    {
+      "model": "anthropic:claude-3-5-haiku-latest",
+      "mode": "stateful_compact",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 53.666666666666664,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.9450811604357473
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 20.666666666666668,
+      "avg_tokens": 13311.333333333334,
+      "avg_cost_usd": 0.013724666666666668,
+      "repetition_rate": 0.8037037037037038
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 34.0,
+      "avg_tokens": 31282.0,
+      "avg_cost_usd": 0.037862,
+      "repetition_rate": 0.715219421101774
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Boat",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 17.0,
+      "avg_tokens": 14383.0,
+      "avg_cost_usd": 0.017059,
+      "repetition_rate": 0.8607456140350878
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 7.0,
+      "avg_tokens": 5703.333333333333,
+      "avg_cost_usd": 0.007023333333333333,
+      "repetition_rate": 0.5090909090909091
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 58.0,
+      "avg_tokens": 44687.0,
+      "avg_cost_usd": 0.050257666666666666,
+      "repetition_rate": 0.7009813384813385
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 123.0,
+      "avg_tokens": 90317.66666666667,
+      "avg_cost_usd": 0.093171,
+      "repetition_rate": 0.7505982251165166
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 43.0,
+      "avg_tokens": 26968.333333333332,
+      "avg_cost_usd": 0.032459,
+      "repetition_rate": 0.817043813192104
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 63.333333333333336,
+      "avg_tokens": 60154.0,
+      "avg_cost_usd": 0.06142066666666666,
+      "repetition_rate": 0.7515894429247617
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 24.333333333333332,
+      "avg_tokens": 17028.666666666668,
+      "avg_cost_usd": 0.01984733333333333,
+      "repetition_rate": 0.6565656565656566
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 115.0,
+      "avg_tokens": 78584.0,
+      "avg_cost_usd": 0.080884,
+      "repetition_rate": 0.8052383212063693
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 107.66666666666667,
+      "avg_tokens": 67511.0,
+      "avg_cost_usd": 0.06966433333333333,
+      "repetition_rate": 0.7912254730012268
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 27.0,
+      "avg_tokens": 19455.666666666668,
+      "avg_cost_usd": 0.019995666666666665,
+      "repetition_rate": 0.5135483870967742
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Prison_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 423.3333333333333,
+      "avg_tokens": 299326.3333333333,
+      "avg_cost_usd": 0.311849,
+      "repetition_rate": 0.8496463005820342
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 60.666666666666664,
+      "avg_tokens": 37224.666666666664,
+      "avg_cost_usd": 0.038438,
+      "repetition_rate": 0.8269900350545512
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "stub",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 67.0,
+      "avg_tokens": 57358.333333333336,
+      "avg_cost_usd": 0.06381166666666667,
+      "repetition_rate": 0.6702395085712229
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 33.333333333333336,
+      "avg_tokens": 28559.666666666668,
+      "avg_cost_usd": 0.03959033333333333,
+      "repetition_rate": 0.776060606060606
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 28.333333333333332,
+      "avg_tokens": 30756.333333333332,
+      "avg_cost_usd": 0.04130966666666667,
+      "repetition_rate": 0.7224037763253449
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Boat",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 19534.0,
+      "avg_cost_usd": 0.026804666666666668,
+      "repetition_rate": 0.8245614035087719
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 24.333333333333332,
+      "avg_tokens": 27896.0,
+      "avg_cost_usd": 0.03633066666666667,
+      "repetition_rate": 0.7397360703812317
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 38.0,
+      "avg_tokens": 37185.0,
+      "avg_cost_usd": 0.051297,
+      "repetition_rate": 0.7221180295073769
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 28.666666666666668,
+      "avg_tokens": 26545.333333333332,
+      "avg_cost_usd": 0.036993333333333336,
+      "repetition_rate": 0.7841269841269841
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 59.333333333333336,
+      "avg_tokens": 48286.333333333336,
+      "avg_cost_usd": 0.06830900000000001,
+      "repetition_rate": 0.7603159232584882
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 80.66666666666667,
+      "avg_tokens": 94572.66666666667,
+      "avg_cost_usd": 0.12347399999999999,
+      "repetition_rate": 0.7326468493478272
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 29.333333333333332,
+      "avg_tokens": 25337.333333333332,
+      "avg_cost_usd": 0.03564933333333333,
+      "repetition_rate": 0.7468982630272953
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 105.66666666666667,
+      "avg_tokens": 94588.0,
+      "avg_cost_usd": 0.13214,
+      "repetition_rate": 0.7826924709277651
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 159.33333333333334,
+      "avg_tokens": 130652.33333333333,
+      "avg_cost_usd": 0.18174433333333337,
+      "repetition_rate": 0.815810140402628
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 35.666666666666664,
+      "avg_tokens": 33168.333333333336,
+      "avg_cost_usd": 0.046775000000000004,
+      "repetition_rate": 0.6543114543114543
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Prison_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 214.33333333333334,
+      "avg_tokens": 192980.66666666666,
+      "avg_cost_usd": 0.266334,
+      "repetition_rate": 0.8260266576775455
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.666666666666664,
+      "avg_tokens": 27624.666666666668,
+      "avg_cost_usd": 0.038934,
+      "repetition_rate": 0.743892828999212
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "reasoning",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 48.666666666666664,
+      "avg_tokens": 50816.333333333336,
+      "avg_cost_usd": 0.067535,
+      "repetition_rate": 0.6102198455139631
+    },
     {
       "model": "claude-sonnet-4-6",
       "mode": "stub",
@@ -122,7 +670,7 @@
       "success_rate": 1.0,
       "avg_steps": 26.0,
       "avg_tokens": 16641.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.051483,
       "repetition_rate": 0.7692307692307693
     },
     {
@@ -133,19 +681,19 @@
       "success_rate": 0.0,
       "avg_steps": 35.0,
       "avg_tokens": 32509.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.117327,
       "repetition_rate": 0.7142857142857143
     },
     {
       "model": "claude-sonnet-4-6",
       "mode": "stub",
       "quest": "Boat",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 19.0,
-      "avg_tokens": 15640.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8421052631578947
+      "runs": 2,
+      "success_rate": 0.5,
+      "avg_steps": 17.5,
+      "avg_tokens": 14785.5,
+      "avg_cost_usd": 0.0519825,
+      "repetition_rate": 0.8585526315789473
     },
     {
       "model": "claude-sonnet-4-6",
@@ -155,7 +703,7 @@
       "success_rate": 0.0,
       "avg_steps": 6.0,
       "avg_tokens": 4424.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.017172,
       "repetition_rate": 0.5
     },
     {
@@ -166,7 +714,7 @@
       "success_rate": 0.0,
       "avg_steps": 69.0,
       "avg_tokens": 52455.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.168657,
       "repetition_rate": 0.6521739130434783
     },
     {
@@ -177,7 +725,7 @@
       "success_rate": 0.0,
       "avg_steps": 157.0,
       "avg_tokens": 117594.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.36525,
       "repetition_rate": 0.7452229299363057
     },
     {
@@ -188,7 +736,7 @@
       "success_rate": 0.0,
       "avg_steps": 42.0,
       "avg_tokens": 24618.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.076374,
       "repetition_rate": 0.6904761904761905
     },
     {
@@ -199,7 +747,7 @@
       "success_rate": 0.0,
       "avg_steps": 74.0,
       "avg_tokens": 70017.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.214491,
       "repetition_rate": 0.7027027027027027
     },
     {
@@ -210,7 +758,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 20449.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.063207,
       "repetition_rate": 0.5806451612903226
     },
     {
@@ -221,7 +769,7 @@
       "success_rate": 0.0,
       "avg_steps": 104.0,
       "avg_tokens": 70821.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.218703,
       "repetition_rate": 0.7403846153846154
     },
     {
@@ -232,7 +780,7 @@
       "success_rate": 0.0,
       "avg_steps": 112.0,
       "avg_tokens": 70587.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.218481,
       "repetition_rate": 0.6339285714285714
     },
     {
@@ -243,7 +791,7 @@
       "success_rate": 1.0,
       "avg_steps": 26.0,
       "avg_tokens": 19114.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.058902,
       "repetition_rate": 0.4230769230769231
     },
     {
@@ -254,7 +802,7 @@
       "success_rate": 0.0,
       "avg_steps": 91.0,
       "avg_tokens": 61528.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.190044,
       "repetition_rate": 0.8351648351648352
     },
     {
@@ -265,7 +813,7 @@
       "success_rate": 0.0,
       "avg_steps": 74.0,
       "avg_tokens": 45617.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.141291,
       "repetition_rate": 0.8783783783783784
     },
     {
@@ -276,7 +824,7 @@
       "success_rate": 0.0,
       "avg_steps": 57.0,
       "avg_tokens": 47297.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.148563,
       "repetition_rate": 0.7543859649122807
     },
     {
@@ -287,7 +835,7 @@
       "success_rate": 1.0,
       "avg_steps": 27.0,
       "avg_tokens": 21892.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.082008,
       "repetition_rate": 0.7777777777777778
     },
     {
@@ -298,7 +846,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 37810.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.153102,
       "repetition_rate": 0.7058823529411765
     },
     {
@@ -309,7 +857,7 @@
       "success_rate": 1.0,
       "avg_steps": 16.0,
       "avg_tokens": 16347.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.066165,
       "repetition_rate": 0.875
     },
     {
@@ -320,7 +868,7 @@
       "success_rate": 0.0,
       "avg_steps": 6.0,
       "avg_tokens": 5388.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02256,
       "repetition_rate": 0.5
     },
     {
@@ -331,7 +879,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 28854.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.107922,
       "repetition_rate": 0.6451612903225806
     },
     {
@@ -342,7 +890,7 @@
       "success_rate": 0.0,
       "avg_steps": 53.0,
       "avg_tokens": 47450.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.17601,
       "repetition_rate": 0.7358490566037735
     },
     {
@@ -353,7 +901,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 22884.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.089112,
       "repetition_rate": 0.7419354838709677
     },
     {
@@ -364,7 +912,7 @@
       "success_rate": 0.0,
       "avg_steps": 72.0,
       "avg_tokens": 81639.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.295485,
       "repetition_rate": 0.6388888888888888
     },
     {
@@ -375,7 +923,7 @@
       "success_rate": 0.0,
       "avg_steps": 27.0,
       "avg_tokens": 22960.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.087696,
       "repetition_rate": 0.7037037037037037
     },
     {
@@ -386,7 +934,7 @@
       "success_rate": 0.0,
       "avg_steps": 107.0,
       "avg_tokens": 92679.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.350097,
       "repetition_rate": 0.7476635514018691
     },
     {
@@ -397,7 +945,7 @@
       "success_rate": 0.0,
       "avg_steps": 66.0,
       "avg_tokens": 50960.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.194964,
       "repetition_rate": 0.8939393939393939
     },
     {
@@ -408,7 +956,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 31095.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.119757,
       "repetition_rate": 0.5294117647058824
     },
     {
@@ -419,7 +967,7 @@
       "success_rate": 0.0,
       "avg_steps": 58.0,
       "avg_tokens": 48779.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.183177,
       "repetition_rate": 0.8103448275862069
     },
     {
@@ -430,7 +978,7 @@
       "success_rate": 1.0,
       "avg_steps": 80.0,
       "avg_tokens": 63624.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.244656,
       "repetition_rate": 0.8375
     },
     {
@@ -441,7 +989,7 @@
       "success_rate": 0.0,
       "avg_steps": 64.0,
       "avg_tokens": 64862.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.234822,
       "repetition_rate": 0.703125
     },
     {
@@ -452,7 +1000,7 @@
       "success_rate": 1.0,
       "avg_steps": 26.0,
       "avg_tokens": 21626.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.081402,
       "repetition_rate": 0.8076923076923077
     },
     {
@@ -463,7 +1011,7 @@
       "success_rate": 0.0,
       "avg_steps": 33.0,
       "avg_tokens": 37380.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.149664,
       "repetition_rate": 0.696969696969697
     },
     {
@@ -474,7 +1022,7 @@
       "success_rate": 1.0,
       "avg_steps": 19.0,
       "avg_tokens": 19617.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.078963,
       "repetition_rate": 0.8421052631578947
     },
     {
@@ -485,7 +1033,7 @@
       "success_rate": 0.0,
       "avg_steps": 6.0,
       "avg_tokens": 5582.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.024174,
       "repetition_rate": 0.5
     },
     {
@@ -496,7 +1044,7 @@
       "success_rate": 0.0,
       "avg_steps": 40.0,
       "avg_tokens": 38330.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.144054,
       "repetition_rate": 0.6
     },
     {
@@ -507,7 +1055,7 @@
       "success_rate": 0.0,
       "avg_steps": 11.0,
       "avg_tokens": 9509.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.036243,
       "repetition_rate": 0.7272727272727273
     },
     {
@@ -518,7 +1066,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 23949.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.093135,
       "repetition_rate": 0.7741935483870968
     },
     {
@@ -529,7 +1077,7 @@
       "success_rate": 0.0,
       "avg_steps": 67.0,
       "avg_tokens": 76668.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.276936,
       "repetition_rate": 0.6865671641791045
     },
     {
@@ -540,7 +1088,7 @@
       "success_rate": 0.0,
       "avg_steps": 30.0,
       "avg_tokens": 26132.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.104892,
       "repetition_rate": 0.6
     },
     {
@@ -551,7 +1099,7 @@
       "success_rate": 0.0,
       "avg_steps": 110.0,
       "avg_tokens": 96912.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.364716,
       "repetition_rate": 0.7454545454545455
     },
     {
@@ -562,7 +1110,7 @@
       "success_rate": 0.0,
       "avg_steps": 173.0,
       "avg_tokens": 140415.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.528633,
       "repetition_rate": 0.7109826589595376
     },
     {
@@ -573,7 +1121,7 @@
       "success_rate": 1.0,
       "avg_steps": 28.0,
       "avg_tokens": 26283.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.099969,
       "repetition_rate": 0.5357142857142857
     },
     {
@@ -584,7 +1132,7 @@
       "success_rate": 0.0,
       "avg_steps": 113.0,
       "avg_tokens": 99256.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.371388,
       "repetition_rate": 0.831858407079646
     },
     {
@@ -595,7 +1143,7 @@
       "success_rate": 0.0,
       "avg_steps": 114.0,
       "avg_tokens": 92708.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.35298,
       "repetition_rate": 0.8070175438596491
     },
     {
@@ -606,7 +1154,7 @@
       "success_rate": 0.0,
       "avg_steps": 80.0,
       "avg_tokens": 82368.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.298668,
       "repetition_rate": 0.725
     },
     {
@@ -617,7 +1165,7 @@
       "success_rate": 1.0,
       "avg_steps": 26.0,
       "avg_tokens": 35741.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.171783,
       "repetition_rate": 0.7692307692307693
     },
     {
@@ -628,7 +1176,7 @@
       "success_rate": 0.0,
       "avg_steps": 27.0,
       "avg_tokens": 52148.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.239976,
       "repetition_rate": 0.7777777777777778
     },
     {
@@ -639,7 +1187,7 @@
       "success_rate": 1.0,
       "avg_steps": 20.0,
       "avg_tokens": 29732.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.14556,
       "repetition_rate": 0.9
     },
     {
@@ -650,7 +1198,7 @@
       "success_rate": 0.0,
       "avg_steps": 26.0,
       "avg_tokens": 37501.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.170931,
       "repetition_rate": 0.8076923076923077
     },
     {
@@ -661,7 +1209,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 46264.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.2133,
       "repetition_rate": 0.5588235294117647
     },
     {
@@ -672,7 +1220,7 @@
       "success_rate": 0.0,
       "avg_steps": 63.0,
       "avg_tokens": 81533.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.377163,
       "repetition_rate": 0.7777777777777778
     },
     {
@@ -683,7 +1231,7 @@
       "success_rate": 0.0,
       "avg_steps": 20.0,
       "avg_tokens": 24305.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.122103,
       "repetition_rate": 0.75
     },
     {
@@ -694,7 +1242,7 @@
       "success_rate": 0.0,
       "avg_steps": 56.0,
       "avg_tokens": 113607.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.514533,
       "repetition_rate": 0.6607142857142857
     },
     {
@@ -705,7 +1253,7 @@
       "success_rate": 0.0,
       "avg_steps": 27.0,
       "avg_tokens": 36117.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.172263,
       "repetition_rate": 0.7777777777777778
     },
     {
@@ -716,7 +1264,7 @@
       "success_rate": 0.0,
       "avg_steps": 86.0,
       "avg_tokens": 97188.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.448524,
       "repetition_rate": 0.7674418604651163
     },
     {
@@ -727,7 +1275,7 @@
       "success_rate": 0.0,
       "avg_steps": 66.0,
       "avg_tokens": 80552.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.392256,
       "repetition_rate": 0.9090909090909091
     },
     {
@@ -738,7 +1286,7 @@
       "success_rate": 0.0,
       "avg_steps": 29.0,
       "avg_tokens": 48239.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.236673,
       "repetition_rate": 0.5517241379310345
     },
     {
@@ -749,7 +1297,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 37280.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.17412,
       "repetition_rate": 0.8709677419354839
     },
     {
@@ -760,7 +1308,7 @@
       "success_rate": 0.0,
       "avg_steps": 29.0,
       "avg_tokens": 35299.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.173133,
       "repetition_rate": 0.8620689655172413
     },
     {
@@ -771,8 +1319,151 @@
       "success_rate": 0.0,
       "avg_steps": 50.0,
       "avg_tokens": 67707.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.295497,
       "repetition_rate": 0.7
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Banket_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 0.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.0
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Codebox_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 0.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.0
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Depth_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 16.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.390625
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Disk_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 7.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.5714285714285714
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Driver_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 19.5,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.3076923076923077
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Edelweiss_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 16.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.34375
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Election_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 0.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.0
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Foncers_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 29.5,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.6823529411764706
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Ministry_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 0.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.0
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Player_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 8.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.5
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Robots_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 12.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.4166666666666667
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Shashki_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 9.5,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.3684210526315789
+    },
+    {
+      "model": "claude:claude-haiku-4-5-20251001",
+      "mode": "stateful_compact",
+      "quest": "Sortirovka1_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 0.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.0
     },
     {
       "model": "deepseek-chat",
@@ -782,7 +1473,7 @@
       "success_rate": 0.0,
       "avg_steps": 47.0,
       "avg_tokens": 27847.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00780724,
       "repetition_rate": 0.7021276595744681
     },
     {
@@ -793,19 +1484,19 @@
       "success_rate": 0.0,
       "avg_steps": 24.0,
       "avg_tokens": 18613.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00521696,
       "repetition_rate": 0.6666666666666666
     },
     {
       "model": "deepseek-chat",
       "mode": "stub",
       "quest": "Boat",
-      "runs": 1,
+      "runs": 2,
       "success_rate": 1.0,
-      "avg_steps": 14.0,
-      "avg_tokens": 9263.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.7857142857142857
+      "avg_steps": 16.5,
+      "avg_tokens": 10810.0,
+      "avg_cost_usd": 0.00303037,
+      "repetition_rate": 0.8139097744360901
     },
     {
       "model": "deepseek-chat",
@@ -815,7 +1506,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 24917.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0069839,
       "repetition_rate": 0.7419354838709677
     },
     {
@@ -826,7 +1517,7 @@
       "success_rate": 0.0,
       "avg_steps": 37.0,
       "avg_tokens": 24038.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00673904,
       "repetition_rate": 0.6216216216216216
     },
     {
@@ -837,7 +1528,7 @@
       "success_rate": 0.0,
       "avg_steps": 11.0,
       "avg_tokens": 6524.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00182868,
       "repetition_rate": 0.7272727272727273
     },
     {
@@ -848,7 +1539,7 @@
       "success_rate": 0.0,
       "avg_steps": 46.0,
       "avg_tokens": 25258.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00708316,
       "repetition_rate": 0.782608695652174
     },
     {
@@ -859,7 +1550,7 @@
       "success_rate": 0.0,
       "avg_steps": 3.0,
       "avg_tokens": 1708.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0004788,
       "repetition_rate": 0.3333333333333333
     },
     {
@@ -870,7 +1561,7 @@
       "success_rate": 0.0,
       "avg_steps": 23.0,
       "avg_tokens": 13790.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0038661,
       "repetition_rate": 0.6521739130434783
     },
     {
@@ -881,7 +1572,7 @@
       "success_rate": 0.0,
       "avg_steps": 97.0,
       "avg_tokens": 58068.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01628032,
       "repetition_rate": 0.7731958762886598
     },
     {
@@ -892,7 +1583,7 @@
       "success_rate": 0.0,
       "avg_steps": 192.0,
       "avg_tokens": 105252.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02951326,
       "repetition_rate": 0.7604166666666666
     },
     {
@@ -903,7 +1594,7 @@
       "success_rate": 1.0,
       "avg_steps": 26.0,
       "avg_tokens": 16582.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00464884,
       "repetition_rate": 0.5769230769230769
     },
     {
@@ -914,7 +1605,7 @@
       "success_rate": 0.0,
       "avg_steps": 112.0,
       "avg_tokens": 66828.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01873732,
       "repetition_rate": 0.875
     },
     {
@@ -925,7 +1616,7 @@
       "success_rate": 0.0,
       "avg_steps": 59.0,
       "avg_tokens": 31440.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00881636,
       "repetition_rate": 0.8305084745762712
     },
     {
@@ -936,7 +1627,7 @@
       "success_rate": 1.0,
       "avg_steps": 54.0,
       "avg_tokens": 39869.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01117634,
       "repetition_rate": 0.5925925925925926
     },
     {
@@ -947,7 +1638,7 @@
       "success_rate": 1.0,
       "avg_steps": 29.0,
       "avg_tokens": 20484.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00586894,
       "repetition_rate": 0.8275862068965517
     },
     {
@@ -958,7 +1649,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 31974.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00912422,
       "repetition_rate": 0.6176470588235294
     },
     {
@@ -969,7 +1660,7 @@
       "success_rate": 1.0,
       "avg_steps": 19.0,
       "avg_tokens": 15113.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00431984,
       "repetition_rate": 0.8421052631578947
     },
     {
@@ -980,7 +1671,7 @@
       "success_rate": 0.0,
       "avg_steps": 13.0,
       "avg_tokens": 11452.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0032641,
       "repetition_rate": 0.6153846153846154
     },
     {
@@ -991,7 +1682,7 @@
       "success_rate": 0.0,
       "avg_steps": 33.0,
       "avg_tokens": 26968.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00770462,
       "repetition_rate": 0.6363636363636364
     },
     {
@@ -1002,7 +1693,7 @@
       "success_rate": 0.0,
       "avg_steps": 14.0,
       "avg_tokens": 10216.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00292558,
       "repetition_rate": 0.7857142857142857
     },
     {
@@ -1013,7 +1704,7 @@
       "success_rate": 0.0,
       "avg_steps": 44.0,
       "avg_tokens": 28649.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00822598,
       "repetition_rate": 0.7954545454545454
     },
     {
@@ -1024,7 +1715,7 @@
       "success_rate": 0.0,
       "avg_steps": 87.0,
       "avg_tokens": 88152.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02510592,
       "repetition_rate": 0.7471264367816092
     },
     {
@@ -1035,7 +1726,7 @@
       "success_rate": 0.0,
       "avg_steps": 27.0,
       "avg_tokens": 20137.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0057666,
       "repetition_rate": 0.6296296296296297
     },
     {
@@ -1046,7 +1737,7 @@
       "success_rate": 0.0,
       "avg_steps": 114.0,
       "avg_tokens": 85280.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0243936,
       "repetition_rate": 0.7719298245614035
     },
     {
@@ -1057,7 +1748,7 @@
       "success_rate": 0.0,
       "avg_steps": 36.0,
       "avg_tokens": 24781.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00710416,
       "repetition_rate": 0.8055555555555556
     },
     {
@@ -1068,7 +1759,7 @@
       "success_rate": 1.0,
       "avg_steps": 37.0,
       "avg_tokens": 28864.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00827456,
       "repetition_rate": 0.5675675675675675
     },
     {
@@ -1079,7 +1770,7 @@
       "success_rate": 0.0,
       "avg_steps": 212.0,
       "avg_tokens": 162505.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.04651458,
       "repetition_rate": 0.8113207547169812
     },
     {
@@ -1090,7 +1781,7 @@
       "success_rate": 0.0,
       "avg_steps": 27.0,
       "avg_tokens": 18552.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00532238,
       "repetition_rate": 0.7777777777777778
     },
     {
@@ -1101,7 +1792,7 @@
       "success_rate": 0.0,
       "avg_steps": 99.0,
       "avg_tokens": 87991.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02508366,
       "repetition_rate": 0.6363636363636364
     },
     {
@@ -1112,7 +1803,7 @@
       "success_rate": 1.0,
       "avg_steps": 28.0,
       "avg_tokens": 20553.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00589638,
       "repetition_rate": 0.8214285714285714
     },
     {
@@ -1123,7 +1814,7 @@
       "success_rate": 0.0,
       "avg_steps": 25.0,
       "avg_tokens": 23478.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00670586,
       "repetition_rate": 0.72
     },
     {
@@ -1134,7 +1825,7 @@
       "success_rate": 1.0,
       "avg_steps": 19.0,
       "avg_tokens": 15375.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00439488,
       "repetition_rate": 0.8421052631578947
     },
     {
@@ -1145,7 +1836,7 @@
       "success_rate": 0.0,
       "avg_steps": 19.0,
       "avg_tokens": 17803.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00506646,
       "repetition_rate": 0.7368421052631579
     },
     {
@@ -1156,7 +1847,7 @@
       "success_rate": 0.0,
       "avg_steps": 32.0,
       "avg_tokens": 26003.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00741846,
       "repetition_rate": 0.59375
     },
     {
@@ -1167,7 +1858,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 26552.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00759276,
       "repetition_rate": 0.7941176470588235
     },
     {
@@ -1178,7 +1869,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 22903.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0065646,
       "repetition_rate": 0.8387096774193549
     },
     {
@@ -1189,7 +1880,7 @@
       "success_rate": 0.0,
       "avg_steps": 58.0,
       "avg_tokens": 58206.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01657558,
       "repetition_rate": 0.7068965517241379
     },
     {
@@ -1200,7 +1891,7 @@
       "success_rate": 0.0,
       "avg_steps": 37.0,
       "avg_tokens": 28454.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00813372,
       "repetition_rate": 0.6756756756756757
     },
     {
@@ -1211,7 +1902,7 @@
       "success_rate": 0.0,
       "avg_steps": 116.0,
       "avg_tokens": 88347.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02526594,
       "repetition_rate": 0.7413793103448276
     },
     {
@@ -1222,7 +1913,7 @@
       "success_rate": 0.0,
       "avg_steps": 103.0,
       "avg_tokens": 70990.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02034844,
       "repetition_rate": 0.8640776699029126
     },
     {
@@ -1233,7 +1924,7 @@
       "success_rate": 1.0,
       "avg_steps": 23.0,
       "avg_tokens": 18276.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00523824,
       "repetition_rate": 0.5652173913043478
     },
     {
@@ -1244,7 +1935,7 @@
       "success_rate": 0.0,
       "avg_steps": 201.0,
       "avg_tokens": 160860.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.04611138,
       "repetition_rate": 0.8507462686567164
     },
     {
@@ -1255,7 +1946,7 @@
       "success_rate": 0.0,
       "avg_steps": 46.0,
       "avg_tokens": 31775.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00911274,
       "repetition_rate": 0.8478260869565217
     },
     {
@@ -1266,7 +1957,7 @@
       "success_rate": 1.0,
       "avg_steps": 83.0,
       "avg_tokens": 75220.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02146214,
       "repetition_rate": 0.7108433734939759
     },
     {
@@ -1277,7 +1968,7 @@
       "success_rate": 1.0,
       "avg_steps": 28.0,
       "avg_tokens": 28636.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00849716,
       "repetition_rate": 0.8214285714285714
     },
     {
@@ -1288,7 +1979,7 @@
       "success_rate": 0.0,
       "avg_steps": 33.0,
       "avg_tokens": 48068.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0140805,
       "repetition_rate": 0.6363636363636364
     },
     {
@@ -1299,7 +1990,7 @@
       "success_rate": 1.0,
       "avg_steps": 19.0,
       "avg_tokens": 18163.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00536536,
       "repetition_rate": 0.7368421052631579
     },
     {
@@ -1310,7 +2001,7 @@
       "success_rate": 0.0,
       "avg_steps": 16.0,
       "avg_tokens": 17939.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00526246,
       "repetition_rate": 0.75
     },
     {
@@ -1321,7 +2012,7 @@
       "success_rate": 0.0,
       "avg_steps": 110.0,
       "avg_tokens": 104536.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.03063368,
       "repetition_rate": 0.6909090909090909
     },
     {
@@ -1332,7 +2023,7 @@
       "success_rate": 0.0,
       "avg_steps": 11.0,
       "avg_tokens": 12383.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00365106,
       "repetition_rate": 0.7272727272727273
     },
     {
@@ -1343,7 +2034,7 @@
       "success_rate": 0.0,
       "avg_steps": 74.0,
       "avg_tokens": 62211.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0184261,
       "repetition_rate": 0.7297297297297297
     },
     {
@@ -1354,7 +2045,7 @@
       "success_rate": 0.0,
       "avg_steps": 47.0,
       "avg_tokens": 72984.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0213073,
       "repetition_rate": 0.7659574468085106
     },
     {
@@ -1365,7 +2056,7 @@
       "success_rate": 0.0,
       "avg_steps": 32.0,
       "avg_tokens": 28320.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00831922,
       "repetition_rate": 0.78125
     },
     {
@@ -1376,7 +2067,7 @@
       "success_rate": 0.0,
       "avg_steps": 115.0,
       "avg_tokens": 86425.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02536002,
       "repetition_rate": 0.7739130434782608
     },
     {
@@ -1387,7 +2078,7 @@
       "success_rate": 0.0,
       "avg_steps": 74.0,
       "avg_tokens": 71040.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02117332,
       "repetition_rate": 0.8783783783783784
     },
     {
@@ -1398,7 +2089,7 @@
       "success_rate": 0.0,
       "avg_steps": 18.0,
       "avg_tokens": 21103.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00624652,
       "repetition_rate": 0.5
     },
     {
@@ -1409,7 +2100,7 @@
       "success_rate": 0.0,
       "avg_steps": 113.0,
       "avg_tokens": 97851.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02884028,
       "repetition_rate": 0.8495575221238938
     },
     {
@@ -1420,7 +2111,7 @@
       "success_rate": 0.0,
       "avg_steps": 32.0,
       "avg_tokens": 27414.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00811762,
       "repetition_rate": 0.71875
     },
     {
@@ -1431,41 +2122,624 @@
       "success_rate": 0.0,
       "avg_steps": 101.0,
       "avg_tokens": 121008.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.03537744,
       "repetition_rate": 0.6831683168316832
+    },
+    {
+      "model": "deepseek-chat-v3-0324",
+      "mode": "stateful_compact",
+      "quest": "Disk_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 6.0,
+      "avg_tokens": 4348.333333333333,
+      "avg_cost_usd": 0.0010448466666666666,
+      "repetition_rate": 0.5119047619047619
+    },
+    {
+      "model": "deepseek-chat-v3-0324",
+      "mode": "stateful_compact",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 78.66666666666667,
+      "avg_tokens": 273681.0,
+      "avg_cost_usd": 0.05831979,
+      "repetition_rate": 0.7378901652100874
+    },
+    {
+      "model": "deepseek-chat-v3-0324",
+      "mode": "stateful_compact",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 94.0,
+      "avg_tokens": 318489.3333333333,
+      "avg_cost_usd": 0.06764245666666667,
+      "repetition_rate": 0.7274608144903039
+    },
+    {
+      "model": "deepseek-chat-v3-0324",
+      "mode": "stateful_compact",
+      "quest": "Pilot_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 11.666666666666666,
+      "avg_tokens": 13001.333333333334,
+      "avg_cost_usd": 0.0029943266666666666,
+      "repetition_rate": 0.4682539682539682
+    },
+    {
+      "model": "deepseek-chat-v3-0324",
+      "mode": "stateful_compact",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 46.333333333333336,
+      "avg_tokens": 112612.0,
+      "avg_cost_usd": 0.0241678,
+      "repetition_rate": 0.755888007690459
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 20.0,
+      "avg_tokens": 11370.333333333334,
+      "avg_cost_usd": 0.002948136666666667,
+      "repetition_rate": 0.85
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.666666666666664,
+      "avg_tokens": 26234.666666666668,
+      "avg_cost_usd": 0.006800199999999999,
+      "repetition_rate": 0.7228163992869875
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Boat",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 15.333333333333334,
+      "avg_tokens": 10074.333333333334,
+      "avg_cost_usd": 0.002611723333333333,
+      "repetition_rate": 0.7797619047619048
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 20.333333333333332,
+      "avg_tokens": 15701.666666666666,
+      "avg_cost_usd": 0.004070003333333333,
+      "repetition_rate": 0.759557945041816
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 51.0,
+      "avg_tokens": 32843.666666666664,
+      "avg_cost_usd": 0.008514723333333333,
+      "repetition_rate": 0.6786142380654576
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 84.0,
+      "avg_tokens": 53514.0,
+      "avg_cost_usd": 0.01387365,
+      "repetition_rate": 0.7145971077499018
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 31.0,
+      "avg_tokens": 18124.0,
+      "avg_cost_usd": 0.004699106666666667,
+      "repetition_rate": 0.6989247311827956
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 3.0,
+      "avg_tokens": 1710.0,
+      "avg_cost_usd": 0.00044337,
+      "repetition_rate": 0.3333333333333333
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 35.333333333333336,
+      "avg_tokens": 20979.0,
+      "avg_cost_usd": 0.00543925,
+      "repetition_rate": 0.6935165609584214
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 89.33333333333333,
+      "avg_tokens": 53539.0,
+      "avg_cost_usd": 0.013880983333333333,
+      "repetition_rate": 0.7758295085102315
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 110.33333333333333,
+      "avg_tokens": 59065.0,
+      "avg_cost_usd": 0.015315596666666667,
+      "repetition_rate": 0.8107463524130191
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 28.333333333333332,
+      "avg_tokens": 17896.333333333332,
+      "avg_cost_usd": 0.004639713333333333,
+      "repetition_rate": 0.5268817204301075
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Prison_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 346.0,
+      "avg_tokens": 209976.33333333334,
+      "avg_cost_usd": 0.05443957666666666,
+      "repetition_rate": 0.8575339999022735
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 59.666666666666664,
+      "avg_tokens": 31557.0,
+      "avg_cost_usd": 0.00818287,
+      "repetition_rate": 0.7725235995253529
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "stub",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 49.666666666666664,
+      "avg_tokens": 36297.333333333336,
+      "avg_cost_usd": 0.009409006666666666,
+      "repetition_rate": 0.6120136943666356
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Badday_eng",
+      "runs": 12,
+      "success_rate": 0.16666666666666666,
+      "avg_steps": 41.583333333333336,
+      "avg_tokens": 67913.5,
+      "avg_cost_usd": 0.0173951675,
+      "repetition_rate": 0.7181676881433127
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Banket_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 41.916666666666664,
+      "avg_tokens": 81835.41666666667,
+      "avg_cost_usd": 0.020912323333333333,
+      "repetition_rate": 0.7092106211057639
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Boat",
+      "runs": 12,
+      "success_rate": 0.5,
+      "avg_steps": 21.25,
+      "avg_tokens": 40104.666666666664,
+      "avg_cost_usd": 0.010256600833333334,
+      "repetition_rate": 0.7216626097112715
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Codebox_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 49.916666666666664,
+      "avg_tokens": 111280.0,
+      "avg_cost_usd": 0.028359857500000002,
+      "repetition_rate": 0.7160735664822767
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Depth_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 62.0,
+      "avg_tokens": 115230.25,
+      "avg_cost_usd": 0.029462324999999998,
+      "repetition_rate": 0.7136891656453952
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Driver_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 43.5,
+      "avg_tokens": 133852.58333333334,
+      "avg_cost_usd": 0.034024640833333335,
+      "repetition_rate": 0.7154813788861457
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Edelweiss_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 69.41666666666667,
+      "avg_tokens": 98389.91666666667,
+      "avg_cost_usd": 0.025245936666666666,
+      "repetition_rate": 0.7388870365697752
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Election_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 103.08333333333333,
+      "avg_tokens": 228443.16666666666,
+      "avg_cost_usd": 0.058307961666666665,
+      "repetition_rate": 0.7762995797489115
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Foncers_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 44.0,
+      "avg_tokens": 97667.58333333333,
+      "avg_cost_usd": 0.02490410833333333,
+      "repetition_rate": 0.66654554115581
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Leonardo_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 93.5,
+      "avg_tokens": 112207.16666666667,
+      "avg_cost_usd": 0.028952143333333333,
+      "repetition_rate": 0.7465875186548164
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Ministry_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 58.416666666666664,
+      "avg_tokens": 61781.166666666664,
+      "avg_cost_usd": 0.016049614166666667,
+      "repetition_rate": 0.7911630128440114
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Pizza_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 55.333333333333336,
+      "avg_tokens": 141246.25,
+      "avg_cost_usd": 0.035964665,
+      "repetition_rate": 0.6294022950496094
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Prison_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 43.25,
+      "avg_tokens": 36118.5,
+      "avg_cost_usd": 0.009577879999999999,
+      "repetition_rate": 0.42410169708016593
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Robots_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 15.666666666666666,
+      "avg_tokens": 14690.833333333334,
+      "avg_cost_usd": 0.003839368333333333,
+      "repetition_rate": 0.4014279044127023
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "reasoning",
+      "quest": "Ski_eng",
+      "runs": 12,
+      "success_rate": 0.08333333333333333,
+      "avg_steps": 28.5,
+      "avg_tokens": 31074.25,
+      "avg_cost_usd": 0.0081310775,
+      "repetition_rate": 0.33820806100217865
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Badday_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 31.5,
+      "avg_tokens": 62155.0,
+      "avg_cost_usd": 0.00947618,
+      "repetition_rate": 0.7933467741935484
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Banket_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 33.5,
+      "avg_tokens": 84460.5,
+      "avg_cost_usd": 0.013163290000000001,
+      "repetition_rate": 0.7165178571428572
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Codebox_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 100470.0,
+      "avg_cost_usd": 0.016408560000000003,
+      "repetition_rate": 0.890625
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Depth_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 39.0,
+      "avg_tokens": 112175.5,
+      "avg_cost_usd": 0.01790873,
+      "repetition_rate": 0.8549465240641712
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Disk_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 7.0,
+      "avg_tokens": 7006.0,
+      "avg_cost_usd": 0.00118986,
+      "repetition_rate": 0.7142857142857143
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Driver_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 33.5,
+      "avg_tokens": 82216.0,
+      "avg_cost_usd": 0.012972190000000001,
+      "repetition_rate": 0.7620535714285714
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Edelweiss_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 27.0,
+      "avg_tokens": 80832.5,
+      "avg_cost_usd": 0.01260504,
+      "repetition_rate": 0.37037037037037035
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Election_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 85.5,
+      "avg_tokens": 331065.5,
+      "avg_cost_usd": 0.05071325,
+      "repetition_rate": 0.7900385250412769
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Foncers_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 43.0,
+      "avg_tokens": 113241.0,
+      "avg_cost_usd": 0.01821519,
+      "repetition_rate": 0.7795138888888888
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Leonardo_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 40.0,
+      "avg_tokens": 141124.0,
+      "avg_cost_usd": 0.02137499,
+      "repetition_rate": 0.3625
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Ministry_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 26.0,
+      "avg_tokens": 75176.5,
+      "avg_cost_usd": 0.01131907,
+      "repetition_rate": 0.3557692307692308
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Pilot_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 30.0,
+      "avg_tokens": 68757.5,
+      "avg_cost_usd": 0.01081318,
+      "repetition_rate": 0.734375
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Pizza_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 76650.5,
+      "avg_cost_usd": 0.01276912,
+      "repetition_rate": 0.734375
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Player_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 8.0,
+      "avg_tokens": 9915.0,
+      "avg_cost_usd": 0.00172277,
+      "repetition_rate": 0.625
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Robots_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 63.5,
+      "avg_tokens": 174904.5,
+      "avg_cost_usd": 0.02713683,
+      "repetition_rate": 0.7716423948220065
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Shashki_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 35937.5,
+      "avg_cost_usd": 0.00635047,
+      "repetition_rate": 0.868421052631579
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Ski_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 36.0,
+      "avg_tokens": 100329.5,
+      "avg_cost_usd": 0.016128629999999998,
+      "repetition_rate": 0.596875
+    },
+    {
+      "model": "deepseek-v4-flash",
+      "mode": "stateful_compact",
+      "quest": "Sortirovka1_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 0.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.0
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "stub",
       "quest": "Badday_eng",
-      "runs": 1,
+      "runs": 2,
       "success_rate": 0.0,
-      "avg_steps": 33.0,
-      "avg_tokens": 19112.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8484848484848485
+      "avg_steps": 31.5,
+      "avg_tokens": 12520.0,
+      "avg_cost_usd": 0.0038022,
+      "repetition_rate": 0.8409090909090909
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "stub",
       "quest": "Banket_eng",
-      "runs": 1,
+      "runs": 2,
       "success_rate": 0.0,
-      "avg_steps": 26.0,
-      "avg_tokens": 20963.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.5769230769230769
+      "avg_steps": 23.5,
+      "avg_tokens": 10481.5,
+      "avg_cost_usd": 0.00317305,
+      "repetition_rate": 0.7646520146520146
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "stub",
       "quest": "Boat",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 19.0,
-      "avg_tokens": 11944.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.7368421052631579
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 18.0,
+      "avg_tokens": 9203.0,
+      "avg_cost_usd": 0.0027931666666666665,
+      "repetition_rate": 0.7763157894736842
     },
     {
       "model": "gemini-2.5-flash",
@@ -1475,7 +2749,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 25719.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0077839,
       "repetition_rate": 0.7741935483870968
     },
     {
@@ -1486,7 +2760,7 @@
       "success_rate": 0.0,
       "avg_steps": 36.0,
       "avg_tokens": 25243.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0076521,
       "repetition_rate": 0.6944444444444444
     },
     {
@@ -1497,7 +2771,7 @@
       "success_rate": 0.0,
       "avg_steps": 69.0,
       "avg_tokens": 45808.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0138942,
       "repetition_rate": 0.782608695652174
     },
     {
@@ -1508,7 +2782,7 @@
       "success_rate": 0.0,
       "avg_steps": 59.0,
       "avg_tokens": 33160.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0100778,
       "repetition_rate": 0.7796610169491526
     },
     {
@@ -1519,7 +2793,7 @@
       "success_rate": 0.0,
       "avg_steps": 44.0,
       "avg_tokens": 38756.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0117236,
       "repetition_rate": 0.7045454545454546
     },
     {
@@ -1530,7 +2804,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 18749.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0056929,
       "repetition_rate": 0.5806451612903226
     },
     {
@@ -1541,7 +2815,7 @@
       "success_rate": 0.0,
       "avg_steps": 81.0,
       "avg_tokens": 51006.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01548,
       "repetition_rate": 0.7530864197530864
     },
     {
@@ -1552,7 +2826,7 @@
       "success_rate": 0.0,
       "avg_steps": 122.0,
       "avg_tokens": 70141.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0213107,
       "repetition_rate": 0.7540983606557377
     },
     {
@@ -1563,7 +2837,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 19951.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0060535,
       "repetition_rate": 0.6129032258064516
     },
     {
@@ -1574,7 +2848,7 @@
       "success_rate": 0.0,
       "avg_steps": 325.0,
       "avg_tokens": 205555.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0623815,
       "repetition_rate": 0.8307692307692308
     },
     {
@@ -1585,7 +2859,7 @@
       "success_rate": 0.0,
       "avg_steps": 40.0,
       "avg_tokens": 22092.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0067156,
       "repetition_rate": 0.75
     },
     {
@@ -1596,41 +2870,41 @@
       "success_rate": 0.0,
       "avg_steps": 59.0,
       "avg_tokens": 48676.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0148844,
       "repetition_rate": 0.6779661016949152
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "reasoning",
       "quest": "Badday_eng",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 30.0,
-      "avg_tokens": 22720.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8
+      "runs": 2,
+      "success_rate": 0.5,
+      "avg_steps": 28.5,
+      "avg_tokens": 11360.0,
+      "avg_cost_usd": 0.0052527,
+      "repetition_rate": 0.8814814814814815
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "reasoning",
       "quest": "Banket_eng",
-      "runs": 1,
+      "runs": 2,
       "success_rate": 0.0,
-      "avg_steps": 33.0,
-      "avg_tokens": 32571.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.696969696969697
+      "avg_steps": 19.5,
+      "avg_tokens": 16285.5,
+      "avg_cost_usd": 0.00707905,
+      "repetition_rate": 0.7651515151515151
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "reasoning",
       "quest": "Boat",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 19.0,
-      "avg_tokens": 15250.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.6842105263157895
+      "runs": 2,
+      "success_rate": 0.5,
+      "avg_steps": 14.5,
+      "avg_tokens": 7625.0,
+      "avg_cost_usd": 0.0035349,
+      "repetition_rate": 0.7921052631578948
     },
     {
       "model": "gemini-2.5-flash",
@@ -1640,7 +2914,7 @@
       "success_rate": 0.0,
       "avg_steps": 14.0,
       "avg_tokens": 13190.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0057566,
       "repetition_rate": 0.6428571428571429
     },
     {
@@ -1651,7 +2925,7 @@
       "success_rate": 0.0,
       "avg_steps": 32.0,
       "avg_tokens": 27518.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0121604,
       "repetition_rate": 0.6875
     },
     {
@@ -1662,7 +2936,7 @@
       "success_rate": 0.0,
       "avg_steps": 78.0,
       "avg_tokens": 65540.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0287326,
       "repetition_rate": 0.8076923076923077
     },
     {
@@ -1673,7 +2947,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 24116.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.011131,
       "repetition_rate": 0.7419354838709677
     },
     {
@@ -1684,7 +2958,7 @@
       "success_rate": 0.0,
       "avg_steps": 68.0,
       "avg_tokens": 72534.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0303952,
       "repetition_rate": 0.7352941176470589
     },
     {
@@ -1695,7 +2969,7 @@
       "success_rate": 0.0,
       "avg_steps": 30.0,
       "avg_tokens": 23512.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0110136,
       "repetition_rate": 0.7
     },
     {
@@ -1706,7 +2980,7 @@
       "success_rate": 0.0,
       "avg_steps": 112.0,
       "avg_tokens": 89509.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0402793,
       "repetition_rate": 0.7767857142857143
     },
     {
@@ -1717,7 +2991,7 @@
       "success_rate": 0.0,
       "avg_steps": 149.0,
       "avg_tokens": 111612.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0526236,
       "repetition_rate": 0.7315436241610739
     },
     {
@@ -1728,7 +3002,7 @@
       "success_rate": 0.0,
       "avg_steps": 45.0,
       "avg_tokens": 37388.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0173016,
       "repetition_rate": 0.5555555555555556
     },
     {
@@ -1739,7 +3013,7 @@
       "success_rate": 0.0,
       "avg_steps": 330.0,
       "avg_tokens": 272571.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.1246955,
       "repetition_rate": 0.8272727272727273
     },
     {
@@ -1750,7 +3024,7 @@
       "success_rate": 0.0,
       "avg_steps": 109.0,
       "avg_tokens": 80020.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0368672,
       "repetition_rate": 0.8440366972477065
     },
     {
@@ -1761,41 +3035,41 @@
       "success_rate": 0.0,
       "avg_steps": 50.0,
       "avg_tokens": 49160.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0213348,
       "repetition_rate": 0.66
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "light_hints",
       "quest": "Badday_eng",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 30.0,
-      "avg_tokens": 23045.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8333333333333334
+      "runs": 2,
+      "success_rate": 0.5,
+      "avg_steps": 28.5,
+      "avg_tokens": 11522.5,
+      "avg_cost_usd": 0.00525085,
+      "repetition_rate": 0.8981481481481481
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "light_hints",
       "quest": "Banket_eng",
-      "runs": 1,
+      "runs": 2,
       "success_rate": 0.0,
-      "avg_steps": 22.0,
-      "avg_tokens": 21621.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.6818181818181818
+      "avg_steps": 14.0,
+      "avg_tokens": 10810.5,
+      "avg_cost_usd": 0.00469185,
+      "repetition_rate": 0.7575757575757576
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "light_hints",
       "quest": "Boat",
-      "runs": 1,
+      "runs": 2,
       "success_rate": 1.0,
-      "avg_steps": 19.0,
-      "avg_tokens": 15604.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8421052631578947
+      "avg_steps": 18.5,
+      "avg_tokens": 7802.0,
+      "avg_cost_usd": 0.0036353,
+      "repetition_rate": 0.8932748538011696
     },
     {
       "model": "gemini-2.5-flash",
@@ -1805,7 +3079,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 31749.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0137553,
       "repetition_rate": 0.7419354838709677
     },
     {
@@ -1816,7 +3090,7 @@
       "success_rate": 0.0,
       "avg_steps": 35.0,
       "avg_tokens": 31234.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0142498,
       "repetition_rate": 0.6571428571428571
     },
     {
@@ -1827,7 +3101,7 @@
       "success_rate": 0.0,
       "avg_steps": 94.0,
       "avg_tokens": 80831.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0363405,
       "repetition_rate": 0.8085106382978723
     },
     {
@@ -1838,7 +3112,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 25348.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0117492,
       "repetition_rate": 0.6764705882352942
     },
     {
@@ -1849,7 +3123,7 @@
       "success_rate": 0.0,
       "avg_steps": 65.0,
       "avg_tokens": 70820.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0311064,
       "repetition_rate": 0.676923076923077
     },
     {
@@ -1860,7 +3134,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 23997.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0114935,
       "repetition_rate": 0.6451612903225806
     },
     {
@@ -1871,7 +3145,7 @@
       "success_rate": 0.0,
       "avg_steps": 108.0,
       "avg_tokens": 88061.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0397085,
       "repetition_rate": 0.8055555555555556
     },
     {
@@ -1882,7 +3156,7 @@
       "success_rate": 0.0,
       "avg_steps": 379.0,
       "avg_tokens": 287811.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.1341735,
       "repetition_rate": 0.7361477572559367
     },
     {
@@ -1893,7 +3167,7 @@
       "success_rate": 1.0,
       "avg_steps": 35.0,
       "avg_tokens": 29818.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0138998,
       "repetition_rate": 0.5428571428571428
     },
     {
@@ -1904,7 +3178,7 @@
       "success_rate": 0.0,
       "avg_steps": 44.0,
       "avg_tokens": 34697.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0159047,
       "repetition_rate": 0.7727272727272727
     },
     {
@@ -1915,7 +3189,7 @@
       "success_rate": 0.0,
       "avg_steps": 33.0,
       "avg_tokens": 24564.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0111972,
       "repetition_rate": 0.7575757575757576
     },
     {
@@ -1926,41 +3200,41 @@
       "success_rate": 0.0,
       "avg_steps": 65.0,
       "avg_tokens": 65880.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0286212,
       "repetition_rate": 0.6461538461538462
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "planner",
       "quest": "Badday_eng",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 25.0,
-      "avg_tokens": 28221.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.76
+      "runs": 2,
+      "success_rate": 0.5,
+      "avg_steps": 26.0,
+      "avg_tokens": 14110.5,
+      "avg_cost_usd": 0.00854185,
+      "repetition_rate": 0.8614814814814815
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "planner",
       "quest": "Banket_eng",
-      "runs": 1,
+      "runs": 2,
       "success_rate": 0.0,
-      "avg_steps": 27.0,
-      "avg_tokens": 40587.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.6666666666666666
+      "avg_steps": 16.5,
+      "avg_tokens": 20293.5,
+      "avg_cost_usd": 0.01075865,
+      "repetition_rate": 0.75
     },
     {
       "model": "gemini-2.5-flash",
       "mode": "planner",
       "quest": "Boat",
-      "runs": 1,
+      "runs": 2,
       "success_rate": 1.0,
-      "avg_steps": 19.0,
-      "avg_tokens": 17446.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8421052631578947
+      "avg_steps": 16.0,
+      "avg_tokens": 8723.0,
+      "avg_cost_usd": 0.0050556,
+      "repetition_rate": 0.8825910931174089
     },
     {
       "model": "gemini-2.5-flash",
@@ -1970,7 +3244,7 @@
       "success_rate": 0.0,
       "avg_steps": 16.0,
       "avg_tokens": 19131.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0118355,
       "repetition_rate": 0.6875
     },
     {
@@ -1981,7 +3255,7 @@
       "success_rate": 0.0,
       "avg_steps": 36.0,
       "avg_tokens": 39776.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0227304,
       "repetition_rate": 0.6666666666666666
     },
     {
@@ -1992,7 +3266,7 @@
       "success_rate": 0.0,
       "avg_steps": 79.0,
       "avg_tokens": 87262.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0506162,
       "repetition_rate": 0.8227848101265823
     },
     {
@@ -2003,7 +3277,7 @@
       "success_rate": 0.0,
       "avg_steps": 32.0,
       "avg_tokens": 31518.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.019989,
       "repetition_rate": 0.84375
     },
     {
@@ -2014,7 +3288,7 @@
       "success_rate": 0.0,
       "avg_steps": 46.0,
       "avg_tokens": 74457.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0382695,
       "repetition_rate": 0.6739130434782609
     },
     {
@@ -2025,7 +3299,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 31349.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0190891,
       "repetition_rate": 0.6774193548387096
     },
     {
@@ -2036,7 +3310,7 @@
       "success_rate": 0.0,
       "avg_steps": 109.0,
       "avg_tokens": 88542.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0535302,
       "repetition_rate": 0.7981651376146789
     },
     {
@@ -2047,7 +3321,7 @@
       "success_rate": 0.0,
       "avg_steps": 40.0,
       "avg_tokens": 39691.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0243659,
       "repetition_rate": 0.875
     },
     {
@@ -2058,7 +3332,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 39541.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0237071,
       "repetition_rate": 0.4838709677419355
     },
     {
@@ -2069,7 +3343,7 @@
       "success_rate": 0.0,
       "avg_steps": 251.0,
       "avg_tokens": 232379.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.1406989,
       "repetition_rate": 0.8406374501992032
     },
     {
@@ -2080,7 +3354,7 @@
       "success_rate": 0.0,
       "avg_steps": 117.0,
       "avg_tokens": 100114.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0633862,
       "repetition_rate": 0.8205128205128205
     },
     {
@@ -2091,8 +3365,1889 @@
       "success_rate": 0.0,
       "avg_steps": 49.0,
       "avg_tokens": 60306.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0327394,
       "repetition_rate": 0.7551020408163265
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 26.666666666666668,
+      "avg_tokens": 15646.0,
+      "avg_cost_usd": 0.007889666666666666,
+      "repetition_rate": 0.7976190476190476
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.333333333333336,
+      "avg_tokens": 27293.666666666668,
+      "avg_cost_usd": 0.013730166666666668,
+      "repetition_rate": 0.6203208556149732
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Boat",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 20.0,
+      "avg_tokens": 12675.0,
+      "avg_cost_usd": 0.0063875,
+      "repetition_rate": 0.8666666666666667
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 20.0,
+      "avg_tokens": 15925.666666666666,
+      "avg_cost_usd": 0.008012833333333332,
+      "repetition_rate": 0.8055555555555557
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 59.666666666666664,
+      "avg_tokens": 41832.666666666664,
+      "avg_cost_usd": 0.0210655,
+      "repetition_rate": 0.6493640699523052
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 97.66666666666667,
+      "avg_tokens": 65099.666666666664,
+      "avg_cost_usd": 0.032794,
+      "repetition_rate": 0.7271526172139838
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 69.33333333333333,
+      "avg_tokens": 39386.333333333336,
+      "avg_cost_usd": 0.0198665,
+      "repetition_rate": 0.7061599126925294
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 53.0,
+      "avg_tokens": 47015.666666666664,
+      "avg_cost_usd": 0.023640333333333333,
+      "repetition_rate": 0.6818181818181818
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 29.0,
+      "avg_tokens": 17429.666666666668,
+      "avg_cost_usd": 0.008787333333333333,
+      "repetition_rate": 0.6429939792008758
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 81.66666666666667,
+      "avg_tokens": 51678.0,
+      "avg_cost_usd": 0.02604316666666667,
+      "repetition_rate": 0.7386757789535568
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 213.33333333333334,
+      "avg_tokens": 118540.0,
+      "avg_cost_usd": 0.05980333333333334,
+      "repetition_rate": 0.7278965119600652
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 27.0,
+      "avg_tokens": 17625.0,
+      "avg_cost_usd": 0.00888,
+      "repetition_rate": 0.49204301075268814
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Prison_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 366.0,
+      "avg_tokens": 235639.33333333334,
+      "avg_cost_usd": 0.11886883333333333,
+      "repetition_rate": 0.8418640217902591
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 71.33333333333333,
+      "avg_tokens": 39480.666666666664,
+      "avg_cost_usd": 0.019918666666666664,
+      "repetition_rate": 0.8420356446672236
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stub",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 60.666666666666664,
+      "avg_tokens": 48425.0,
+      "avg_cost_usd": 0.02436416666666667,
+      "repetition_rate": 0.6684725393201422
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Badday_eng",
+      "runs": 22,
+      "success_rate": 0.13636363636363635,
+      "avg_steps": 28.181818181818183,
+      "avg_tokens": 51373.86363636364,
+      "avg_cost_usd": 0.03039375,
+      "repetition_rate": 0.7457214162182509
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Banket_eng",
+      "runs": 22,
+      "success_rate": 0.0,
+      "avg_steps": 30.318181818181817,
+      "avg_tokens": 67494.0,
+      "avg_cost_usd": 0.03928120454545454,
+      "repetition_rate": 0.593016684339595
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Boat",
+      "runs": 18,
+      "success_rate": 1.0,
+      "avg_steps": 20.77777777777778,
+      "avg_tokens": 24107.222222222223,
+      "avg_cost_usd": 0.015716666666666667,
+      "repetition_rate": 0.8332586273375747
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Borzukhan_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 30.666666666666668,
+      "avg_tokens": 23340.333333333332,
+      "avg_cost_usd": 0.016631,
+      "repetition_rate": 0.6845238095238096
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Codebox_eng",
+      "runs": 22,
+      "success_rate": 0.0,
+      "avg_steps": 31.40909090909091,
+      "avg_tokens": 86543.0,
+      "avg_cost_usd": 0.04916911363636364,
+      "repetition_rate": 0.733535326500311
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Depth_eng",
+      "runs": 22,
+      "success_rate": 0.0,
+      "avg_steps": 50.27272727272727,
+      "avg_tokens": 128392.45454545454,
+      "avg_cost_usd": 0.07357372727272728,
+      "repetition_rate": 0.6730498423261184
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Diehard",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 37.0,
+      "avg_tokens": 30366.0,
+      "avg_cost_usd": 0.021512166666666666,
+      "repetition_rate": 0.8288288288288288
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Disk_eng",
+      "runs": 10,
+      "success_rate": 0.2,
+      "avg_steps": 7.4,
+      "avg_tokens": 6634.9,
+      "avg_cost_usd": 0.0043771999999999995,
+      "repetition_rate": 0.5904761904761904
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Driver_eng",
+      "runs": 22,
+      "success_rate": 0.0,
+      "avg_steps": 74.0909090909091,
+      "avg_tokens": 251898.9090909091,
+      "avg_cost_usd": 0.13861218181818183,
+      "repetition_rate": 0.7092470892608362
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Edelweiss_eng",
+      "runs": 25,
+      "success_rate": 0.0,
+      "avg_steps": 56.16,
+      "avg_tokens": 104016.68,
+      "avg_cost_usd": 0.06127373999999999,
+      "repetition_rate": 0.7082774293977759
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Election_eng",
+      "runs": 25,
+      "success_rate": 0.04,
+      "avg_steps": 69.08,
+      "avg_tokens": 281224.76,
+      "avg_cost_usd": 0.15306638,
+      "repetition_rate": 0.688799368221561
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Foncers_eng",
+      "runs": 25,
+      "success_rate": 0.0,
+      "avg_steps": 44.2,
+      "avg_tokens": 86972.92,
+      "avg_cost_usd": 0.05134706000000001,
+      "repetition_rate": 0.684059961313163
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Gobsaur",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 4.0,
+      "avg_tokens": 2567.6666666666665,
+      "avg_cost_usd": 0.0020155,
+      "repetition_rate": 0.5833333333333334
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Hachball",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 44.666666666666664,
+      "avg_tokens": 38022.0,
+      "avg_cost_usd": 0.0272235,
+      "repetition_rate": 0.8506734006734007
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Leonardo_eng",
+      "runs": 22,
+      "success_rate": 0.045454545454545456,
+      "avg_steps": 115.04545454545455,
+      "avg_tokens": 369840.5909090909,
+      "avg_cost_usd": 0.20514154545454544,
+      "repetition_rate": 0.782190391478785
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Logic_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 12.0,
+      "avg_tokens": 9877.0,
+      "avg_cost_usd": 0.006967666666666666,
+      "repetition_rate": 0.6111111111111112
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Ministry_eng",
+      "runs": 25,
+      "success_rate": 0.04,
+      "avg_steps": 121.36,
+      "avg_tokens": 340380.0,
+      "avg_cost_usd": 0.19022480000000003,
+      "repetition_rate": 0.7583048246840651
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Muzon_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.0,
+      "avg_tokens": 26905.666666666668,
+      "avg_cost_usd": 0.01910116666666667,
+      "repetition_rate": 0.8076339431178141
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Pilot_eng",
+      "runs": 13,
+      "success_rate": 0.23076923076923078,
+      "avg_steps": 17.307692307692307,
+      "avg_tokens": 51192.53846153846,
+      "avg_cost_usd": 0.02858992307692308,
+      "repetition_rate": 0.5278896885708031
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Pizza_eng",
+      "runs": 22,
+      "success_rate": 0.18181818181818182,
+      "avg_steps": 34.09090909090909,
+      "avg_tokens": 68807.95454545454,
+      "avg_cost_usd": 0.04063409090909091,
+      "repetition_rate": 0.5163704267984761
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Player_eng",
+      "runs": 13,
+      "success_rate": 0.0,
+      "avg_steps": 7.769230769230769,
+      "avg_tokens": 7454.461538461538,
+      "avg_cost_usd": 0.004967038461538462,
+      "repetition_rate": 0.5164835164835165
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Prison_eng",
+      "runs": 12,
+      "success_rate": 0.0,
+      "avg_steps": 76.91666666666667,
+      "avg_tokens": 126717.5,
+      "avg_cost_usd": 0.077118125,
+      "repetition_rate": 0.7927038415852895
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Robots_eng",
+      "runs": 25,
+      "success_rate": 0.04,
+      "avg_steps": 52.0,
+      "avg_tokens": 172127.56,
+      "avg_cost_usd": 0.09590258,
+      "repetition_rate": 0.7498602432810437
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Rush",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 31.666666666666668,
+      "avg_tokens": 25026.333333333332,
+      "avg_cost_usd": 0.017813166666666668,
+      "repetition_rate": 0.852486559139785
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Shashki_eng",
+      "runs": 13,
+      "success_rate": 0.15384615384615385,
+      "avg_steps": 18.923076923076923,
+      "avg_tokens": 28408.69230769231,
+      "avg_cost_usd": 0.017620692307692306,
+      "repetition_rate": 0.6800719748088169
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Ski_eng",
+      "runs": 25,
+      "success_rate": 0.2,
+      "avg_steps": 55.6,
+      "avg_tokens": 214588.0,
+      "avg_cost_usd": 0.12012843000000001,
+      "repetition_rate": 0.7143762490697106
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Sortirovka1_eng",
+      "runs": 13,
+      "success_rate": 0.0,
+      "avg_steps": 83.3076923076923,
+      "avg_tokens": 305718.1538461539,
+      "avg_cost_usd": 0.1672411923076923,
+      "repetition_rate": 0.8151636617261916
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Spy",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 24.0,
+      "avg_tokens": 18812.333333333332,
+      "avg_cost_usd": 0.013567000000000001,
+      "repetition_rate": 0.7926860942288713
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Svarokok_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 73.33333333333333,
+      "avg_tokens": 65581.33333333333,
+      "avg_cost_usd": 0.045720666666666666,
+      "repetition_rate": 0.7939449869682428
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "reasoning",
+      "quest": "Tomb",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 23799.333333333332,
+      "avg_cost_usd": 0.0173905,
+      "repetition_rate": 0.8229166666666666
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 30.0,
+      "avg_tokens": 77412.0,
+      "avg_cost_usd": 0.04367933333333333,
+      "repetition_rate": 0.7776580459770116
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 29.0,
+      "avg_tokens": 98057.33333333333,
+      "avg_cost_usd": 0.05523533333333333,
+      "repetition_rate": 0.5664488017429194
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 170521.33333333334,
+      "avg_cost_usd": 0.09831816666666666,
+      "repetition_rate": 0.78125
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 45.666666666666664,
+      "avg_tokens": 239329.33333333334,
+      "avg_cost_usd": 0.13514383333333332,
+      "repetition_rate": 0.7389125478556373
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Disk_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 7.666666666666667,
+      "avg_tokens": 10187.0,
+      "avg_cost_usd": 0.006603499999999999,
+      "repetition_rate": 0.6031746031746031
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 115.33333333333333,
+      "avg_tokens": 486301.0,
+      "avg_cost_usd": 0.26506633333333335,
+      "repetition_rate": 0.6929773760122155
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 39.333333333333336,
+      "avg_tokens": 118153.0,
+      "avg_cost_usd": 0.06555316666666666,
+      "repetition_rate": 0.7033836937559658
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 84.33333333333333,
+      "avg_tokens": 454504.0,
+      "avg_cost_usd": 0.25375366666666666,
+      "repetition_rate": 0.7098376554923044
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 36.666666666666664,
+      "avg_tokens": 114543.66666666667,
+      "avg_cost_usd": 0.06434266666666667,
+      "repetition_rate": 0.694574420677362
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 82.66666666666667,
+      "avg_tokens": 326756.3333333333,
+      "avg_cost_usd": 0.17958316666666665,
+      "repetition_rate": 0.7586366538952746
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 102.66666666666667,
+      "avg_tokens": 371302.0,
+      "avg_cost_usd": 0.20254516666666667,
+      "repetition_rate": 0.7304712598830246
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Pilot_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 9.0,
+      "avg_tokens": 15983.0,
+      "avg_cost_usd": 0.010274833333333332,
+      "repetition_rate": 0.4074074074074074
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 40.666666666666664,
+      "avg_tokens": 138193.33333333334,
+      "avg_cost_usd": 0.0774475,
+      "repetition_rate": 0.4828042328042328
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Player_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 7.666666666666667,
+      "avg_tokens": 12981.666666666666,
+      "avg_cost_usd": 0.008717500000000001,
+      "repetition_rate": 0.5238095238095238
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 49.0,
+      "avg_tokens": 172333.33333333334,
+      "avg_cost_usd": 0.09538333333333333,
+      "repetition_rate": 0.7685038329368226
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Shashki_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 54202.0,
+      "avg_cost_usd": 0.0335185,
+      "repetition_rate": 0.6666666666666666
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 108.66666666666667,
+      "avg_tokens": 569379.3333333334,
+      "avg_cost_usd": 0.313923,
+      "repetition_rate": 0.6613089815337007
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented",
+      "quest": "Sortirovka1_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 113.0,
+      "avg_tokens": 620615.0,
+      "avg_cost_usd": 0.34909833333333334,
+      "repetition_rate": 0.8276273207290069
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Badday_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 25.0,
+      "avg_tokens": 48299.5,
+      "avg_cost_usd": 0.0337285,
+      "repetition_rate": 0.7584541062801933
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Banket_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 35.0,
+      "avg_tokens": 98071.0,
+      "avg_cost_usd": 0.06484675000000001,
+      "repetition_rate": 0.6142857142857143
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Codebox_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 101514.0,
+      "avg_cost_usd": 0.068357,
+      "repetition_rate": 0.765625
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Depth_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 34.5,
+      "avg_tokens": 106701.0,
+      "avg_cost_usd": 0.0733255,
+      "repetition_rate": 0.7107263513513513
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Disk_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 7.0,
+      "avg_tokens": 6415.0,
+      "avg_cost_usd": 0.0056,
+      "repetition_rate": 0.5714285714285714
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Driver_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 89.0,
+      "avg_tokens": 317576.5,
+      "avg_cost_usd": 0.19672574999999998,
+      "repetition_rate": 0.7331081081081081
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Edelweiss_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 36.5,
+      "avg_tokens": 86163.0,
+      "avg_cost_usd": 0.056614,
+      "repetition_rate": 0.7339939024390244
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Election_eng",
+      "runs": 2,
+      "success_rate": 0.5,
+      "avg_steps": 84.5,
+      "avg_tokens": 329622.0,
+      "avg_cost_usd": 0.21492475,
+      "repetition_rate": 0.692436974789916
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Foncers_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 34.0,
+      "avg_tokens": 86683.0,
+      "avg_cost_usd": 0.05829525,
+      "repetition_rate": 0.6904761904761905
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Leonardo_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 98.0,
+      "avg_tokens": 369718.0,
+      "avg_cost_usd": 0.231384,
+      "repetition_rate": 0.7807128545818833
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Ministry_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 56.0,
+      "avg_tokens": 159328.0,
+      "avg_cost_usd": 0.100824,
+      "repetition_rate": 0.6888888888888889
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Pilot_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 15.5,
+      "avg_tokens": 23314.5,
+      "avg_cost_usd": 0.01887475,
+      "repetition_rate": 0.4789915966386554
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Pizza_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 35.0,
+      "avg_tokens": 95763.0,
+      "avg_cost_usd": 0.06483900000000001,
+      "repetition_rate": 0.47619047619047616
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Player_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 8.0,
+      "avg_tokens": 8761.0,
+      "avg_cost_usd": 0.00804925,
+      "repetition_rate": 0.4375
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Robots_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 44.5,
+      "avg_tokens": 125131.5,
+      "avg_cost_usd": 0.0810795,
+      "repetition_rate": 0.7862997658079625
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Shashki_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 31912.0,
+      "avg_cost_usd": 0.025121,
+      "repetition_rate": 0.6578947368421053
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Ski_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 87590.5,
+      "avg_cost_usd": 0.058998999999999996,
+      "repetition_rate": 0.671875
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_cot",
+      "quest": "Sortirovka1_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 93.5,
+      "avg_tokens": 333996.0,
+      "avg_cost_usd": 0.21170424999999998,
+      "repetition_rate": 0.8143377569607078
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Badday_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 26.5,
+      "avg_tokens": 65179.5,
+      "avg_cost_usd": 0.04123725,
+      "repetition_rate": 0.7872023809523809
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Banket_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 34.0,
+      "avg_tokens": 109916.5,
+      "avg_cost_usd": 0.067112,
+      "repetition_rate": 0.6176470588235294
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Codebox_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 124429.5,
+      "avg_cost_usd": 0.07560225000000001,
+      "repetition_rate": 0.765625
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Depth_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 64.0,
+      "avg_tokens": 305640.0,
+      "avg_cost_usd": 0.18226,
+      "repetition_rate": 0.6874269005847953
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Disk_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 7.0,
+      "avg_tokens": 6548.0,
+      "avg_cost_usd": 0.00518025,
+      "repetition_rate": 0.5714285714285714
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Driver_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 43.5,
+      "avg_tokens": 175454.0,
+      "avg_cost_usd": 0.1034695,
+      "repetition_rate": 0.7126984126984127
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Edelweiss_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 81498.5,
+      "avg_cost_usd": 0.051096749999999996,
+      "repetition_rate": 0.703125
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Election_eng",
+      "runs": 2,
+      "success_rate": 0.5,
+      "avg_steps": 85.0,
+      "avg_tokens": 410595.5,
+      "avg_cost_usd": 0.2400915,
+      "repetition_rate": 0.6754434589800444
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Foncers_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 92889.0,
+      "avg_cost_usd": 0.05789325,
+      "repetition_rate": 0.65625
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Leonardo_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 93.5,
+      "avg_tokens": 435901.0,
+      "avg_cost_usd": 0.25620925,
+      "repetition_rate": 0.7479416607856975
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Ministry_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 79.0,
+      "avg_tokens": 317384.0,
+      "avg_cost_usd": 0.18520324999999999,
+      "repetition_rate": 0.7769984789589319
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Pilot_eng",
+      "runs": 2,
+      "success_rate": 0.5,
+      "avg_steps": 35.0,
+      "avg_tokens": 138999.5,
+      "avg_cost_usd": 0.08279475,
+      "repetition_rate": 0.5892857142857143
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Pizza_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 96806.5,
+      "avg_cost_usd": 0.06052575,
+      "repetition_rate": 0.46875
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Player_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 8.0,
+      "avg_tokens": 8938.0,
+      "avg_cost_usd": 0.0071015,
+      "repetition_rate": 0.5
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Robots_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 75.5,
+      "avg_tokens": 299414.0,
+      "avg_cost_usd": 0.17711075,
+      "repetition_rate": 0.8253484320557491
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Shashki_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 36425.0,
+      "avg_cost_usd": 0.02489625,
+      "repetition_rate": 0.6842105263157895
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Ski_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 80.0,
+      "avg_tokens": 374183.0,
+      "avg_cost_usd": 0.2194215,
+      "repetition_rate": 0.71484375
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_extended",
+      "quest": "Sortirovka1_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 112.5,
+      "avg_tokens": 511430.0,
+      "avg_cost_usd": 0.30032375,
+      "repetition_rate": 0.8015279325163138
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Badday_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 30.0,
+      "avg_tokens": 74198.5,
+      "avg_cost_usd": 0.046316750000000004,
+      "repetition_rate": 0.7664071190211346
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Banket_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 35.0,
+      "avg_tokens": 105271.5,
+      "avg_cost_usd": 0.06435325,
+      "repetition_rate": 0.5714285714285714
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Codebox_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 110356.5,
+      "avg_cost_usd": 0.0667045,
+      "repetition_rate": 0.8125
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Depth_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 92.5,
+      "avg_tokens": 456952.0,
+      "avg_cost_usd": 0.26698725,
+      "repetition_rate": 0.673406862745098
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Disk_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 7.0,
+      "avg_tokens": 6733.5,
+      "avg_cost_usd": 0.0052405,
+      "repetition_rate": 0.5714285714285714
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Driver_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 106.5,
+      "avg_tokens": 488417.5,
+      "avg_cost_usd": 0.28233375,
+      "repetition_rate": 0.7032967032967032
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Edelweiss_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 35.5,
+      "avg_tokens": 86314.0,
+      "avg_cost_usd": 0.05278575,
+      "repetition_rate": 0.7039682539682539
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Election_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 95.5,
+      "avg_tokens": 502264.5,
+      "avg_cost_usd": 0.29243225,
+      "repetition_rate": 0.6962719298245614
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Foncers_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 33.0,
+      "avg_tokens": 75548.0,
+      "avg_cost_usd": 0.04645775,
+      "repetition_rate": 0.6515151515151515
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Leonardo_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 89.5,
+      "avg_tokens": 397403.0,
+      "avg_cost_usd": 0.23142775,
+      "repetition_rate": 0.7344303797468354
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Ministry_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 48.0,
+      "avg_tokens": 137448.5,
+      "avg_cost_usd": 0.07985675,
+      "repetition_rate": 0.7720620842572062
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Pilot_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 9.0,
+      "avg_tokens": 10258.0,
+      "avg_cost_usd": 0.00764525,
+      "repetition_rate": 0.4444444444444444
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Pizza_eng",
+      "runs": 2,
+      "success_rate": 0.5,
+      "avg_steps": 41.5,
+      "avg_tokens": 159292.5,
+      "avg_cost_usd": 0.09563250000000001,
+      "repetition_rate": 0.4801920768307323
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Player_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 8.0,
+      "avg_tokens": 7983.0,
+      "avg_cost_usd": 0.00574525,
+      "repetition_rate": 0.5
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Robots_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 72.5,
+      "avg_tokens": 232597.0,
+      "avg_cost_usd": 0.13651225,
+      "repetition_rate": 0.7687459599224304
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Shashki_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 30841.0,
+      "avg_cost_usd": 0.02110175,
+      "repetition_rate": 0.6578947368421053
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Ski_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 20.5,
+      "avg_tokens": 48890.0,
+      "avg_cost_usd": 0.03224875,
+      "repetition_rate": 0.513157894736842
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "memo_structured",
+      "quest": "Sortirovka1_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 96.5,
+      "avg_tokens": 376457.0,
+      "avg_cost_usd": 0.22075099999999998,
+      "repetition_rate": 0.8095315904139433
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Badday_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 28.818181818181817,
+      "avg_tokens": 58880.545454545456,
+      "avg_cost_usd": 0.0345555,
+      "repetition_rate": 0.7663876247719407
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Banket_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 25.09090909090909,
+      "avg_tokens": 57694.27272727273,
+      "avg_cost_usd": 0.033681909090909096,
+      "repetition_rate": 0.535878745437569
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Codebox_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 94880.18181818182,
+      "avg_cost_usd": 0.05370418181818182,
+      "repetition_rate": 0.7698863636363636
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Depth_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 45.54545454545455,
+      "avg_tokens": 148103.72727272726,
+      "avg_cost_usd": 0.08452913636363636,
+      "repetition_rate": 0.7246059450617162
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Disk_eng",
+      "runs": 11,
+      "success_rate": 0.2727272727272727,
+      "avg_steps": 7.545454545454546,
+      "avg_tokens": 6504.636363636364,
+      "avg_cost_usd": 0.004375727272727273,
+      "repetition_rate": 0.5974025974025974
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Driver_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 53.36363636363637,
+      "avg_tokens": 168709.27272727274,
+      "avg_cost_usd": 0.09494440909090908,
+      "repetition_rate": 0.7226684997243297
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Edelweiss_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 40.90909090909091,
+      "avg_tokens": 105289.81818181818,
+      "avg_cost_usd": 0.059889681818181814,
+      "repetition_rate": 0.6901576247783463
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Election_eng",
+      "runs": 11,
+      "success_rate": 0.5454545454545454,
+      "avg_steps": 93.72727272727273,
+      "avg_tokens": 359748.2727272727,
+      "avg_cost_usd": 0.199558,
+      "repetition_rate": 0.6751366060352718
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Foncers_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 35.18181818181818,
+      "avg_tokens": 85368.90909090909,
+      "avg_cost_usd": 0.049499,
+      "repetition_rate": 0.6838145208061476
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Leonardo_eng",
+      "runs": 11,
+      "success_rate": 0.2727272727272727,
+      "avg_steps": 95.9090909090909,
+      "avg_tokens": 344806.8181818182,
+      "avg_cost_usd": 0.19286863636363635,
+      "repetition_rate": 0.7541897702384017
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Ministry_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 106.54545454545455,
+      "avg_tokens": 341156.54545454547,
+      "avg_cost_usd": 0.18973327272727272,
+      "repetition_rate": 0.7975588739997043
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Pilot_eng",
+      "runs": 11,
+      "success_rate": 0.36363636363636365,
+      "avg_steps": 25.454545454545453,
+      "avg_tokens": 76321.90909090909,
+      "avg_cost_usd": 0.04371822727272728,
+      "repetition_rate": 0.566187370680355
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Pizza_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 35.81818181818182,
+      "avg_tokens": 93053.54545454546,
+      "avg_cost_usd": 0.053932681818181824,
+      "repetition_rate": 0.47679663173084225
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Player_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 8.0,
+      "avg_tokens": 7748.181818181818,
+      "avg_cost_usd": 0.005309090909090909,
+      "repetition_rate": 0.5
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Robots_eng",
+      "runs": 11,
+      "success_rate": 0.09090909090909091,
+      "avg_steps": 60.36363636363637,
+      "avg_tokens": 178975.63636363635,
+      "avg_cost_usd": 0.10112600000000001,
+      "repetition_rate": 0.7852723964660622
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Shashki_eng",
+      "runs": 11,
+      "success_rate": 0.09090909090909091,
+      "avg_steps": 19.09090909090909,
+      "avg_tokens": 28664.454545454544,
+      "avg_cost_usd": 0.017722454545454545,
+      "repetition_rate": 0.6619617224880382
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Ski_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 69.27272727272727,
+      "avg_tokens": 258842.54545454544,
+      "avg_cost_usd": 0.14423831818181818,
+      "repetition_rate": 0.6680234358404419
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact",
+      "quest": "Sortirovka1_eng",
+      "runs": 11,
+      "success_rate": 0.18181818181818182,
+      "avg_steps": 113.81818181818181,
+      "avg_tokens": 406602.0909090909,
+      "avg_cost_usd": 0.22861013636363633,
+      "repetition_rate": 0.7945631239639623
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 28.333333333333332,
+      "avg_tokens": 58118.0,
+      "avg_cost_usd": 0.03416983333333334,
+      "repetition_rate": 0.7756492124308215
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 22.666666666666668,
+      "avg_tokens": 50517.0,
+      "avg_cost_usd": 0.02970266666666667,
+      "repetition_rate": 0.5229691876750701
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 99736.66666666667,
+      "avg_cost_usd": 0.0569275,
+      "repetition_rate": 0.7708333333333334
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 32.666666666666664,
+      "avg_tokens": 92578.0,
+      "avg_cost_usd": 0.05432483333333333,
+      "repetition_rate": 0.7345328282828283
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Disk_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 7.0,
+      "avg_tokens": 6026.0,
+      "avg_cost_usd": 0.0041005,
+      "repetition_rate": 0.5714285714285714
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 57.0,
+      "avg_tokens": 177923.33333333334,
+      "avg_cost_usd": 0.10016333333333333,
+      "repetition_rate": 0.7285829182233292
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 41.333333333333336,
+      "avg_tokens": 111980.0,
+      "avg_cost_usd": 0.06365083333333334,
+      "repetition_rate": 0.7229166666666668
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 91.66666666666667,
+      "avg_tokens": 362812.6666666667,
+      "avg_cost_usd": 0.20228216666666668,
+      "repetition_rate": 0.7055167055167054
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 38.0,
+      "avg_tokens": 105745.66666666667,
+      "avg_cost_usd": 0.060497833333333334,
+      "repetition_rate": 0.6774999999999999
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 99.33333333333333,
+      "avg_tokens": 367806.3333333333,
+      "avg_cost_usd": 0.20575733333333335,
+      "repetition_rate": 0.773371399841988
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 51.666666666666664,
+      "avg_tokens": 149621.66666666666,
+      "avg_cost_usd": 0.08436083333333333,
+      "repetition_rate": 0.7795400816677412
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Pilot_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 24.666666666666668,
+      "avg_tokens": 76821.33333333333,
+      "avg_cost_usd": 0.043873166666666664,
+      "repetition_rate": 0.5697167755991285
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 34.0,
+      "avg_tokens": 86711.33333333333,
+      "avg_cost_usd": 0.05075316666666666,
+      "repetition_rate": 0.5387391067538126
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Player_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 8.0,
+      "avg_tokens": 8091.333333333333,
+      "avg_cost_usd": 0.005494833333333333,
+      "repetition_rate": 0.5
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 62.666666666666664,
+      "avg_tokens": 204655.66666666666,
+      "avg_cost_usd": 0.11452116666666667,
+      "repetition_rate": 0.7919314796425025
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Shashki_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 29553.666666666668,
+      "avg_cost_usd": 0.018364333333333333,
+      "repetition_rate": 0.6491228070175438
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 58.0,
+      "avg_tokens": 219998.0,
+      "avg_cost_usd": 0.12310566666666667,
+      "repetition_rate": 0.5831409895843436
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "stateful_compact_hints",
+      "quest": "Sortirovka1_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 142.33333333333334,
+      "avg_tokens": 512745.0,
+      "avg_cost_usd": 0.2889391666666667,
+      "repetition_rate": 0.826332214711762
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.666666666666664,
+      "avg_tokens": 97761.0,
+      "avg_cost_usd": 0.054703833333333333,
+      "repetition_rate": 0.755842151675485
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 28.666666666666668,
+      "avg_tokens": 96757.0,
+      "avg_cost_usd": 0.054406,
+      "repetition_rate": 0.5664488017429194
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 152558.0,
+      "avg_cost_usd": 0.08692233333333332,
+      "repetition_rate": 0.78125
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 34.0,
+      "avg_tokens": 158354.66666666666,
+      "avg_cost_usd": 0.09167900000000001,
+      "repetition_rate": 0.6710526315789473
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Disk_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 7.666666666666667,
+      "avg_tokens": 11101.333333333334,
+      "avg_cost_usd": 0.0071123333333333325,
+      "repetition_rate": 0.6031746031746031
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 51.0,
+      "avg_tokens": 197027.0,
+      "avg_cost_usd": 0.10812766666666666,
+      "repetition_rate": 0.7102616824530061
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 35.0,
+      "avg_tokens": 108267.33333333333,
+      "avg_cost_usd": 0.06080116666666666,
+      "repetition_rate": 0.6964869281045751
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 94.0,
+      "avg_tokens": 565725.0,
+      "avg_cost_usd": 0.31540416666666665,
+      "repetition_rate": 0.6986135209819421
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.666666666666664,
+      "avg_tokens": 100233.0,
+      "avg_cost_usd": 0.05660066666666667,
+      "repetition_rate": 0.7120798319327731
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 87.66666666666667,
+      "avg_tokens": 368532.3333333333,
+      "avg_cost_usd": 0.20245533333333332,
+      "repetition_rate": 0.7293404515626737
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 63.333333333333336,
+      "avg_tokens": 219280.66666666666,
+      "avg_cost_usd": 0.12083366666666667,
+      "repetition_rate": 0.7770299145299145
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Pilot_eng",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 54.666666666666664,
+      "avg_tokens": 235396.33333333334,
+      "avg_cost_usd": 0.12936483333333335,
+      "repetition_rate": 0.7676425320103482
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 38.0,
+      "avg_tokens": 128869.0,
+      "avg_cost_usd": 0.0723245,
+      "repetition_rate": 0.5138888888888888
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Player_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 7.666666666666667,
+      "avg_tokens": 12029.333333333334,
+      "avg_cost_usd": 0.007904666666666666,
+      "repetition_rate": 0.4761904761904762
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 73.66666666666667,
+      "avg_tokens": 288946.6666666667,
+      "avg_cost_usd": 0.15876583333333336,
+      "repetition_rate": 0.7509696016771489
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Shashki_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 48474.666666666664,
+      "avg_cost_usd": 0.029301499999999998,
+      "repetition_rate": 0.6315789473684211
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 119.66666666666667,
+      "avg_tokens": 647403.0,
+      "avg_cost_usd": 0.35502733333333336,
+      "repetition_rate": 0.6922959003898729
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tool_augmented_hints",
+      "quest": "Sortirovka1_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 104.33333333333333,
+      "avg_tokens": 659906.3333333334,
+      "avg_cost_usd": 0.37684066666666666,
+      "repetition_rate": 0.79850714792597
     },
     {
       "model": "gpt-5.4",
@@ -2102,7 +5257,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 17320.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02300625,
       "repetition_rate": 0.8064516129032258
     },
     {
@@ -2113,7 +5268,7 @@
       "success_rate": 0.0,
       "avg_steps": 35.0,
       "avg_tokens": 27360.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.03573125,
       "repetition_rate": 0.7428571428571429
     },
     {
@@ -2124,7 +5279,7 @@
       "success_rate": 1.0,
       "avg_steps": 16.0,
       "avg_tokens": 9941.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01312625,
       "repetition_rate": 0.75
     },
     {
@@ -2135,7 +5290,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 25116.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.03275125,
       "repetition_rate": 0.7419354838709677
     },
     {
@@ -2146,7 +5301,7 @@
       "success_rate": 0.0,
       "avg_steps": 100.0,
       "avg_tokens": 64273.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.08471625,
       "repetition_rate": 0.67
     },
     {
@@ -2157,7 +5312,7 @@
       "success_rate": 0.0,
       "avg_steps": 79.0,
       "avg_tokens": 51318.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.06760375,
       "repetition_rate": 0.7088607594936709
     },
     {
@@ -2168,7 +5323,7 @@
       "success_rate": 0.0,
       "avg_steps": 41.0,
       "avg_tokens": 22327.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0297025,
       "repetition_rate": 0.6829268292682927
     },
     {
@@ -2179,7 +5334,7 @@
       "success_rate": 0.0,
       "avg_steps": 71.0,
       "avg_tokens": 60558.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.07880375,
       "repetition_rate": 0.7464788732394366
     },
     {
@@ -2190,7 +5345,7 @@
       "success_rate": 0.0,
       "avg_steps": 33.0,
       "avg_tokens": 19109.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02533,
       "repetition_rate": 0.6060606060606061
     },
     {
@@ -2201,7 +5356,7 @@
       "success_rate": 0.0,
       "avg_steps": 111.0,
       "avg_tokens": 66226.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.08763875,
       "repetition_rate": 0.7657657657657657
     },
     {
@@ -2212,7 +5367,7 @@
       "success_rate": 0.0,
       "avg_steps": 209.0,
       "avg_tokens": 113182.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.15062125,
       "repetition_rate": 0.7272727272727273
     },
     {
@@ -2223,7 +5378,7 @@
       "success_rate": 1.0,
       "avg_steps": 31.0,
       "avg_tokens": 19681.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0259575,
       "repetition_rate": 0.5161290322580645
     },
     {
@@ -2234,7 +5389,7 @@
       "success_rate": 0.0,
       "avg_steps": 67.0,
       "avg_tokens": 39407.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.05219,
       "repetition_rate": 0.835820895522388
     },
     {
@@ -2245,7 +5400,7 @@
       "success_rate": 0.0,
       "avg_steps": 24.0,
       "avg_tokens": 12724.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.016955,
       "repetition_rate": 0.7916666666666666
     },
     {
@@ -2256,7 +5411,7 @@
       "success_rate": 0.0,
       "avg_steps": 77.0,
       "avg_tokens": 56495.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0739875,
       "repetition_rate": 0.6623376623376623
     },
     {
@@ -2267,7 +5422,7 @@
       "success_rate": 1.0,
       "avg_steps": 29.0,
       "avg_tokens": 21057.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.04285875,
       "repetition_rate": 0.8275862068965517
     },
     {
@@ -2278,7 +5433,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 32651.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.06214625,
       "repetition_rate": 0.6764705882352942
     },
     {
@@ -2289,7 +5444,7 @@
       "success_rate": 1.0,
       "avg_steps": 19.0,
       "avg_tokens": 15183.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.03264625,
       "repetition_rate": 0.8421052631578947
     },
     {
@@ -2300,7 +5455,7 @@
       "success_rate": 0.0,
       "avg_steps": 25.0,
       "avg_tokens": 24393.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.04653875,
       "repetition_rate": 0.72
     },
     {
@@ -2311,7 +5466,7 @@
       "success_rate": 0.0,
       "avg_steps": 41.0,
       "avg_tokens": 33740.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.06570375,
       "repetition_rate": 0.6341463414634146
     },
     {
@@ -2322,7 +5477,7 @@
       "success_rate": 0.0,
       "avg_steps": 36.0,
       "avg_tokens": 28769.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.05743375,
       "repetition_rate": 0.7777777777777778
     },
     {
@@ -2333,7 +5488,7 @@
       "success_rate": 0.0,
       "avg_steps": 127.0,
       "avg_tokens": 87120.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.185375,
       "repetition_rate": 0.7322834645669292
     },
     {
@@ -2344,7 +5499,7 @@
       "success_rate": 0.0,
       "avg_steps": 87.0,
       "avg_tokens": 89823.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.163615,
       "repetition_rate": 0.7241379310344828
     },
     {
@@ -2355,7 +5510,7 @@
       "success_rate": 0.0,
       "avg_steps": 22.0,
       "avg_tokens": 16872.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.034775,
       "repetition_rate": 0.6818181818181818
     },
     {
@@ -2366,7 +5521,7 @@
       "success_rate": 0.0,
       "avg_steps": 108.0,
       "avg_tokens": 81499.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.1629925,
       "repetition_rate": 0.7962962962962963
     },
     {
@@ -2377,7 +5532,7 @@
       "success_rate": 0.0,
       "avg_steps": 98.0,
       "avg_tokens": 69530.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.143525,
       "repetition_rate": 0.7346938775510204
     },
     {
@@ -2388,7 +5543,7 @@
       "success_rate": 1.0,
       "avg_steps": 31.0,
       "avg_tokens": 24997.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.05072375,
       "repetition_rate": 0.6774193548387096
     },
     {
@@ -2399,7 +5554,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 23163.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0467075,
       "repetition_rate": 0.8064516129032258
     },
     {
@@ -2410,7 +5565,7 @@
       "success_rate": 0.0,
       "avg_steps": 58.0,
       "avg_tokens": 39914.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0832125,
       "repetition_rate": 0.8103448275862069
     },
     {
@@ -2421,7 +5576,7 @@
       "success_rate": 1.0,
       "avg_steps": 62.0,
       "avg_tokens": 55050.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.10459125,
       "repetition_rate": 0.7903225806451613
     },
     {
@@ -2432,7 +5587,7 @@
       "success_rate": 1.0,
       "avg_steps": 28.0,
       "avg_tokens": 20768.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.04215625,
       "repetition_rate": 0.8214285714285714
     },
     {
@@ -2443,7 +5598,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 33011.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0624125,
       "repetition_rate": 0.7352941176470589
     },
     {
@@ -2454,7 +5609,7 @@
       "success_rate": 1.0,
       "avg_steps": 19.0,
       "avg_tokens": 15412.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0325825,
       "repetition_rate": 0.7894736842105263
     },
     {
@@ -2465,7 +5620,7 @@
       "success_rate": 0.0,
       "avg_steps": 16.0,
       "avg_tokens": 15075.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02937875,
       "repetition_rate": 0.625
     },
     {
@@ -2476,7 +5631,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 25898.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0501875,
       "repetition_rate": 0.5483870967741935
     },
     {
@@ -2487,7 +5642,7 @@
       "success_rate": 0.0,
       "avg_steps": 155.0,
       "avg_tokens": 127491.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.25025,
       "repetition_rate": 0.7870967741935484
     },
     {
@@ -2498,7 +5653,7 @@
       "success_rate": 0.0,
       "avg_steps": 57.0,
       "avg_tokens": 39047.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0823825,
       "repetition_rate": 0.7368421052631579
     },
     {
@@ -2509,7 +5664,7 @@
       "success_rate": 0.0,
       "avg_steps": 4.0,
       "avg_tokens": 3182.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00613,
       "repetition_rate": 0.5
     },
     {
@@ -2520,7 +5675,7 @@
       "success_rate": 0.0,
       "avg_steps": 33.0,
       "avg_tokens": 25190.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.05155125,
       "repetition_rate": 0.6666666666666666
     },
     {
@@ -2531,7 +5686,7 @@
       "success_rate": 0.0,
       "avg_steps": 110.0,
       "avg_tokens": 84746.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.16750625,
       "repetition_rate": 0.8090909090909091
     },
     {
@@ -2542,7 +5697,7 @@
       "success_rate": 0.0,
       "avg_steps": 138.0,
       "avg_tokens": 100165.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.2047875,
       "repetition_rate": 0.6594202898550725
     },
     {
@@ -2553,7 +5708,7 @@
       "success_rate": 1.0,
       "avg_steps": 41.0,
       "avg_tokens": 33864.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.06913125,
       "repetition_rate": 0.5853658536585366
     },
     {
@@ -2564,7 +5719,7 @@
       "success_rate": 0.0,
       "avg_steps": 72.0,
       "avg_tokens": 55521.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.11078875,
       "repetition_rate": 0.8055555555555556
     },
     {
@@ -2575,7 +5730,7 @@
       "success_rate": 0.0,
       "avg_steps": 45.0,
       "avg_tokens": 31834.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.065465,
       "repetition_rate": 0.7777777777777778
     },
     {
@@ -2586,7 +5741,7 @@
       "success_rate": 1.0,
       "avg_steps": 54.0,
       "avg_tokens": 48431.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.091855,
       "repetition_rate": 0.7592592592592593
     },
     {
@@ -2597,7 +5752,7 @@
       "success_rate": 1.0,
       "avg_steps": 27.0,
       "avg_tokens": 34853.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.09940875,
       "repetition_rate": 0.8148148148148148
     },
     {
@@ -2608,7 +5763,7 @@
       "success_rate": 0.0,
       "avg_steps": 23.0,
       "avg_tokens": 36416.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.08534125,
       "repetition_rate": 0.6521739130434783
     },
     {
@@ -2619,7 +5774,7 @@
       "success_rate": 1.0,
       "avg_steps": 19.0,
       "avg_tokens": 21861.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.060655,
       "repetition_rate": 0.8421052631578947
     },
     {
@@ -2630,7 +5785,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 36930.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.087235,
       "repetition_rate": 0.8387096774193549
     },
     {
@@ -2641,7 +5796,7 @@
       "success_rate": 0.0,
       "avg_steps": 33.0,
       "avg_tokens": 40666.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.1064125,
       "repetition_rate": 0.5757575757575758
     },
     {
@@ -2652,7 +5807,7 @@
       "success_rate": 0.0,
       "avg_steps": 25.0,
       "avg_tokens": 31893.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.08778125,
       "repetition_rate": 0.8
     },
     {
@@ -2663,7 +5818,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 35366.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.10117,
       "repetition_rate": 0.7352941176470589
     },
     {
@@ -2674,7 +5829,7 @@
       "success_rate": 0.0,
       "avg_steps": 63.0,
       "avg_tokens": 115474.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.28286375,
       "repetition_rate": 0.6984126984126984
     },
     {
@@ -2685,7 +5840,7 @@
       "success_rate": 0.0,
       "avg_steps": 35.0,
       "avg_tokens": 40699.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.1111175,
       "repetition_rate": 0.7142857142857143
     },
     {
@@ -2696,7 +5851,7 @@
       "success_rate": 0.0,
       "avg_steps": 104.0,
       "avg_tokens": 101897.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.269585,
       "repetition_rate": 0.75
     },
     {
@@ -2707,7 +5862,7 @@
       "success_rate": 0.0,
       "avg_steps": 60.0,
       "avg_tokens": 68160.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.1981625,
       "repetition_rate": 0.8333333333333334
     },
     {
@@ -2718,7 +5873,7 @@
       "success_rate": 0.0,
       "avg_steps": 50.0,
       "avg_tokens": 72432.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.20086875,
       "repetition_rate": 0.42
     },
     {
@@ -2729,7 +5884,7 @@
       "success_rate": 0.0,
       "avg_steps": 87.0,
       "avg_tokens": 96433.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.26794375,
       "repetition_rate": 0.8505747126436781
     },
     {
@@ -2740,7 +5895,7 @@
       "success_rate": 0.0,
       "avg_steps": 25.0,
       "avg_tokens": 25846.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.07275,
       "repetition_rate": 0.72
     },
     {
@@ -2751,338 +5906,338 @@
       "success_rate": 0.0,
       "avg_steps": 76.0,
       "avg_tokens": 107937.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.27845625,
       "repetition_rate": 0.7894736842105263
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Badday_eng",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 25.0,
-      "avg_tokens": 14141.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8
+      "runs": 4,
+      "success_rate": 0.75,
+      "avg_steps": 51.75,
+      "avg_tokens": 30205.25,
+      "avg_cost_usd": 0.008229875,
+      "repetition_rate": 0.7986842105263158
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Banket_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 25.0,
-      "avg_tokens": 19303.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.64
+      "avg_steps": 23.5,
+      "avg_tokens": 18065.5,
+      "avg_cost_usd": 0.004819125,
+      "repetition_rate": 0.6609090909090909
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Boat",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 19.0,
-      "avg_tokens": 11779.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.7894736842105263
+      "runs": 5,
+      "success_rate": 0.4,
+      "avg_steps": 17.4,
+      "avg_tokens": 10867.2,
+      "avg_cost_usd": 0.00290685,
+      "repetition_rate": 0.8028947368421052
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Codebox_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 31.0,
-      "avg_tokens": 25379.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8064516129032258
+      "avg_steps": 26.0,
+      "avg_tokens": 21021.25,
+      "avg_cost_usd": 0.0055983125,
+      "repetition_rate": 0.778785918025596
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Depth_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 127.0,
-      "avg_tokens": 82685.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.7244094488188977
+      "avg_steps": 78.0,
+      "avg_tokens": 50931.5,
+      "avg_cost_usd": 0.013838,
+      "repetition_rate": 0.6921498253798472
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Driver_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 82.0,
-      "avg_tokens": 51907.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8170731707317073
+      "avg_steps": 81.25,
+      "avg_tokens": 51419.75,
+      "avg_cost_usd": 0.01387825,
+      "repetition_rate": 0.7893121934761858
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Edelweiss_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 54.0,
-      "avg_tokens": 28606.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.7037037037037037
+      "avg_steps": 59.75,
+      "avg_tokens": 30603.5,
+      "avg_cost_usd": 0.0085700625,
+      "repetition_rate": 0.7538392050587173
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Election_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 84.0,
-      "avg_tokens": 72836.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.6666666666666666
+      "avg_steps": 63.75,
+      "avg_tokens": 54871.5,
+      "avg_cost_usd": 0.0145749375,
+      "repetition_rate": 0.622179650915283
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Foncers_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 19.0,
-      "avg_tokens": 11158.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.5789473684210527
+      "avg_steps": 25.0,
+      "avg_tokens": 14631.25,
+      "avg_cost_usd": 0.0040445624999999995,
+      "repetition_rate": 0.6518640350877193
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Leonardo_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 107.0,
-      "avg_tokens": 64444.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.7289719626168224
+      "avg_steps": 91.75,
+      "avg_tokens": 55194.0,
+      "avg_cost_usd": 0.0149714375,
+      "repetition_rate": 0.7303244646231035
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Ministry_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 48.0,
-      "avg_tokens": 26213.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8125
+      "avg_steps": 84.25,
+      "avg_tokens": 47050.5,
+      "avg_cost_usd": 0.0127780625,
+      "repetition_rate": 0.768409911457197
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Pizza_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 1.0,
-      "avg_steps": 31.0,
-      "avg_tokens": 19393.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.6451612903225806
+      "avg_steps": 33.0,
+      "avg_tokens": 20791.75,
+      "avg_cost_usd": 0.005722937500000001,
+      "repetition_rate": 0.6218963831867057
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Prison_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 292.0,
-      "avg_tokens": 177581.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8356164383561644
+      "avg_steps": 305.5,
+      "avg_tokens": 186200.5,
+      "avg_cost_usd": 0.049939874999999995,
+      "repetition_rate": 0.827233852338378
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Robots_eng",
-      "runs": 1,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 35.0,
-      "avg_tokens": 18260.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.7428571428571429
+      "avg_steps": 40.25,
+      "avg_tokens": 21224.25,
+      "avg_cost_usd": 0.00582625,
+      "repetition_rate": 0.7776223091976516
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "stub",
       "quest": "Ski_eng",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 111.0,
-      "avg_tokens": 82754.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.6306306306306306
+      "runs": 4,
+      "success_rate": 0.5,
+      "avg_steps": 82.25,
+      "avg_tokens": 60651.25,
+      "avg_cost_usd": 0.016378625,
+      "repetition_rate": 0.6713760610037206
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Badday_eng",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 25.0,
-      "avg_tokens": 17740.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8
+      "runs": 13,
+      "success_rate": 0.23076923076923078,
+      "avg_steps": 34.61538461538461,
+      "avg_tokens": 51076.230769230766,
+      "avg_cost_usd": 0.041502307692307686,
+      "repetition_rate": 0.7446096908607834
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Banket_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 25.0,
-      "avg_tokens": 23037.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.72
+      "avg_steps": 39.38461538461539,
+      "avg_tokens": 60859.153846153844,
+      "avg_cost_usd": 0.04946103846153846,
+      "repetition_rate": 0.7293903114892335
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Boat",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 20.0,
-      "avg_tokens": 15825.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8
+      "runs": 13,
+      "success_rate": 0.15384615384615385,
+      "avg_steps": 24.692307692307693,
+      "avg_tokens": 35644.92307692308,
+      "avg_cost_usd": 0.030084865384615387,
+      "repetition_rate": 0.7641458873195115
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Codebox_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 31.0,
-      "avg_tokens": 30378.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8064516129032258
+      "avg_steps": 30.076923076923077,
+      "avg_tokens": 57417.61538461538,
+      "avg_cost_usd": 0.046677538461538465,
+      "repetition_rate": 0.7169896005359901
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Depth_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 32.0,
-      "avg_tokens": 25918.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.65625
+      "avg_steps": 60.23076923076923,
+      "avg_tokens": 122732.0,
+      "avg_cost_usd": 0.09855338461538461,
+      "repetition_rate": 0.7213147226805607
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Driver_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 13.0,
-      "avg_tokens": 9970.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.6923076923076923
+      "avg_steps": 39.69230769230769,
+      "avg_tokens": 65320.692307692305,
+      "avg_cost_usd": 0.05574275,
+      "repetition_rate": 0.7409129670258431
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Edelweiss_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 31.0,
-      "avg_tokens": 20572.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.7419354838709677
+      "avg_steps": 64.61538461538461,
+      "avg_tokens": 160552.76923076922,
+      "avg_cost_usd": 0.12810834615384617,
+      "repetition_rate": 0.7390488097280474
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Election_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 83.0,
-      "avg_tokens": 84279.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.6746987951807228
+      "avg_steps": 81.07692307692308,
+      "avg_tokens": 106387.53846153847,
+      "avg_cost_usd": 0.08193601923076922,
+      "repetition_rate": 0.7222035405942804
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Foncers_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 23.0,
-      "avg_tokens": 17128.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.6086956521739131
+      "avg_steps": 59.61538461538461,
+      "avg_tokens": 156237.23076923078,
+      "avg_cost_usd": 0.12556807692307692,
+      "repetition_rate": 0.7013911250655981
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Leonardo_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 118.0,
-      "avg_tokens": 88997.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.7627118644067796
+      "avg_steps": 101.84615384615384,
+      "avg_tokens": 213654.23076923078,
+      "avg_cost_usd": 0.16547863461538462,
+      "repetition_rate": 0.7744833198560894
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Ministry_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 35.0,
-      "avg_tokens": 24532.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8571428571428571
+      "avg_steps": 42.69230769230769,
+      "avg_tokens": 48233.307692307695,
+      "avg_cost_usd": 0.03815613461538461,
+      "repetition_rate": 0.785077940702907
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Pizza_eng",
-      "runs": 1,
-      "success_rate": 1.0,
-      "avg_steps": 29.0,
-      "avg_tokens": 22880.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.6206896551724138
+      "runs": 13,
+      "success_rate": 0.15384615384615385,
+      "avg_steps": 67.07692307692308,
+      "avg_tokens": 112627.23076923077,
+      "avg_cost_usd": 0.09488988461538463,
+      "repetition_rate": 0.7224868725684819
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Prison_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 94.0,
-      "avg_tokens": 71334.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.8297872340425532
+      "avg_steps": 50.92307692307692,
+      "avg_tokens": 91187.69230769231,
+      "avg_cost_usd": 0.06175297692307692,
+      "repetition_rate": 0.7738710851606547
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Robots_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 38.0,
-      "avg_tokens": 25443.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.7631578947368421
+      "avg_steps": 30.923076923076923,
+      "avg_tokens": 31556.076923076922,
+      "avg_cost_usd": 0.014326210769230768,
+      "repetition_rate": 0.8256115124773957
     },
     {
       "model": "gpt-5.4-mini",
       "mode": "reasoning",
       "quest": "Ski_eng",
-      "runs": 1,
+      "runs": 13,
       "success_rate": 0.0,
-      "avg_steps": 50.0,
-      "avg_tokens": 44165.0,
-      "avg_cost_usd": 0.0,
-      "repetition_rate": 0.68
+      "avg_steps": 38.61538461538461,
+      "avg_tokens": 51772.307692307695,
+      "avg_cost_usd": 0.022698643076923077,
+      "repetition_rate": 0.6802200919948812
     },
     {
       "model": "gpt-5.4-mini",
@@ -3092,7 +6247,7 @@
       "success_rate": 1.0,
       "avg_steps": 23.0,
       "avg_tokens": 16745.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.006484,
       "repetition_rate": 0.8260869565217391
     },
     {
@@ -3103,7 +6258,7 @@
       "success_rate": 0.0,
       "avg_steps": 22.0,
       "avg_tokens": 20602.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00730825,
       "repetition_rate": 0.6818181818181818
     },
     {
@@ -3114,7 +6269,7 @@
       "success_rate": 1.0,
       "avg_steps": 19.0,
       "avg_tokens": 15128.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.005987,
       "repetition_rate": 0.7894736842105263
     },
     {
@@ -3125,7 +6280,7 @@
       "success_rate": 0.0,
       "avg_steps": 27.0,
       "avg_tokens": 26477.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0095925,
       "repetition_rate": 0.8148148148148148
     },
     {
@@ -3136,7 +6291,7 @@
       "success_rate": 0.0,
       "avg_steps": 44.0,
       "avg_tokens": 36071.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0137725,
       "repetition_rate": 0.6136363636363636
     },
     {
@@ -3147,7 +6302,7 @@
       "success_rate": 0.0,
       "avg_steps": 147.0,
       "avg_tokens": 121288.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.04662325,
       "repetition_rate": 0.7619047619047619
     },
     {
@@ -3158,7 +6313,7 @@
       "success_rate": 0.0,
       "avg_steps": 66.0,
       "avg_tokens": 44750.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01861275,
       "repetition_rate": 0.696969696969697
     },
     {
@@ -3169,7 +6324,7 @@
       "success_rate": 0.0,
       "avg_steps": 87.0,
       "avg_tokens": 90225.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.031546,
       "repetition_rate": 0.7126436781609196
     },
     {
@@ -3180,7 +6335,7 @@
       "success_rate": 0.0,
       "avg_steps": 36.0,
       "avg_tokens": 27120.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.010791,
       "repetition_rate": 0.7222222222222222
     },
     {
@@ -3191,7 +6346,7 @@
       "success_rate": 0.0,
       "avg_steps": 107.0,
       "avg_tokens": 82050.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0315865,
       "repetition_rate": 0.7757009345794392
     },
     {
@@ -3202,7 +6357,7 @@
       "success_rate": 0.0,
       "avg_steps": 64.0,
       "avg_tokens": 46106.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01799625,
       "repetition_rate": 0.828125
     },
     {
@@ -3213,7 +6368,7 @@
       "success_rate": 0.0,
       "avg_steps": 37.0,
       "avg_tokens": 29740.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01170675,
       "repetition_rate": 0.7027027027027027
     },
     {
@@ -3224,7 +6379,7 @@
       "success_rate": 0.0,
       "avg_steps": 209.0,
       "avg_tokens": 160565.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0612025,
       "repetition_rate": 0.8373205741626795
     },
     {
@@ -3235,7 +6390,7 @@
       "success_rate": 0.0,
       "avg_steps": 95.0,
       "avg_tokens": 65421.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02586475,
       "repetition_rate": 0.8
     },
     {
@@ -3246,7 +6401,7 @@
       "success_rate": 1.0,
       "avg_steps": 58.0,
       "avg_tokens": 51711.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01907375,
       "repetition_rate": 0.7758620689655172
     },
     {
@@ -3257,7 +6412,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 35001.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01708025,
       "repetition_rate": 0.7741935483870968
     },
     {
@@ -3268,7 +6423,7 @@
       "success_rate": 0.0,
       "avg_steps": 21.0,
       "avg_tokens": 32329.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.014545,
       "repetition_rate": 0.7142857142857143
     },
     {
@@ -3279,7 +6434,7 @@
       "success_rate": 1.0,
       "avg_steps": 20.0,
       "avg_tokens": 21231.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0108885,
       "repetition_rate": 0.8
     },
     {
@@ -3290,7 +6445,7 @@
       "success_rate": 0.0,
       "avg_steps": 27.0,
       "avg_tokens": 30225.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01387375,
       "repetition_rate": 0.7777777777777778
     },
     {
@@ -3301,7 +6456,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 34972.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01653925,
       "repetition_rate": 0.6129032258064516
     },
     {
@@ -3312,7 +6467,7 @@
       "success_rate": 0.0,
       "avg_steps": 109.0,
       "avg_tokens": 124654.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.06037275,
       "repetition_rate": 0.7706422018348624
     },
     {
@@ -3323,7 +6478,7 @@
       "success_rate": 0.0,
       "avg_steps": 49.0,
       "avg_tokens": 44448.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.02327625,
       "repetition_rate": 0.7755102040816326
     },
     {
@@ -3334,7 +6489,7 @@
       "success_rate": 0.0,
       "avg_steps": 4.0,
       "avg_tokens": 6100.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.00285675,
       "repetition_rate": 0.5
     },
     {
@@ -3345,7 +6500,7 @@
       "success_rate": 0.0,
       "avg_steps": 21.0,
       "avg_tokens": 22967.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01127175,
       "repetition_rate": 0.7619047619047619
     },
     {
@@ -3356,7 +6511,7 @@
       "success_rate": 0.0,
       "avg_steps": 100.0,
       "avg_tokens": 88747.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.042905,
       "repetition_rate": 0.77
     },
     {
@@ -3367,7 +6522,7 @@
       "success_rate": 0.0,
       "avg_steps": 65.0,
       "avg_tokens": 68112.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.034626,
       "repetition_rate": 0.6923076923076923
     },
     {
@@ -3378,7 +6533,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 37450.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01820525,
       "repetition_rate": 0.6774193548387096
     },
     {
@@ -3389,7 +6544,7 @@
       "success_rate": 0.0,
       "avg_steps": 145.0,
       "avg_tokens": 143000.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.06958275,
       "repetition_rate": 0.7931034482758621
     },
     {
@@ -3400,7 +6555,7 @@
       "success_rate": 0.0,
       "avg_steps": 46.0,
       "avg_tokens": 40738.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.020849,
       "repetition_rate": 0.7391304347826086
     },
     {
@@ -3411,8 +6566,1108 @@
       "success_rate": 1.0,
       "avg_steps": 34.0,
       "avg_tokens": 43632.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0203125,
       "repetition_rate": 0.6470588235294118
+    },
+    {
+      "model": "llama-4-scout",
+      "mode": "stateful_compact",
+      "quest": "Disk_eng",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 8.333333333333334,
+      "avg_tokens": 7244.666666666667,
+      "avg_cost_usd": 0.0006610466666666666,
+      "repetition_rate": 0.6825396825396824
+    },
+    {
+      "model": "llama-4-scout",
+      "mode": "stateful_compact",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 88.66666666666667,
+      "avg_tokens": 302002.6666666667,
+      "avg_cost_usd": 0.02549040666666667,
+      "repetition_rate": 0.7445090856855563
+    },
+    {
+      "model": "llama-4-scout",
+      "mode": "stateful_compact",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 64.66666666666667,
+      "avg_tokens": 181515.33333333334,
+      "avg_cost_usd": 0.015320486666666666,
+      "repetition_rate": 0.7796474358974358
+    },
+    {
+      "model": "llama-4-scout",
+      "mode": "stateful_compact",
+      "quest": "Pilot_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 30.333333333333332,
+      "avg_tokens": 75418.0,
+      "avg_cost_usd": 0.00636894,
+      "repetition_rate": 0.6866397969846245
+    },
+    {
+      "model": "llama-4-scout",
+      "mode": "stateful_compact",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 51.333333333333336,
+      "avg_tokens": 123645.0,
+      "avg_cost_usd": 0.01043082,
+      "repetition_rate": 0.8018394648829431
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 49.0,
+      "avg_tokens": 50514.333333333336,
+      "avg_cost_usd": 0.020306253333333333,
+      "repetition_rate": 0.8152243353481743
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 7.0,
+      "avg_tokens": 10078.666666666666,
+      "avg_cost_usd": 0.0040174699999999995,
+      "repetition_rate": 0.7142857142857143
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Boat",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 15.0,
+      "avg_tokens": 18377.666666666668,
+      "avg_cost_usd": 0.007383703333333334,
+      "repetition_rate": 0.8232456140350877
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 25.666666666666668,
+      "avg_tokens": 45482.333333333336,
+      "avg_cost_usd": 0.018071663333333335,
+      "repetition_rate": 0.782078853046595
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 53.333333333333336,
+      "avg_tokens": 70095.33333333333,
+      "avg_cost_usd": 0.029048393333333335,
+      "repetition_rate": 0.7290488728750923
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 11.0,
+      "avg_tokens": 14574.333333333334,
+      "avg_cost_usd": 0.006391366666666666,
+      "repetition_rate": 0.8425925925925926
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 29.0,
+      "avg_tokens": 32561.0,
+      "avg_cost_usd": 0.015079373333333333,
+      "repetition_rate": 0.7827956989247312
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 26.666666666666668,
+      "avg_tokens": 38496.666666666664,
+      "avg_cost_usd": 0.014211343333333334,
+      "repetition_rate": 0.5700152207001522
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 18.0,
+      "avg_tokens": 22775.0,
+      "avg_cost_usd": 0.009792213333333334,
+      "repetition_rate": 0.7075163398692811
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 85.33333333333333,
+      "avg_tokens": 98000.33333333333,
+      "avg_cost_usd": 0.040996076666666666,
+      "repetition_rate": 0.8814536340852129
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 66.33333333333333,
+      "avg_tokens": 67260.66666666667,
+      "avg_cost_usd": 0.028876676666666667,
+      "repetition_rate": 0.8084426753157402
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 30.666666666666668,
+      "avg_tokens": 44087.0,
+      "avg_cost_usd": 0.01934756,
+      "repetition_rate": 0.6845878136200717
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Prison_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 80.0,
+      "avg_tokens": 89595.66666666667,
+      "avg_cost_usd": 0.03587598333333333,
+      "repetition_rate": 0.8781492132479133
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 58.333333333333336,
+      "avg_tokens": 57149.333333333336,
+      "avg_cost_usd": 0.02428245,
+      "repetition_rate": 0.818246415429514
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "stub",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 59.333333333333336,
+      "avg_tokens": 92232.0,
+      "avg_cost_usd": 0.03734973666666667,
+      "repetition_rate": 0.7059724612145505
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 47.333333333333336,
+      "avg_tokens": 65912.0,
+      "avg_cost_usd": 0.027815593333333333,
+      "repetition_rate": 0.7869943676395289
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 20.0,
+      "avg_tokens": 34553.666666666664,
+      "avg_cost_usd": 0.013857973333333334,
+      "repetition_rate": 0.8680555555555555
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Boat",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 15.666666666666666,
+      "avg_tokens": 25045.0,
+      "avg_cost_usd": 0.01037487,
+      "repetition_rate": 0.9170490328385066
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 25.666666666666668,
+      "avg_tokens": 48274.0,
+      "avg_cost_usd": 0.018495256666666668,
+      "repetition_rate": 0.771326164874552
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 46.666666666666664,
+      "avg_tokens": 78550.33333333333,
+      "avg_cost_usd": 0.03315534333333333,
+      "repetition_rate": 0.7116274457958752
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 9.0,
+      "avg_tokens": 14071.333333333334,
+      "avg_cost_usd": 0.006083783333333333,
+      "repetition_rate": 0.7658730158730158
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 31.0,
+      "avg_tokens": 41133.333333333336,
+      "avg_cost_usd": 0.019223713333333333,
+      "repetition_rate": 0.8064516129032259
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.333333333333336,
+      "avg_tokens": 60073.0,
+      "avg_cost_usd": 0.02354267666666667,
+      "repetition_rate": 0.8799019607843137
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 15.0,
+      "avg_tokens": 21892.666666666668,
+      "avg_cost_usd": 0.00938145,
+      "repetition_rate": 0.8232142857142857
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 62.0,
+      "avg_tokens": 88773.66666666667,
+      "avg_cost_usd": 0.03821826,
+      "repetition_rate": 0.8865046296296296
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 61.666666666666664,
+      "avg_tokens": 83567.33333333333,
+      "avg_cost_usd": 0.03652496,
+      "repetition_rate": 0.8227016542233933
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 30.333333333333332,
+      "avg_tokens": 49064.666666666664,
+      "avg_cost_usd": 0.02100021666666667,
+      "repetition_rate": 0.6921146953405017
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Prison_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 85.33333333333333,
+      "avg_tokens": 127810.0,
+      "avg_cost_usd": 0.05414950666666667,
+      "repetition_rate": 0.8668679549114332
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 45.333333333333336,
+      "avg_tokens": 60880.333333333336,
+      "avg_cost_usd": 0.027300920000000003,
+      "repetition_rate": 0.8208755274261602
+    },
+    {
+      "model": "minimax-m2.5",
+      "mode": "reasoning",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 62.666666666666664,
+      "avg_tokens": 112035.66666666667,
+      "avg_cost_usd": 0.04507698666666667,
+      "repetition_rate": 0.7197280444744948
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Badday_eng",
+      "runs": 6,
+      "success_rate": 0.8333333333333334,
+      "avg_steps": 26.166666666666668,
+      "avg_tokens": 13711.0,
+      "avg_cost_usd": 0.006902166666666667,
+      "repetition_rate": 0.8191430237270644
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Banket_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 34.0,
+      "avg_tokens": 26803.0,
+      "avg_cost_usd": 0.013467833333333333,
+      "repetition_rate": 0.6814362108479756
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Boat",
+      "runs": 6,
+      "success_rate": 1.0,
+      "avg_steps": 18.0,
+      "avg_tokens": 10736.0,
+      "avg_cost_usd": 0.0054013333333333335,
+      "repetition_rate": 0.8234649122807017
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Codebox_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 22.666666666666668,
+      "avg_tokens": 18434.333333333332,
+      "avg_cost_usd": 0.0092625,
+      "repetition_rate": 0.7480286738351255
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Depth_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 76.5,
+      "avg_tokens": 52745.333333333336,
+      "avg_cost_usd": 0.02652466666666667,
+      "repetition_rate": 0.7106358959754476
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Driver_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 61.833333333333336,
+      "avg_tokens": 40411.0,
+      "avg_cost_usd": 0.020328166666666665,
+      "repetition_rate": 0.756721744915614
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Edelweiss_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 46.666666666666664,
+      "avg_tokens": 25803.333333333332,
+      "avg_cost_usd": 0.013005999999999998,
+      "repetition_rate": 0.7237880185400648
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Election_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 70.16666666666667,
+      "avg_tokens": 61864.666666666664,
+      "avg_cost_usd": 0.03107266666666667,
+      "repetition_rate": 0.6505843693343694
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Foncers_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 35.333333333333336,
+      "avg_tokens": 21438.333333333332,
+      "avg_cost_usd": 0.010789833333333334,
+      "repetition_rate": 0.659279475082495
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Leonardo_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 87.16666666666667,
+      "avg_tokens": 53730.666666666664,
+      "avg_cost_usd": 0.027039666666666667,
+      "repetition_rate": 0.7517910877090114
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Ministry_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 108.0,
+      "avg_tokens": 58972.166666666664,
+      "avg_cost_usd": 0.029702083333333334,
+      "repetition_rate": 0.8103747134997222
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Pizza_eng",
+      "runs": 6,
+      "success_rate": 0.8333333333333334,
+      "avg_steps": 28.0,
+      "avg_tokens": 18451.5,
+      "avg_cost_usd": 0.00928175,
+      "repetition_rate": 0.537834631071561
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Prison_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 470.8333333333333,
+      "avg_tokens": 296429.8333333333,
+      "avg_cost_usd": 0.14915658333333334,
+      "repetition_rate": 0.8616869317771044
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Robots_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 39.333333333333336,
+      "avg_tokens": 21702.166666666668,
+      "avg_cost_usd": 0.01092975,
+      "repetition_rate": 0.8389655172413794
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "stub",
+      "quest": "Ski_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 70.33333333333333,
+      "avg_tokens": 56946.333333333336,
+      "avg_cost_usd": 0.028613833333333335,
+      "repetition_rate": 0.6025732626619189
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Badday_eng",
+      "runs": 6,
+      "success_rate": 1.0,
+      "avg_steps": 23.833333333333332,
+      "avg_tokens": 18038.5,
+      "avg_cost_usd": 0.010326583333333333,
+      "repetition_rate": 0.8395502661025164
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Banket_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 33.666666666666664,
+      "avg_tokens": 33076.166666666664,
+      "avg_cost_usd": 0.01845325,
+      "repetition_rate": 0.6829216535098888
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Boat",
+      "runs": 6,
+      "success_rate": 1.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 15602.166666666666,
+      "avg_cost_usd": 0.00890625,
+      "repetition_rate": 0.8070175438596491
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Codebox_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 23.0,
+      "avg_tokens": 22474.666666666668,
+      "avg_cost_usd": 0.012547499999999998,
+      "repetition_rate": 0.7120743727598566
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Depth_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 54.166666666666664,
+      "avg_tokens": 47880.666666666664,
+      "avg_cost_usd": 0.027163166666666665,
+      "repetition_rate": 0.6579244638984506
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Driver_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 46.166666666666664,
+      "avg_tokens": 39014.5,
+      "avg_cost_usd": 0.02216441666666667,
+      "repetition_rate": 0.750380026799109
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Edelweiss_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 36.333333333333336,
+      "avg_tokens": 27207.0,
+      "avg_cost_usd": 0.015626499999999998,
+      "repetition_rate": 0.6745742425536885
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Election_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 77.5,
+      "avg_tokens": 83058.33333333333,
+      "avg_cost_usd": 0.04615233333333333,
+      "repetition_rate": 0.672706105840699
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Foncers_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 28.333333333333332,
+      "avg_tokens": 22242.666666666668,
+      "avg_cost_usd": 0.012688,
+      "repetition_rate": 0.7174138078170337
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Leonardo_eng",
+      "runs": 6,
+      "success_rate": 0.16666666666666666,
+      "avg_steps": 105.33333333333333,
+      "avg_tokens": 83101.0,
+      "avg_cost_usd": 0.04722883333333333,
+      "repetition_rate": 0.7442600372535288
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Ministry_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 197.5,
+      "avg_tokens": 146650.16666666666,
+      "avg_cost_usd": 0.08389591666666667,
+      "repetition_rate": 0.7981068652795712
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Pizza_eng",
+      "runs": 6,
+      "success_rate": 0.16666666666666666,
+      "avg_steps": 38.666666666666664,
+      "avg_tokens": 32616.666666666668,
+      "avg_cost_usd": 0.018640833333333332,
+      "repetition_rate": 0.5535885167464115
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Prison_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 145.16666666666666,
+      "avg_tokens": 117193.16666666667,
+      "avg_cost_usd": 0.06671225,
+      "repetition_rate": 0.8411010712517605
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Robots_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 56.5,
+      "avg_tokens": 41277.833333333336,
+      "avg_cost_usd": 0.023723750000000002,
+      "repetition_rate": 0.799464500398872
+    },
+    {
+      "model": "mistral-large-2512",
+      "mode": "reasoning",
+      "quest": "Ski_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 54.666666666666664,
+      "avg_tokens": 55171.5,
+      "avg_cost_usd": 0.03071525,
+      "repetition_rate": 0.6394135483582769
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Badday_eng",
+      "runs": 6,
+      "success_rate": 1.0,
+      "avg_steps": 24.0,
+      "avg_tokens": 13726.0,
+      "avg_cost_usd": 0.0055672000000000004,
+      "repetition_rate": 0.8246092503987241
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Banket_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 34.333333333333336,
+      "avg_tokens": 27914.333333333332,
+      "avg_cost_usd": 0.011275600000000002,
+      "repetition_rate": 0.6504201680672269
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Boat",
+      "runs": 6,
+      "success_rate": 0.8333333333333334,
+      "avg_steps": 17.5,
+      "avg_tokens": 11298.5,
+      "avg_cost_usd": 0.0045754,
+      "repetition_rate": 0.7993421052631579
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Codebox_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 15.833333333333334,
+      "avg_tokens": 12165.5,
+      "avg_cost_usd": 0.004916866666666666,
+      "repetition_rate": 0.696175755248336
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Depth_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 52.666666666666664,
+      "avg_tokens": 36109.333333333336,
+      "avg_cost_usd": 0.014612266666666667,
+      "repetition_rate": 0.6132385560129058
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Driver_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 84.16666666666667,
+      "avg_tokens": 55804.5,
+      "avg_cost_usd": 0.022591133333333333,
+      "repetition_rate": 0.7401227175055124
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Edelweiss_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 44.0,
+      "avg_tokens": 24676.5,
+      "avg_cost_usd": 0.0100114,
+      "repetition_rate": 0.7141254447535963
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Election_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 73.33333333333333,
+      "avg_tokens": 64473.833333333336,
+      "avg_cost_usd": 0.0260242,
+      "repetition_rate": 0.7027408174790738
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Foncers_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 32.5,
+      "avg_tokens": 18983.5,
+      "avg_cost_usd": 0.0076974,
+      "repetition_rate": 0.6423387096774194
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Leonardo_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 95.33333333333333,
+      "avg_tokens": 58834.666666666664,
+      "avg_cost_usd": 0.023838933333333336,
+      "repetition_rate": 0.7399261699297567
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Ministry_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 360.6666666666667,
+      "avg_tokens": 196670.16666666666,
+      "avg_cost_usd": 0.0798222,
+      "repetition_rate": 0.7684457789193223
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Pizza_eng",
+      "runs": 6,
+      "success_rate": 1.0,
+      "avg_steps": 29.0,
+      "avg_tokens": 19338.666666666668,
+      "avg_cost_usd": 0.007828266666666667,
+      "repetition_rate": 0.46648392393664917
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Prison_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 346.3333333333333,
+      "avg_tokens": 218629.83333333334,
+      "avg_cost_usd": 0.08858046666666668,
+      "repetition_rate": 0.8408879517101401
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Robots_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 41.833333333333336,
+      "avg_tokens": 23099.333333333332,
+      "avg_cost_usd": 0.009373600000000001,
+      "repetition_rate": 0.8081490693761783
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "stub",
+      "quest": "Ski_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 66.33333333333333,
+      "avg_tokens": 53709.166666666664,
+      "avg_cost_usd": 0.0217202,
+      "repetition_rate": 0.5841537445199781
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Badday_eng",
+      "runs": 6,
+      "success_rate": 0.8333333333333334,
+      "avg_steps": 28.5,
+      "avg_tokens": 21753.166666666668,
+      "avg_cost_usd": 0.011560733333333335,
+      "repetition_rate": 0.8074865076422362
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Banket_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 34.166666666666664,
+      "avg_tokens": 34115.333333333336,
+      "avg_cost_usd": 0.017561066666666666,
+      "repetition_rate": 0.6392708598590952
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Boat",
+      "runs": 6,
+      "success_rate": 1.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 15884.666666666666,
+      "avg_cost_usd": 0.008583200000000001,
+      "repetition_rate": 0.8421052631578947
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Codebox_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 17.5,
+      "avg_tokens": 16828.5,
+      "avg_cost_usd": 0.008573533333333333,
+      "repetition_rate": 0.6990527393753201
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Depth_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 56.0,
+      "avg_tokens": 49638.0,
+      "avg_cost_usd": 0.0262936,
+      "repetition_rate": 0.6666643280975662
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Driver_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 23.833333333333332,
+      "avg_tokens": 19801.333333333332,
+      "avg_cost_usd": 0.010536799999999999,
+      "repetition_rate": 0.7334684049800329
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Edelweiss_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 38.166666666666664,
+      "avg_tokens": 28943.5,
+      "avg_cost_usd": 0.015583533333333335,
+      "repetition_rate": 0.7190644549077229
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Election_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 72.5,
+      "avg_tokens": 78548.16666666667,
+      "avg_cost_usd": 0.040343,
+      "repetition_rate": 0.6689026991766718
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Foncers_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 26.5,
+      "avg_tokens": 21346.333333333332,
+      "avg_cost_usd": 0.011329733333333333,
+      "repetition_rate": 0.6428979524331239
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Leonardo_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 97.5,
+      "avg_tokens": 78759.33333333333,
+      "avg_cost_usd": 0.041983733333333335,
+      "repetition_rate": 0.7507508999920244
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Ministry_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 172.5,
+      "avg_tokens": 127951.66666666667,
+      "avg_cost_usd": 0.06839933333333334,
+      "repetition_rate": 0.7978752930255167
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Pizza_eng",
+      "runs": 6,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 35.833333333333336,
+      "avg_tokens": 30427.0,
+      "avg_cost_usd": 0.016234533333333332,
+      "repetition_rate": 0.5451580244500901
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Prison_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 78.33333333333333,
+      "avg_tokens": 62533.0,
+      "avg_cost_usd": 0.033274,
+      "repetition_rate": 0.815611065675486
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Robots_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 39.166666666666664,
+      "avg_tokens": 29016.166666666668,
+      "avg_cost_usd": 0.015661133333333334,
+      "repetition_rate": 0.8062326030716834
+    },
+    {
+      "model": "mistral-medium-3.1",
+      "mode": "reasoning",
+      "quest": "Ski_eng",
+      "runs": 6,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 85.0,
+      "avg_tokens": 85894.5,
+      "avg_cost_usd": 0.04403886666666667,
+      "repetition_rate": 0.693016691791709
+    },
+    {
+      "model": "mistral-small-2603",
+      "mode": "stateful_compact",
+      "quest": "Disk_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 6.666666666666667,
+      "avg_tokens": 5316.333333333333,
+      "avg_cost_usd": 0.0009253999999999999,
+      "repetition_rate": 0.49603174603174605
+    },
+    {
+      "model": "mistral-small-2603",
+      "mode": "stateful_compact",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 55.0,
+      "avg_tokens": 183993.33333333334,
+      "avg_cost_usd": 0.029550800000000002,
+      "repetition_rate": 0.5878692646134507
+    },
+    {
+      "model": "mistral-small-2603",
+      "mode": "stateful_compact",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 59.666666666666664,
+      "avg_tokens": 179742.33333333334,
+      "avg_cost_usd": 0.0290171,
+      "repetition_rate": 0.755072463768116
+    },
+    {
+      "model": "mistral-small-2603",
+      "mode": "stateful_compact",
+      "quest": "Pilot_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 27.666666666666668,
+      "avg_tokens": 68175.0,
+      "avg_cost_usd": 0.0110418,
+      "repetition_rate": 0.7204545454545453
+    },
+    {
+      "model": "mistral-small-2603",
+      "mode": "stateful_compact",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 41.666666666666664,
+      "avg_tokens": 109646.66666666667,
+      "avg_cost_usd": 0.0177115,
+      "repetition_rate": 0.8037114845938375
     },
     {
       "model": "qwen-2.5-72b-instruct",
@@ -3422,7 +7677,7 @@
       "success_rate": 1.0,
       "avg_steps": 25.0,
       "avg_tokens": 14306.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0057224,
       "repetition_rate": 0.76
     },
     {
@@ -3433,7 +7688,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 27095.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.010838,
       "repetition_rate": 0.6176470588235294
     },
     {
@@ -3444,7 +7699,7 @@
       "success_rate": 0.0,
       "avg_steps": 11.0,
       "avg_tokens": 8013.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0032052,
       "repetition_rate": 0.8181818181818182
     },
     {
@@ -3455,7 +7710,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 25501.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0102004,
       "repetition_rate": 0.7741935483870968
     },
     {
@@ -3466,7 +7721,7 @@
       "success_rate": 0.0,
       "avg_steps": 32.0,
       "avg_tokens": 21957.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0087828,
       "repetition_rate": 0.75
     },
     {
@@ -3477,7 +7732,7 @@
       "success_rate": 0.0,
       "avg_steps": 41.0,
       "avg_tokens": 26893.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0107572,
       "repetition_rate": 0.7073170731707317
     },
     {
@@ -3488,7 +7743,7 @@
       "success_rate": 0.0,
       "avg_steps": 41.0,
       "avg_tokens": 19137.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0076548,
       "repetition_rate": 0.9024390243902439
     },
     {
@@ -3499,7 +7754,7 @@
       "success_rate": 0.0,
       "avg_steps": 4.0,
       "avg_tokens": 2529.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0010116,
       "repetition_rate": 0.5
     },
     {
@@ -3510,7 +7765,7 @@
       "success_rate": 0.0,
       "avg_steps": 20.0,
       "avg_tokens": 12002.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0048008,
       "repetition_rate": 0.6
     },
     {
@@ -3521,7 +7776,7 @@
       "success_rate": 0.0,
       "avg_steps": 109.0,
       "avg_tokens": 65841.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0263364,
       "repetition_rate": 0.8073394495412844
     },
     {
@@ -3532,7 +7787,7 @@
       "success_rate": 0.0,
       "avg_steps": 73.0,
       "avg_tokens": 41214.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0164856,
       "repetition_rate": 0.7397260273972602
     },
     {
@@ -3543,7 +7798,7 @@
       "success_rate": 1.0,
       "avg_steps": 30.0,
       "avg_tokens": 19278.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0077112,
       "repetition_rate": 0.5666666666666667
     },
     {
@@ -3554,7 +7809,7 @@
       "success_rate": 0.0,
       "avg_steps": 600.0,
       "avg_tokens": 378530.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.151412,
       "repetition_rate": 0.8616666666666667
     },
     {
@@ -3565,7 +7820,7 @@
       "success_rate": 0.0,
       "avg_steps": 27.0,
       "avg_tokens": 14676.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0058704,
       "repetition_rate": 0.7777777777777778
     },
     {
@@ -3576,7 +7831,7 @@
       "success_rate": 0.0,
       "avg_steps": 78.0,
       "avg_tokens": 62043.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0248172,
       "repetition_rate": 0.7307692307692307
     },
     {
@@ -3587,7 +7842,7 @@
       "success_rate": 1.0,
       "avg_steps": 29.0,
       "avg_tokens": 20861.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0083444,
       "repetition_rate": 0.7931034482758621
     },
     {
@@ -3598,7 +7853,7 @@
       "success_rate": 0.0,
       "avg_steps": 26.0,
       "avg_tokens": 24353.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0097412,
       "repetition_rate": 0.6538461538461539
     },
     {
@@ -3609,7 +7864,7 @@
       "success_rate": 0.0,
       "avg_steps": 16.0,
       "avg_tokens": 13514.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0054056,
       "repetition_rate": 0.75
     },
     {
@@ -3620,7 +7875,7 @@
       "success_rate": 0.0,
       "avg_steps": 30.0,
       "avg_tokens": 28426.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0113704,
       "repetition_rate": 0.7333333333333333
     },
     {
@@ -3631,7 +7886,7 @@
       "success_rate": 0.0,
       "avg_steps": 75.0,
       "avg_tokens": 62328.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0249312,
       "repetition_rate": 0.68
     },
     {
@@ -3642,7 +7897,7 @@
       "success_rate": 0.0,
       "avg_steps": 43.0,
       "avg_tokens": 34105.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.013642,
       "repetition_rate": 0.7906976744186046
     },
     {
@@ -3653,7 +7908,7 @@
       "success_rate": 0.0,
       "avg_steps": 56.0,
       "avg_tokens": 34879.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0139516,
       "repetition_rate": 0.8214285714285714
     },
     {
@@ -3664,7 +7919,7 @@
       "success_rate": 0.0,
       "avg_steps": 50.0,
       "avg_tokens": 49706.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0198824,
       "repetition_rate": 0.78
     },
     {
@@ -3675,7 +7930,7 @@
       "success_rate": 0.0,
       "avg_steps": 24.0,
       "avg_tokens": 17636.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0070544,
       "repetition_rate": 0.6666666666666666
     },
     {
@@ -3686,7 +7941,7 @@
       "success_rate": 0.0,
       "avg_steps": 98.0,
       "avg_tokens": 75704.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0302816,
       "repetition_rate": 0.7448979591836735
     },
     {
@@ -3697,7 +7952,7 @@
       "success_rate": 0.0,
       "avg_steps": 56.0,
       "avg_tokens": 38725.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.01549,
       "repetition_rate": 0.8392857142857143
     },
     {
@@ -3708,7 +7963,7 @@
       "success_rate": 0.0,
       "avg_steps": 51.0,
       "avg_tokens": 39835.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.015934,
       "repetition_rate": 0.6078431372549019
     },
     {
@@ -3719,7 +7974,7 @@
       "success_rate": 0.0,
       "avg_steps": 71.0,
       "avg_tokens": 53559.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0214236,
       "repetition_rate": 0.8169014084507042
     },
     {
@@ -3730,7 +7985,7 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 22710.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.009084,
       "repetition_rate": 0.7352941176470589
     },
     {
@@ -3741,7 +7996,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 28267.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0113068,
       "repetition_rate": 0.5483870967741935
     },
     {
@@ -3752,7 +8007,7 @@
       "success_rate": 1.0,
       "avg_steps": 28.0,
       "avg_tokens": 20179.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0080716,
       "repetition_rate": 0.8214285714285714
     },
     {
@@ -3763,7 +8018,7 @@
       "success_rate": 0.0,
       "avg_steps": 26.0,
       "avg_tokens": 24777.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0099108,
       "repetition_rate": 0.6153846153846154
     },
     {
@@ -3774,7 +8029,7 @@
       "success_rate": 1.0,
       "avg_steps": 19.0,
       "avg_tokens": 16176.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0064704,
       "repetition_rate": 0.8421052631578947
     },
     {
@@ -3785,7 +8040,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 29752.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0119008,
       "repetition_rate": 0.7419354838709677
     },
     {
@@ -3796,7 +8051,7 @@
       "success_rate": 0.0,
       "avg_steps": 48.0,
       "avg_tokens": 40633.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0162532,
       "repetition_rate": 0.7083333333333334
     },
     {
@@ -3807,7 +8062,7 @@
       "success_rate": 0.0,
       "avg_steps": 36.0,
       "avg_tokens": 29758.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0119032,
       "repetition_rate": 0.6666666666666666
     },
     {
@@ -3818,7 +8073,7 @@
       "success_rate": 0.0,
       "avg_steps": 47.0,
       "avg_tokens": 31889.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0127556,
       "repetition_rate": 0.7659574468085106
     },
     {
@@ -3829,7 +8084,7 @@
       "success_rate": 0.0,
       "avg_steps": 55.0,
       "avg_tokens": 55291.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0221164,
       "repetition_rate": 0.7272727272727273
     },
     {
@@ -3840,7 +8095,7 @@
       "success_rate": 0.0,
       "avg_steps": 21.0,
       "avg_tokens": 15862.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0063448,
       "repetition_rate": 0.6666666666666666
     },
     {
@@ -3851,7 +8106,7 @@
       "success_rate": 0.0,
       "avg_steps": 97.0,
       "avg_tokens": 75025.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.03001,
       "repetition_rate": 0.7835051546391752
     },
     {
@@ -3862,7 +8117,7 @@
       "success_rate": 0.0,
       "avg_steps": 42.0,
       "avg_tokens": 29129.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0116516,
       "repetition_rate": 0.8571428571428571
     },
     {
@@ -3873,7 +8128,7 @@
       "success_rate": 0.0,
       "avg_steps": 36.0,
       "avg_tokens": 28260.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.011304,
       "repetition_rate": 0.6666666666666666
     },
     {
@@ -3884,7 +8139,7 @@
       "success_rate": 0.0,
       "avg_steps": 414.0,
       "avg_tokens": 324471.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.1297884,
       "repetition_rate": 0.8502415458937198
     },
     {
@@ -3895,7 +8150,7 @@
       "success_rate": 0.0,
       "avg_steps": 79.0,
       "avg_tokens": 53412.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0213648,
       "repetition_rate": 0.810126582278481
     },
     {
@@ -3906,7 +8161,7 @@
       "success_rate": 0.0,
       "avg_steps": 36.0,
       "avg_tokens": 33238.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0132952,
       "repetition_rate": 0.6111111111111112
     },
     {
@@ -3917,7 +8172,7 @@
       "success_rate": 1.0,
       "avg_steps": 25.0,
       "avg_tokens": 27164.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0108656,
       "repetition_rate": 0.8
     },
     {
@@ -3928,7 +8183,7 @@
       "success_rate": 0.0,
       "avg_steps": 22.0,
       "avg_tokens": 32696.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0130784,
       "repetition_rate": 0.6818181818181818
     },
     {
@@ -3939,7 +8194,7 @@
       "success_rate": 1.0,
       "avg_steps": 19.0,
       "avg_tokens": 20485.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.008194,
       "repetition_rate": 0.7894736842105263
     },
     {
@@ -3950,7 +8205,7 @@
       "success_rate": 0.0,
       "avg_steps": 25.0,
       "avg_tokens": 25217.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0100868,
       "repetition_rate": 0.68
     },
     {
@@ -3961,7 +8216,7 @@
       "success_rate": 0.0,
       "avg_steps": 37.0,
       "avg_tokens": 41676.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0166704,
       "repetition_rate": 0.7297297297297297
     },
     {
@@ -3972,7 +8227,7 @@
       "success_rate": 0.0,
       "avg_steps": 15.0,
       "avg_tokens": 17002.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0068008,
       "repetition_rate": 0.6666666666666666
     },
     {
@@ -3983,7 +8238,7 @@
       "success_rate": 0.0,
       "avg_steps": 31.0,
       "avg_tokens": 26003.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0104012,
       "repetition_rate": 0.7741935483870968
     },
     {
@@ -3994,7 +8249,7 @@
       "success_rate": 0.0,
       "avg_steps": 42.0,
       "avg_tokens": 65542.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0262168,
       "repetition_rate": 0.7142857142857143
     },
     {
@@ -4005,7 +8260,7 @@
       "success_rate": 0.0,
       "avg_steps": 23.0,
       "avg_tokens": 23006.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0092024,
       "repetition_rate": 0.6521739130434783
     },
     {
@@ -4016,7 +8271,7 @@
       "success_rate": 0.0,
       "avg_steps": 104.0,
       "avg_tokens": 82293.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0329172,
       "repetition_rate": 0.7884615384615384
     },
     {
@@ -4027,7 +8282,7 @@
       "success_rate": 0.0,
       "avg_steps": 159.0,
       "avg_tokens": 155859.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0623436,
       "repetition_rate": 0.8238993710691824
     },
     {
@@ -4038,7 +8293,7 @@
       "success_rate": 0.0,
       "avg_steps": 18.0,
       "avg_tokens": 20229.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0080916,
       "repetition_rate": 0.5
     },
     {
@@ -4049,7 +8304,7 @@
       "success_rate": 0.0,
       "avg_steps": 80.0,
       "avg_tokens": 71809.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0287236,
       "repetition_rate": 0.775
     },
     {
@@ -4060,7 +8315,7 @@
       "success_rate": 0.0,
       "avg_steps": 93.0,
       "avg_tokens": 78455.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.031382,
       "repetition_rate": 0.8064516129032258
     },
     {
@@ -4071,8 +8326,85 @@
       "success_rate": 0.0,
       "avg_steps": 34.0,
       "avg_tokens": 41557.0,
-      "avg_cost_usd": 0.0,
+      "avg_cost_usd": 0.0166228,
       "repetition_rate": 0.7058823529411765
+    },
+    {
+      "model": "qwen3-235b-a22b",
+      "mode": "stub",
+      "quest": "Boat",
+      "runs": 1,
+      "success_rate": 0.0,
+      "avg_steps": 10.0,
+      "avg_tokens": 12323.0,
+      "avg_cost_usd": 0.0040634,
+      "repetition_rate": 0.8
+    },
+    {
+      "model": "qwen3-30b-a3b",
+      "mode": "stateful_compact",
+      "quest": "Disk_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 7.666666666666667,
+      "avg_tokens": 11612.666666666666,
+      "avg_cost_usd": 0.0017948800000000002,
+      "repetition_rate": 0.6507936507936508
+    },
+    {
+      "model": "qwen3-30b-a3b",
+      "mode": "stateful_compact",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 4.0,
+      "avg_tokens": 8981.666666666666,
+      "avg_cost_usd": 0.0015508666666666667,
+      "repetition_rate": 0.19444444444444445
+    },
+    {
+      "model": "qwen3-30b-a3b",
+      "mode": "stateful_compact",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 21.333333333333332,
+      "avg_tokens": 56280.333333333336,
+      "avg_cost_usd": 0.00711276,
+      "repetition_rate": 0.5208333333333334
+    },
+    {
+      "model": "qwen3-30b-a3b",
+      "mode": "stateful_compact",
+      "quest": "Pilot_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 5.333333333333333,
+      "avg_tokens": 9996.0,
+      "avg_cost_usd": 0.0017367466666666665,
+      "repetition_rate": 0.41269841269841273
+    },
+    {
+      "model": "qwen3-30b-a3b",
+      "mode": "stateful_compact",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 34.0,
+      "avg_tokens": 84947.33333333333,
+      "avg_cost_usd": 0.011037786666666667,
+      "repetition_rate": 0.7740332244008714
+    },
+    {
+      "model": "qwen3.6-flash",
+      "mode": "stateful_compact",
+      "quest": "Sortirovka1_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 0.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.0
     }
   ]
 }

--- a/site/play/Badday_eng.json
+++ b/site/play/Badday_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Badday_eng",
-  "generated": "2026-05-03T07:07:43Z",
+  "generated": "2026-05-04T14:33:38Z",
   "total_runs": 285,
   "win_rate": 0.2175,
   "model_families": [

--- a/site/play/Banket_eng.json
+++ b/site/play/Banket_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Banket_eng",
-  "generated": "2026-05-03T07:07:43Z",
+  "generated": "2026-05-04T14:33:38Z",
   "total_runs": 272,
   "win_rate": 0.0,
   "model_families": [

--- a/site/play/Borzukhan_eng.json
+++ b/site/play/Borzukhan_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Borzukhan_eng",
-  "generated": "2026-05-03T07:07:43Z",
+  "generated": "2026-05-04T14:33:38Z",
   "total_runs": 6,
   "win_rate": 0.1667,
   "model_families": [

--- a/site/play/Codebox_eng.json
+++ b/site/play/Codebox_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Codebox_eng",
-  "generated": "2026-05-03T07:07:44Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 265,
   "win_rate": 0.0,
   "model_families": [

--- a/site/play/Depth_eng.json
+++ b/site/play/Depth_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Depth_eng",
-  "generated": "2026-05-03T07:07:44Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 271,
   "win_rate": 0.0,
   "model_families": [

--- a/site/play/Disk_eng.json
+++ b/site/play/Disk_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Disk_eng",
-  "generated": "2026-05-03T07:07:44Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 85,
   "win_rate": 0.1765,
   "model_families": [

--- a/site/play/Driver_eng.json
+++ b/site/play/Driver_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Driver_eng",
-  "generated": "2026-05-03T07:07:44Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 265,
   "win_rate": 0.0,
   "model_families": [

--- a/site/play/Edelweiss_eng.json
+++ b/site/play/Edelweiss_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Edelweiss_eng",
-  "generated": "2026-05-03T07:07:44Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 271,
   "win_rate": 0.0,
   "model_families": [

--- a/site/play/Election_eng.json
+++ b/site/play/Election_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Election_eng",
-  "generated": "2026-05-03T07:07:43Z",
+  "generated": "2026-05-04T14:33:38Z",
   "total_runs": 286,
   "win_rate": 0.042,
   "model_families": [

--- a/site/play/Foncers_eng.json
+++ b/site/play/Foncers_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Foncers_eng",
-  "generated": "2026-05-03T07:07:44Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 269,
   "win_rate": 0.0,
   "model_families": [

--- a/site/play/Leonardo_eng.json
+++ b/site/play/Leonardo_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Leonardo_eng",
-  "generated": "2026-05-03T07:07:44Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 279,
   "win_rate": 0.0251,
   "model_families": [

--- a/site/play/Ministry_eng.json
+++ b/site/play/Ministry_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Ministry_eng",
-  "generated": "2026-05-03T07:07:44Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 269,
   "win_rate": 0.0037,
   "model_families": [

--- a/site/play/Pilot_eng.json
+++ b/site/play/Pilot_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Pilot_eng",
-  "generated": "2026-05-03T07:07:44Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 89,
   "win_rate": 0.0899,
   "model_families": [

--- a/site/play/Pizza_eng.json
+++ b/site/play/Pizza_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Pizza_eng",
-  "generated": "2026-05-03T07:07:43Z",
+  "generated": "2026-05-04T14:33:38Z",
   "total_runs": 297,
   "win_rate": 0.1717,
   "model_families": [

--- a/site/play/Player_eng.json
+++ b/site/play/Player_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Player_eng",
-  "generated": "2026-05-03T07:07:45Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 69,
   "win_rate": 0.0,
   "model_families": [

--- a/site/play/Robots_eng.json
+++ b/site/play/Robots_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Robots_eng",
-  "generated": "2026-05-03T07:07:43Z",
+  "generated": "2026-05-04T14:33:38Z",
   "total_runs": 284,
   "win_rate": 0.0106,
   "model_families": [

--- a/site/play/Shashki_eng.json
+++ b/site/play/Shashki_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Shashki_eng",
-  "generated": "2026-05-03T07:07:45Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 69,
   "win_rate": 0.0435,
   "model_families": [

--- a/site/play/Ski_eng.json
+++ b/site/play/Ski_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Ski_eng",
-  "generated": "2026-05-03T07:07:43Z",
+  "generated": "2026-05-04T14:33:38Z",
   "total_runs": 293,
   "win_rate": 0.0751,
   "model_families": [

--- a/site/play/Sortirovka1_eng.json
+++ b/site/play/Sortirovka1_eng.json
@@ -1,6 +1,6 @@
 {
   "quest": "Sortirovka1_eng",
-  "generated": "2026-05-03T07:07:45Z",
+  "generated": "2026-05-04T14:33:39Z",
   "total_runs": 71,
   "win_rate": 0.0282,
   "model_families": [


### PR DESCRIPTION
## Summary

- Regenerated leaderboard from all benchmark runs (6 -> 21 models, 360 -> 739 result entries)
- New models: Gemini-3-Flash, Mistral Medium/Large/Small, DeepSeek v3.2/v4-Flash, Llama 4 Scout, Minimax M2.5, Qwen3 variants, and more
- Rebuilt cohort data and quest-index.json with updated win rates and run counts

## Verification

- `uv run pytest llm_quest_benchmark/tests/test_play_share_social.py llm_quest_benchmark/tests/test_play_quest_index.py -v` -- all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata generation timestamps in multiple game data configuration files to reflect the latest system refresh cycles. This is routine maintenance to keep internal records synchronized and properly timestamped. All game features, quests, statistics, gameplay mechanics, character information, and player-facing functionality remain absolutely unchanged and fully operational without any impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->