### PR TITLE
Add arXiv draft and paper data

### DIFF
--- a/configs/benchmarks/tiered/tiered_easy_core_v1.yaml
+++ b/configs/benchmarks/tiered/tiered_easy_core_v1.yaml
@@ -1,0 +1,106 @@
+name: tiered_easy_core_v1
+quests:
+  - quests/Boat.qm
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+agents:
+  - model: openrouter:google/gemini-3-flash-preview
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:google/gemini-3-flash-preview
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:google/gemini-3-flash-preview
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:google/gemini-3-flash-preview
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: planner
+    temperature: 0.4
+    runs: 3
+debug: false
+quest_timeout: 600
+max_workers: 6
+output_dir: results/benchmarks

--- a/configs/benchmarks/tiered/tiered_hard_core_v1.yaml
+++ b/configs/benchmarks/tiered/tiered_hard_core_v1.yaml
@@ -1,0 +1,112 @@
+name: tiered_hard_core_v1
+quests:
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Prison_eng.qm
+agents:
+  - model: openrouter:google/gemini-3-flash-preview
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:google/gemini-3-flash-preview
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:google/gemini-3-flash-preview
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:google/gemini-3-flash-preview
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: planner
+    temperature: 0.4
+    runs: 3
+debug: false
+quest_timeout: 600
+max_workers: 6
+output_dir: results/benchmarks

--- a/configs/benchmarks/tiered/tiered_medium_core_v1.yaml
+++ b/configs/benchmarks/tiered/tiered_medium_core_v1.yaml
@@ -1,0 +1,106 @@
+name: tiered_medium_core_v1
+quests:
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+agents:
+  - model: openrouter:google/gemini-3-flash-preview
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:google/gemini-3-flash-preview
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:google/gemini-3-flash-preview
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:google/gemini-3-flash-preview
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:openai/gpt-5.4-mini
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:deepseek/deepseek-v3.2
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:mistralai/mistral-medium-3.1
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:anthropic/claude-haiku-4.5
+    template: planner
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: stub
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  - model: openrouter:minimax/minimax-m2.5
+    template: planner
+    temperature: 0.4
+    runs: 3
+debug: false
+quest_timeout: 600
+max_workers: 6
+output_dir: results/benchmarks

--- a/docs/plans/2026-04-20-preliminary-paper-and-tiered-benchmarks.md
+++ b/docs/plans/2026-04-20-preliminary-paper-and-tiered-benchmarks.md
@@ -1,0 +1,50 @@
+# Preliminary paper and tiered benchmark rollout implementation plan
+
+Goal: turn the current repo state into an honest preliminary benchmark writeup, anchored on an easy -> medium -> hard benchmark progression and the new canonical model lineup.
+
+Architecture: keep the paper/blog post tightly coupled to committed artifacts. Treat the current site as a preliminary paper, derive empirical claims only from committed benchmark outputs, then extend the dataset with tiered benchmark runs and regenerate leaderboard/report artifacts after each tier. Do not describe planned final-study scope as if it already exists.
+
+Tech stack: Python CLI via uv, existing llm-quest benchmark runner, site/leaderboard.json, benchmark artifacts under results/benchmarks, and a repository-local paper directory for the arXiv draft.
+
+## Ground truth decisions locked
+
+- Target machine: this Ubuntu VPS.
+- Target repo: `/root/llm_quest_benchmark`.
+- Canonical paper framing: honest preliminary benchmark draft.
+- Canonical public result source: the six-model published leaderboard slice in `site/leaderboard.json`.
+- Analysis order: easy benchmark first, then medium, then hard.
+- Tier configs under `configs/benchmarks/tiered/` define the next balanced rerun matrix. They are planning artifacts until reruns are executed.
+
+## Phase 0: normalize repo state before writing
+
+1. Inventory current benchmark artifacts and separate published evidence from exploratory local archives.
+2. Freeze the empirical easy, medium, and hard quest packs already proposed in the tiered configs.
+3. Ensure the paper cites only numbers that can be traced to committed data or explicitly marked local exploratory artifacts.
+
+## Phase 1: write from committed evidence
+
+1. Extract tier summaries, quest summaries, and mode/model rollups from `site/leaderboard.json`.
+2. Build a paper-facing data bundle under `paper/data/` plus generated table fragments under `paper/tables/`.
+3. Draft the preprint around three claims:
+   - the difficulty cliff from easy to medium to hard is already obvious;
+   - the current public archive is coverage-uneven across modes and should be read descriptively;
+   - the next balanced rerun should use the tiered configs on the current six-model lineup.
+
+## Phase 2: define the missing reruns and ablations
+
+Balanced rerun plan, but do not execute it in this change:
+
+1. A-D balanced matrix on the current six-model lineup:
+   - 15 quests x 6 models x 4 modes x 3 runs.
+2. Targeted tool-mode follow-up:
+   - easy and medium tiers plus `Election_eng`, where hard-tier nonzero signal already exists.
+3. Stability rerun:
+   - repeat the best and worst cells with additional independent runs.
+4. Human baseline:
+   - collect small-scale play traces through `site/play.html`.
+
+## Phase 3: publication hygiene
+
+1. Keep the site coherent with `master`: do not restore the deleted `site/paper.html`.
+2. Move paper work into `paper/` rather than reviving stale HTML drafts.
+3. Explain in the PR that no new expensive benchmark matrices were run.

--- a/paper/EXPERIMENT_PLAN.md
+++ b/paper/EXPERIMENT_PLAN.md
@@ -2,7 +2,7 @@
 
 These are the missing experiments for a stronger second draft. They are planned only in this branch.
 
-## 1. Balanced A-D tier rerun
+## 1. Balanced easy/medium/hard tier rerun
 
 Use the current six-model lineup from `site/leaderboard.json` with the committed tier configs:
 

--- a/paper/EXPERIMENT_PLAN.md
+++ b/paper/EXPERIMENT_PLAN.md
@@ -1,0 +1,53 @@
+# Remaining Experiments and Ablations
+
+These are the missing experiments for a stronger second draft. They are planned only in this branch.
+
+## 1. Balanced A-D tier rerun
+
+Use the current six-model lineup from `site/leaderboard.json` with the committed tier configs:
+
+- Easy: 3 quests
+- Medium: 3 quests
+- Hard: 9 quests
+- Modes: `stub`, `reasoning`, `light_hints`, `planner`
+- Runs: 3 per cell
+
+Exact matrix size:
+
+- `15 quests x 6 models x 4 modes x 3 runs = 1080 runs`
+
+This is the main missing experiment because it removes the current coverage imbalance.
+
+## 2. Targeted tool-mode follow-up
+
+Run `tool_augmented` only where the public archive already suggests signal:
+
+- Easy tier: `Boat`, `Badday_eng`, `Pizza_eng`
+- Medium tier: `Ski_eng`, `Robots_eng`, `Leonardo_eng`
+- Hard candidate: `Election_eng`
+
+Exact matrix size:
+
+- `7 quests x 6 models x 1 mode x 3 runs = 126 runs`
+
+Rationale: tool mode already has sparse nonzero hard-tier evidence, but not enough coverage for a clean claim.
+
+## 3. Repeat-run stability check
+
+For the strongest and weakest observed cells after the balanced rerun:
+
+- add repeated independent runs
+- report run counts alongside every success claim
+- test whether current easy-tier wins are stable or lucky
+
+## 4. Frontier-model appendix
+
+Keep the main paper on the production-tier six-model lineup. Add a separate appendix run for frontier models only after the balanced rerun is complete.
+
+## 5. Human baseline
+
+Collect small-scale human play traces from `site/play.html`:
+
+- time-to-finish
+- win rate on easy and medium tiers
+- qualitative comparison against agent failure modes

--- a/paper/README.md
+++ b/paper/README.md
@@ -1,0 +1,42 @@
+# Paper Draft
+
+This directory contains the repository-local LaTeX draft for the arXiv preprint.
+
+## Scope
+
+- The draft is intentionally conservative.
+- It uses the six-model published leaderboard slice in `site/leaderboard.json` as the canonical public evidence base.
+- The tier split comes from `configs/benchmarks/tiered/`.
+- No new expensive benchmark matrices were run for this branch.
+
+## Generate source data
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/build_paper_data.py
+```
+
+This writes CSV/JSON source data under `paper/data/` and TeX table fragments under `paper/tables/`.
+
+## Build
+
+Expected TeX toolchain:
+
+```bash
+latexmk -pdf -cd paper/main.tex
+```
+
+If `latexmk` is unavailable:
+
+```bash
+cd paper
+pdflatex main.tex
+bibtex main
+pdflatex main.tex
+pdflatex main.tex
+```
+
+## Status and TODOs
+
+- The draft text is complete enough for review, but it is still a preliminary preprint rather than a final camera-ready paper.
+- The VPS used for this branch does not currently have `latexmk`, `pdflatex`, or `bibtex`, so TeX compilation was not verified here.
+- The next substantive step is to run the balanced tiered reruns already defined in `configs/benchmarks/tiered/`.

--- a/paper/data/build_metadata.json
+++ b/paper/data/build_metadata.json
@@ -1,5 +1,5 @@
 {
   "leaderboard_generated": "2026-05-05T13:35:04.535791",
-  "paper_data_generated": "2026-05-05T12:21:44+00:00",
+  "paper_data_generated": "2026-05-05T12:54:17+00:00",
   "note": "All paper tables are descriptive summaries of the published six-model leaderboard slice."
 }

--- a/paper/data/build_metadata.json
+++ b/paper/data/build_metadata.json
@@ -1,5 +1,5 @@
 {
   "leaderboard_generated": "2026-05-05T13:35:04.535791",
-  "paper_data_generated": "2026-05-05T12:17:16+00:00",
+  "paper_data_generated": "2026-05-05T12:21:44+00:00",
   "note": "All paper tables are descriptive summaries of the published six-model leaderboard slice."
 }

--- a/paper/data/build_metadata.json
+++ b/paper/data/build_metadata.json
@@ -1,0 +1,5 @@
+{
+  "leaderboard_generated": "2026-05-05T13:35:04.535791",
+  "paper_data_generated": "2026-05-05T12:17:16+00:00",
+  "note": "All paper tables are descriptive summaries of the published six-model leaderboard slice."
+}

--- a/paper/data/mode_by_tier.csv
+++ b/paper/data/mode_by_tier.csv
@@ -1,0 +1,16 @@
+tier,tier_label,mode,mode_label,runs,success_rate,quests,models,rows
+easy,Easy,stub,Baseline (A),67,0.746269,3,6,18
+easy,Easy,reasoning,Prompted (B),207,0.31401,3,6,18
+easy,Easy,light_hints,Knowledge (C),9,0.222222,3,2,5
+easy,Easy,planner,Planner (D),3,0.333333,3,1,3
+easy,Easy,tool_augmented,Tool-augmented (E),12,0.0,2,1,2
+medium,Medium,stub,Baseline (A),66,0.106061,3,6,18
+medium,Medium,reasoning,Prompted (B),242,0.066116,3,6,18
+medium,Medium,light_hints,Knowledge (C),12,0.083333,3,2,6
+medium,Medium,planner,Planner (D),3,0.333333,3,1,3
+medium,Medium,tool_augmented,Tool-augmented (E),18,0.055556,3,1,3
+hard,Hard,stub,Baseline (A),198,0.0,9,6,54
+hard,Hard,reasoning,Prompted (B),688,0.014535,9,6,54
+hard,Hard,light_hints,Knowledge (C),33,0.0,9,2,17
+hard,Hard,planner,Planner (D),9,0.0,9,1,9
+hard,Hard,tool_augmented,Tool-augmented (E),48,0.104167,8,1,8

--- a/paper/data/mode_overall.csv
+++ b/paper/data/mode_overall.csv
@@ -1,0 +1,6 @@
+mode,mode_label,runs,success_rate,quests,models,rows
+stub,Baseline (A),331,0.172205,15,6,90
+reasoning,Prompted (B),1137,0.080035,15,6,90
+light_hints,Knowledge (C),54,0.055556,15,2,28
+planner,Planner (D),15,0.133333,15,1,15
+tool_augmented,Tool-augmented (E),78,0.076923,13,1,13

--- a/paper/data/model_summary.csv
+++ b/paper/data/model_summary.csv
@@ -1,0 +1,7 @@
+model,label,runs,success_rate,quests,modes
+mistral-medium-3.1,Mistral Medium 3.1,180,0.188889,15,2
+claude-haiku-4.5,Claude Haiku 4.5,117,0.128205,15,2
+minimax-m2.5,MiniMax m2.5,90,0.088889,15,2
+gemini-3-flash-preview,Gemini 3 Flash Preview,717,0.087866,15,4
+gpt-5.4-mini,GPT-5.4 Mini,286,0.08042,15,4
+deepseek-v3.2,DeepSeek v3.2,225,0.071111,15,2

--- a/paper/data/public_summary.json
+++ b/paper/data/public_summary.json
@@ -1,6 +1,6 @@
 {
   "source": "site/leaderboard.json",
-  "generated_at": "2026-05-05T12:17:16+00:00",
+  "generated_at": "2026-05-05T12:23:48+00:00",
   "leaderboard_generated_at": "2026-05-05T13:35:04.535791",
   "total_runs": 1615,
   "total_rows": 236,

--- a/paper/data/public_summary.json
+++ b/paper/data/public_summary.json
@@ -1,6 +1,6 @@
 {
   "source": "site/leaderboard.json",
-  "generated_at": "2026-05-05T12:23:48+00:00",
+  "generated_at": "2026-05-05T12:54:17+00:00",
   "leaderboard_generated_at": "2026-05-05T13:35:04.535791",
   "total_runs": 1615,
   "total_rows": 236,

--- a/paper/data/public_summary.json
+++ b/paper/data/public_summary.json
@@ -1,0 +1,84 @@
+{
+  "source": "site/leaderboard.json",
+  "generated_at": "2026-05-05T12:17:16+00:00",
+  "leaderboard_generated_at": "2026-05-05T13:35:04.535791",
+  "total_runs": 1615,
+  "total_rows": 236,
+  "models": [
+    {
+      "id": "claude-haiku-4.5",
+      "provider": "anthropic",
+      "label": "Claude Haiku 4.5"
+    },
+    {
+      "id": "deepseek-v3.2",
+      "provider": "deepseek",
+      "label": "DeepSeek v3.2"
+    },
+    {
+      "id": "gemini-3-flash-preview",
+      "provider": "google",
+      "label": "Gemini 3 Flash Preview"
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "provider": "openai",
+      "label": "GPT-5.4 Mini"
+    },
+    {
+      "id": "minimax-m2.5",
+      "provider": "minimax",
+      "label": "MiniMax m2.5"
+    },
+    {
+      "id": "mistral-medium-3.1",
+      "provider": "mistralai",
+      "label": "Mistral Medium 3.1"
+    }
+  ],
+  "modes": [
+    {
+      "id": "stub",
+      "label": "Baseline (A)"
+    },
+    {
+      "id": "reasoning",
+      "label": "Prompted (B)"
+    },
+    {
+      "id": "light_hints",
+      "label": "Knowledge (C)"
+    },
+    {
+      "id": "planner",
+      "label": "Planner (D)"
+    },
+    {
+      "id": "tool_augmented",
+      "label": "Tool-aug (E)"
+    }
+  ],
+  "tiers": {
+    "easy": [
+      "Boat",
+      "Badday_eng",
+      "Pizza_eng"
+    ],
+    "medium": [
+      "Ski_eng",
+      "Robots_eng",
+      "Leonardo_eng"
+    ],
+    "hard": [
+      "Banket_eng",
+      "Codebox_eng",
+      "Depth_eng",
+      "Driver_eng",
+      "Edelweiss_eng",
+      "Election_eng",
+      "Foncers_eng",
+      "Ministry_eng",
+      "Prison_eng"
+    ]
+  }
+}

--- a/paper/data/quest_summary.csv
+++ b/paper/data/quest_summary.csv
@@ -1,0 +1,16 @@
+quest,tier,runs,success_rate,modes,models
+Boat,easy,80,0.65,4,6
+Badday_eng,easy,109,0.33945,5,6
+Pizza_eng,easy,109,0.266055,5,6
+Ski_eng,medium,112,0.160714,5,6
+Leonardo_eng,medium,112,0.044643,5,6
+Robots_eng,medium,117,0.025641,5,6
+Election_eng,hard,117,0.119658,5,6
+Ministry_eng,hard,114,0.008772,5,6
+Banket_eng,hard,111,0.0,5,6
+Codebox_eng,hard,111,0.0,5,6
+Depth_eng,hard,111,0.0,5,6
+Driver_eng,hard,111,0.0,5,6
+Edelweiss_eng,hard,114,0.0,5,6
+Foncers_eng,hard,114,0.0,5,6
+Prison_eng,hard,73,0.0,4,6

--- a/paper/data/tier_summary.csv
+++ b/paper/data/tier_summary.csv
@@ -1,0 +1,4 @@
+tier,tier_label,quest_count,quests,runs,success_rate,models
+easy,Easy,3,"Boat,Badday_eng,Pizza_eng",298,0.395973,6
+medium,Medium,3,"Ski_eng,Robots_eng,Leonardo_eng",341,0.076246,6
+hard,Hard,9,"Banket_eng,Codebox_eng,Depth_eng,Driver_eng,Edelweiss_eng,Election_eng,Foncers_eng,Ministry_eng,Prison_eng",976,0.015369,6

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -1,0 +1,177 @@
+\documentclass[11pt]{article}
+
+\usepackage[margin=1in]{geometry}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{booktabs}
+\usepackage{tabularx}
+\usepackage{array}
+\usepackage{hyperref}
+\usepackage{url}
+\usepackage{xcolor}
+\usepackage{enumitem}
+
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue!50!black,
+  citecolor=blue!50!black,
+  urlcolor=blue!50!black
+}
+
+\title{LLM-Quest Benchmark: From Blog-Style Leaderboard to an Honest Preprint Draft}
+\author{Kirill Korikov}
+\date{May 2026}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+This draft turns the current \texttt{llm\_quest\_benchmark} repository into an arXiv-oriented preprint without pretending that the benchmark is further along than it is. The public repository already exposes a six-model, 15-quest leaderboard slice with 1{,}615 total runs, but coverage is uneven across agent modes and quests. To make the result legible, we reuse the repository's committed tiered benchmark configs and summarize the public slice as three empirical packs: easy, medium, and hard. The published archive already shows a sharp difficulty cliff: the easy pack reaches 39.6\% weighted success over 298 runs, the medium pack drops to 7.6\% over 341 runs, and the hard pack falls to 1.5\% over 976 runs. These numbers are descriptive rather than causal because the current archive is not a balanced rectangular matrix across modes. The paper therefore makes two conservative claims: first, the Space Rangers quest domain exposes a steep transition from locally solvable to effectively unsolved tasks; second, the repository is ready for a stronger next phase built around the committed tiered rerun configs. No new expensive benchmark matrices were run for this draft.
+\end{abstract}
+
+\section{Introduction}
+
+Benchmarks for LLM agents usually vary tasks and models while treating the agent scaffold as fixed. This repository was built around the opposite idea: keep the task domain stable and vary the wrapper around the model. The environment is a corpus of Space Rangers text quests from the community archive, executed through the \texttt{space-rangers-quest} TypeScript interpreter already used by the repository's Python bridge. Each run is a short sequential decision problem: read the current state, choose one action from a list, observe the next state, and continue until success or failure.
+
+That framing is promising, but the current public evidence base is uneven. The published site already aggregates 1{,}615 runs across six primary models and five agent-mode labels, yet those runs were accumulated through several experiments with different coverage patterns. Some modes are dense on easy quests and thin on hard quests. Some models have much deeper historical coverage than others. A credible preprint cannot ignore that.
+
+This draft therefore takes a narrower goal. It converts the existing repository into a reviewable preprint package while keeping the claims tightly aligned with committed artifacts. The core contributions of this branch are:
+
+\begin{enumerate}[leftmargin=1.5em]
+  \item a repository-local \texttt{paper/} directory with LaTeX source, bibliography, and generated paper data;
+  \item an explicit easy/medium/hard reading of the current 15-quest public slice, grounded in the tier configs already present in the repository;
+  \item a written plan for the balanced reruns and ablations still needed before stronger causal claims are justified.
+\end{enumerate}
+
+\section{Repository State and Evidence Base}
+
+The canonical public evidence in this branch is \texttt{site/leaderboard.json}. It defines a six-model published slice:
+
+\begin{itemize}[leftmargin=1.5em]
+  \item Claude Haiku 4.5
+  \item DeepSeek v3.2
+  \item Gemini 3 Flash Preview
+  \item GPT-5.4 Mini
+  \item MiniMax m2.5
+  \item Mistral Medium 3.1
+\end{itemize}
+
+The same file also exposes five public mode labels: baseline (\texttt{stub}), prompted reasoning, knowledge hints, planner, and tool-augmented. However, these labels do not have balanced coverage. The mode totals range from 15 planner runs to 1{,}137 reasoning runs, so the current public slice is best read as a descriptive archive rather than a clean intervention study.
+
+The branch also includes three committed tier configs:
+
+\begin{itemize}[leftmargin=1.5em]
+  \item \texttt{configs/benchmarks/tiered/tiered\_easy\_core\_v1.yaml}
+  \item \texttt{configs/benchmarks/tiered/tiered\_medium\_core\_v1.yaml}
+  \item \texttt{configs/benchmarks/tiered/tiered\_hard\_core\_v1.yaml}
+\end{itemize}
+
+These configs define the quest packs that the next balanced rerun should use. In this draft, they serve a second purpose: they provide a stable tiering scheme for summarizing the current public archive.
+
+\section{Related Work}
+
+The closest recent text-game benchmark is TextQuests \cite{textquests2025}, which uses Infocom interactive fiction to measure long-horizon intrinsic reasoning without external tools. LLM-Quest differs in two ways: it uses authored choice-based Space Rangers quests rather than parser-based games, and it treats agent architecture as a first-class benchmark variable rather than holding it fixed.
+
+TextWorld \cite{textworld2018} remains the canonical environment paper for text-based games, but it is better understood as an environment and generation framework than a benchmark for prompt-level agent design. TextGames \cite{textgames2025} is more directly relevant to this draft's tier framing because it explicitly studies easy, medium, and hard text reasoning tasks. A newer positioning paper on Zork \cite{zork2026} is also consistent with the current repository evidence: modern chat models still struggle badly when the task requires long-horizon state tracking and strategy persistence.
+
+Beyond text games, AgentBench \cite{agentbench2024}, AgentQuest \cite{agentquest2024}, and lmgame-Bench \cite{lmgame2025} frame the broader evaluation problem for LLM agents. Their main relevance here is methodological. They motivate reporting agent behavior on multi-step tasks, but they do not solve the narrower question this repository asks: what changes when the environment remains fixed and the scaffold changes?
+
+Finally, the prompt-and-tool literature provides the architectural backdrop for the benchmark modes. Chain-of-thought prompting \cite{cot2022}, ReAct \cite{react2023}, and Toolformer \cite{toolformer2023} all motivate the choice to expose baseline, reasoning, knowledge, planning, and tool-use variants inside one benchmark surface.
+
+\section{Tier Structure}
+
+The committed tier configs split the 15 public quests into three packs. They are reproduced in Table~\ref{tab:quest-tiers}. The split is not presented as a universal truth about quest difficulty; it is an empirical organization choice already encoded in the repository for the next balanced reruns.
+
+\begin{table}[t]
+  \centering
+  \caption{Quest packs used in this draft.}
+  \label{tab:quest-tiers}
+  \input{tables/quest_tiers.tex}
+\end{table}
+
+Table~\ref{tab:tier-summary} shows why this organization is useful even before reruns. The public archive already exhibits a dramatic performance drop as soon as the benchmark leaves the three easy quests.
+
+\begin{table}[t]
+  \centering
+  \caption{Weighted success on the published six-model archive by tier.}
+  \label{tab:tier-summary}
+  \input{tables/tier_summary.tex}
+\end{table}
+
+The quest-level pattern is equally sharp. In the easy tier, Boat reaches 65.0\% weighted success, Badday reaches 33.9\%, and Pizza reaches 26.6\%. In the medium tier, Ski still shows partial traction at 16.1\%, but Robots drops to 2.6\% and Leonardo to 4.5\%. The hard tier is effectively flat: Election is the only clearly nonzero quest at 12.0\%, Ministry barely registers at 0.9\%, and the other seven hard quests remain at 0.0\% in the published slice.
+
+\section{Results}
+
+\subsection{Easy tier}
+
+The easy tier is where the current repository already supports a practical benchmark story. Across 298 public runs, the easy quests reach 39.6\% weighted success. The best easy quest, Boat, is solved often enough that benchmark differences can be observed without the entire signal collapsing into zeros.
+
+The public archive also shows that simple prompting can already carry much of the easy-tier signal. Baseline rows reach 74.6\% weighted success on easy quests, while prompted reasoning reaches 31.4\%. Knowledge and planner rows have much thinner coverage, so they cannot yet support strong causal claims. The safe interpretation is not that baseline is universally better, but that the current public archive still contains strong prompt-coverage and run-history confounds.
+
+\subsection{Medium tier}
+
+The medium tier is the most informative part of the current archive. It is not saturated, but it is not entirely dead either. Weighted success drops to 7.6\% over 341 runs. Ski remains partly solvable, Leonardo occasionally yields a win, and Robots is close to unsolved.
+
+This is where the benchmark looks most promising for the next balanced rerun. Medium-tier quests are hard enough to punish weak state tracking, but not so hard that all methods collapse to zero. A balanced rerun on this tier is likely to provide the cleanest signal about whether reasoning, hints, or planning genuinely extend solvability.
+
+\subsection{Hard tier}
+
+The hard tier contains most of the public archive's runs and almost none of its wins. Weighted success is only 1.5\% over 976 runs. Seven of the nine hard quests remain at zero, and the two nonzero exceptions are narrow: Election contributes nearly all of the visible hard-tier success, and Ministry contributes only a trace.
+
+This hard-tier collapse is the strongest benchmark finding already present in the repo. It implies that future benchmark improvements should be judged less by small changes in global average and more by whether they create reproducible nonzero performance on currently flat quests.
+
+\subsection{Mode coverage and exploratory signals}
+
+Table~\ref{tab:mode-tier} summarizes the public archive by mode and tier.
+
+\begin{table}[t]
+  \centering
+  \caption{Weighted success by public mode label and tier. Each cell reports success and run count.}
+  \label{tab:mode-tier}
+  \input{tables/mode_by_tier.tex}
+\end{table}
+
+Two facts stand out. First, mode coverage is highly uneven: the current archive contains 1{,}137 reasoning runs, 331 baseline runs, 78 tool-augmented runs, 54 knowledge-hint runs, and only 15 planner runs. Second, the sparse modes still contain clues worth following. Tool-augmented hard-tier rows reach 10.4\% weighted success over 48 runs, far above the hard-tier archive average. That number is too sparse to headline as a conclusion, but it is a good candidate for the next targeted rerun.
+
+\subsection{Model summary}
+
+Table~\ref{tab:model-summary} reports the overall weighted success by public model.
+
+\begin{table}[t]
+  \centering
+  \caption{Weighted success across the full public archive by model.}
+  \label{tab:model-summary}
+  \input{tables/model_summary.tex}
+\end{table}
+
+Mistral Medium 3.1 currently tops the weighted archive summary at 18.9\% over 180 runs, followed by Claude Haiku 4.5 at 12.8\%. However, the leaderboard should not be over-read as a pure model ranking because run coverage differs sharply by model. Gemini 3 Flash Preview, for example, carries 717 published runs, far more than any other model in the current public slice. The preprint therefore treats model ranking as secondary to the benchmark-design problem.
+
+\section{What Is Missing}
+
+The repository is already strong enough for a reviewable preliminary preprint, but not for decisive causal claims about agent architecture. The main missing experiment is straightforward: rerun the current six-model lineup on the committed easy, medium, and hard packs with balanced A-D mode coverage and three runs per cell. Because the tier configs already specify 15 quests and four modes, that balanced rerun is exactly 1{,}080 runs.
+
+The second missing experiment is a targeted tool-mode follow-up. The current archive suggests tool-use signal on hard-tier Election and some medium-tier quests, but the coverage is too sparse to separate real gains from sampling noise. A focused seven-quest tool rerun would turn that hint into a falsifiable claim.
+
+Finally, the benchmark still lacks a human baseline, calibrated repeat-run stability checks, and a clean appendix strategy for frontier-tier models. These are all planned in this branch, but none are claimed as completed evidence.
+
+\section{Limitations}
+
+\begin{itemize}[leftmargin=1.5em]
+  \item \textbf{Coverage imbalance.} The current public slice is not a balanced rectangular matrix across models, modes, and quests.
+  \item \textbf{Archive-style aggregation.} The leaderboard mixes results accumulated through several experiments, so per-mode comparisons are descriptive rather than causal.
+  \item \textbf{Sparse advanced modes.} Planner and tool rows are too thin for strong claims despite some promising nonzero signals.
+  \item \textbf{No build verification on this VPS.} This branch adds LaTeX source and generated tables, but the VPS does not currently have a TeX toolchain installed.
+  \item \textbf{No new expensive reruns.} This branch intentionally avoids recomputing the benchmark matrix.
+\end{itemize}
+
+\section{Conclusion}
+
+The repository is already publishable as a preliminary benchmark report if the claims are kept narrow. The main result is not that one scaffold has clearly won. It is that the Space Rangers quest domain already exposes a steep easy-to-medium-to-hard transition, while the current public archive remains too coverage-uneven for neat mode-level conclusions. That is still useful scientific progress: it tells us where the benchmark is informative today and how to design the next clean rerun.
+
+This branch packages that state into a form that can be reviewed. The paper text, bibliography, tier configs, and generated source data now live in-repo, and the next experiments are explicit rather than implicit.
+
+\bibliographystyle{plain}
+\bibliography{references}
+
+\end{document}

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -1,0 +1,80 @@
+@article{textquests2025,
+  title = {TextQuests: How Good are LLMs at Text-Based Video Games?},
+  author = {Phan, Long and Mazeika, Mantas and Zou, Andy and Hendrycks, Dan},
+  year = {2025},
+  journal = {arXiv preprint arXiv:2507.23701},
+  url = {https://arxiv.org/abs/2507.23701}
+}
+
+@article{textworld2018,
+  title = {TextWorld: A Learning Environment for Text-based Games},
+  author = {C{\^o}t{\'e}, Marc-Alexandre and K{\'a}d{\'a}r, {\'A}kos and Yuan, Xingdi and Kybartas, Ben and Barnes, Tavian and Fine, Emery and Moore, James and Hausknecht, Matthew and El Asri, Layla and Adada, Mahmoud and Tay, Willie and Trischler, Adam},
+  year = {2018},
+  journal = {arXiv preprint arXiv:1806.11532},
+  url = {https://arxiv.org/abs/1806.11532}
+}
+
+@article{textgames2025,
+  title = {TextGames: Learning to Self-Play Text-Based Puzzle Games via Language Model Reasoning},
+  author = {Hudi, Frederikus and Winata, Genta Indra and Zhang, Ruochen and Aji, Alham Fikri},
+  year = {2025},
+  journal = {arXiv preprint arXiv:2502.18431},
+  url = {https://arxiv.org/abs/2502.18431}
+}
+
+@article{zork2026,
+  title = {Playing With AI: How Do State-Of-The-Art Large Language Models Perform in the 1977 Text-Based Adventure Game Zork?},
+  author = {Gerrits, Berry},
+  year = {2026},
+  journal = {arXiv preprint arXiv:2602.15867},
+  url = {https://arxiv.org/abs/2602.15867}
+}
+
+@article{agentbench2024,
+  title = {AgentBench: Evaluating LLMs as Agents},
+  author = {Liu, Xiao and others},
+  year = {2024},
+  journal = {arXiv preprint arXiv:2308.03688},
+  url = {https://arxiv.org/abs/2308.03688}
+}
+
+@inproceedings{agentquest2024,
+  title = {AgentQuest: A Modular Benchmark Framework to Measure Progress and Improve LLM Agents},
+  author = {Gioacchini, Luca and Siracusano, Giuseppe and Sanvito, Davide and Gashteovski, Kiril and Friede, David and Bifulco, Roberto and Lawrence, Carolin},
+  booktitle = {Proceedings of the 2024 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies (Volume 3: System Demonstrations)},
+  year = {2024},
+  pages = {185--193},
+  url = {https://aclanthology.org/2024.naacl-demo.19/}
+}
+
+@article{cot2022,
+  title = {Chain-of-Thought Prompting Elicits Reasoning in Large Language Models},
+  author = {Wei, Jason and others},
+  year = {2022},
+  journal = {Advances in Neural Information Processing Systems},
+  url = {https://arxiv.org/abs/2201.11903}
+}
+
+@article{react2023,
+  title = {ReAct: Synergizing Reasoning and Acting in Language Models},
+  author = {Yao, Shunyu and others},
+  year = {2023},
+  journal = {International Conference on Learning Representations},
+  url = {https://arxiv.org/abs/2210.03629}
+}
+
+@article{toolformer2023,
+  title = {Toolformer: Language Models Can Teach Themselves to Use Tools},
+  author = {Schick, Timo and others},
+  year = {2023},
+  journal = {Advances in Neural Information Processing Systems},
+  url = {https://arxiv.org/abs/2302.04761}
+}
+
+@article{lmgame2025,
+  title = {lmgame-Bench: How Good are LLMs at Playing Games?},
+  author = {Hu, Lanxiang and others},
+  year = {2025},
+  journal = {arXiv preprint arXiv:2505.15146},
+  url = {https://arxiv.org/abs/2505.15146}
+}

--- a/paper/related_work_notes.md
+++ b/paper/related_work_notes.md
@@ -1,0 +1,53 @@
+# Related Work Notes
+
+This file captures the web research used to frame the draft and the paper bibliography.
+
+## Closest text-game and interactive benchmarks
+
+- `TextQuests` - Long Phan, Mantas Mazeika, Andy Zou, Dan Hendrycks. "TextQuests: How Good are LLMs at Text-Based Video Games?" arXiv:2507.23701, 2025.
+  Link: https://arxiv.org/abs/2507.23701
+  Relevance: closest recent LLM benchmark on long-horizon interactive fiction. It uses Infocom parser games and explicitly forbids external tools, which contrasts with this repo's choice-based Space Rangers quests and explicit architecture comparison.
+
+- `TextWorld` - Marc-Alexandre Cote et al. "TextWorld: A Learning Environment for Text-based Games." arXiv:1806.11532, 2018.
+  Link: https://arxiv.org/abs/1806.11532
+  Relevance: foundational text-game environment, but mostly procedural/RL-oriented rather than a benchmark of prompting and agent scaffolding on authored quests.
+
+- `TextGames` - Frederikus Hudi et al. "TextGames: Learning to Self-Play Text-Based Puzzle Games via Language Model Reasoning." arXiv:2502.18431, 2025.
+  Link: https://arxiv.org/abs/2502.18431
+  Relevance: difficulty-tier framing and reasoning stress tests for puzzle-style text tasks.
+
+- `Playing With AI` - Berry Gerrits. "Playing With AI: How Do State-Of-The-Art Large Language Models Perform in the 1977 Text-Based Adventure Game Zork?" arXiv:2602.15867, 2026.
+  Link: https://arxiv.org/abs/2602.15867
+  Relevance: recent evidence that modern chat models still struggle badly on classic text adventure tasks, even with stronger prompting.
+
+- `lmgame-Bench` - Lanxiang Hu et al. "lmgame-Bench: How Good are LLMs at Playing Games?" arXiv:2505.15146, 2025.
+  Link: https://arxiv.org/abs/2505.15146
+  Relevance: broader game benchmark with a unified API and contamination-focused benchmark design.
+
+## General LLM-agent benchmarking
+
+- `AgentBench` - Xiao Liu et al. "AgentBench: Evaluating LLMs as Agents." arXiv:2308.03688, ICLR 2024.
+  Link: https://arxiv.org/abs/2308.03688
+  Relevance: general multi-environment agent benchmark. Useful contrast because it varies environments more than agent scaffolds.
+
+- `AgentQuest` - Luca Gioacchini et al. "AgentQuest: A Modular Benchmark Framework to Measure Progress and Improve LLM Agents." NAACL 2024 demo / arXiv:2404.06411.
+  Links: https://aclanthology.org/2024.naacl-demo.19/ and https://arxiv.org/abs/2404.06411
+  Relevance: modular benchmark framing and progress-oriented metrics.
+
+## Architecture references
+
+- `Chain-of-Thought Prompting` - Jason Wei et al. "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models." NeurIPS 2022.
+- `ReAct` - Shunyu Yao et al. "ReAct: Synergizing Reasoning and Acting in Language Models." ICLR 2023 / arXiv:2210.03629.
+- `Toolformer` - Timo Schick et al. "Toolformer: Language Models Can Teach Themselves to Use Tools." NeurIPS 2023 / arXiv:2302.04761.
+
+These are cited to motivate the benchmark modes, not because the repo implements them exactly.
+
+## Space Rangers-specific resources
+
+- Space Rangers community quest archive:
+  https://gitlab.com/spacerangers
+  Relevance: upstream quest corpus used by the benchmark.
+
+- `space-rangers-quest` TypeScript engine:
+  https://github.com/roginvs/space-rangers-quest
+  Relevance: quest interpreter used by the Python bridge in this repo.

--- a/paper/tables/mode_by_tier.tex
+++ b/paper/tables/mode_by_tier.tex
@@ -1,0 +1,11 @@
+\begin{tabular}{lccc}
+\toprule
+Mode & Easy & Medium & Hard \\
+\midrule
+Baseline (A) & 74.6\% (67) & 10.6\% (66) & 0.0\% (198) \\
+Prompted (B) & 31.4\% (207) & 6.6\% (242) & 1.5\% (688) \\
+Knowledge (C) & 22.2\% (9) & 8.3\% (12) & 0.0\% (33) \\
+Planner (D) & 33.3\% (3) & 33.3\% (3) & 0.0\% (9) \\
+Tool-augmented (E) & 0.0\% (12) & 5.6\% (18) & 10.4\% (48) \\
+\bottomrule
+\end{tabular}

--- a/paper/tables/model_summary.tex
+++ b/paper/tables/model_summary.tex
@@ -1,0 +1,12 @@
+\begin{tabular}{lrrr}
+\toprule
+Model & Runs & Weighted success & Covered quests \\
+\midrule
+Mistral Medium 3.1 & 180 & 18.9\% & 15 \\
+Claude Haiku 4.5 & 117 & 12.8\% & 15 \\
+MiniMax m2.5 & 90 & 8.9\% & 15 \\
+Gemini 3 Flash Preview & 717 & 8.8\% & 15 \\
+GPT-5.4 Mini & 286 & 8.0\% & 15 \\
+DeepSeek v3.2 & 225 & 7.1\% & 15 \\
+\bottomrule
+\end{tabular}

--- a/paper/tables/quest_tiers.tex
+++ b/paper/tables/quest_tiers.tex
@@ -1,0 +1,9 @@
+\begin{tabular}{lp{0.72\linewidth}}
+\toprule
+Tier & Quest IDs \\
+\midrule
+Easy & Boat, Badday\_eng, Pizza\_eng \\
+Medium & Ski\_eng, Robots\_eng, Leonardo\_eng \\
+Hard & Banket\_eng, Codebox\_eng, Depth\_eng, Driver\_eng, Edelweiss\_eng, Election\_eng, Foncers\_eng, Ministry\_eng, Prison\_eng \\
+\bottomrule
+\end{tabular}

--- a/paper/tables/tier_summary.tex
+++ b/paper/tables/tier_summary.tex
@@ -1,0 +1,9 @@
+\begin{tabular}{lrrr}
+\toprule
+Tier & Quests & Runs & Weighted success \\
+\midrule
+Easy & 3 & 298 & 39.6\% \\
+Medium & 3 & 341 & 7.6\% \\
+Hard & 9 & 976 & 1.5\% \\
+\bottomrule
+\end{tabular}

--- a/scripts/build_paper_data.py
+++ b/scripts/build_paper_data.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import csv
 import json
-from collections import defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -64,7 +63,7 @@ def load_leaderboard() -> dict[str, Any]:
 def load_tiers() -> dict[str, list[str]]:
     tiers: dict[str, list[str]] = {}
     for tier, path in TIER_CONFIGS.items():
-        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
         quests = [Path(quest_path).stem for quest_path in payload.get("quests", [])]
         tiers[tier] = quests
     return tiers
@@ -83,7 +82,10 @@ def aggregate(rows: list[dict[str, Any]]) -> Aggregate:
     )
 
 
-def write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, Any]]) -> None:
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError(f"No rows available for CSV output: {path}")
+    fieldnames = list(rows[0].keys())
     with path.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=fieldnames)
         writer.writeheader()
@@ -174,6 +176,9 @@ def main() -> None:
         raise SystemExit(f"Tier configs reference quests not present in leaderboard.json: {missing}")
 
     tier_map = {quest: tier for tier, quests in tiers.items() for quest in quests}
+    untiered = sorted([quest for quest in all_quests if quest not in tier_map])
+    if untiered:
+        raise SystemExit(f"Leaderboard contains quests not assigned to any tier: {untiered}")
     model_labels = {model["id"]: model["label"] for model in leaderboard["models"]}
     rows = list(leaderboard["results"])
 
@@ -276,11 +281,11 @@ def main() -> None:
     }
 
     (DATA_DIR / "public_summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
-    write_csv(DATA_DIR / "tier_summary.csv", list(tier_rows[0].keys()), tier_rows)
-    write_csv(DATA_DIR / "mode_by_tier.csv", list(mode_by_tier_rows[0].keys()), mode_by_tier_rows)
-    write_csv(DATA_DIR / "model_summary.csv", list(model_rows[0].keys()), model_rows)
-    write_csv(DATA_DIR / "quest_summary.csv", list(quest_rows[0].keys()), quest_rows)
-    write_csv(DATA_DIR / "mode_overall.csv", list(mode_overall_rows[0].keys()), mode_overall_rows)
+    write_csv(DATA_DIR / "tier_summary.csv", tier_rows)
+    write_csv(DATA_DIR / "mode_by_tier.csv", mode_by_tier_rows)
+    write_csv(DATA_DIR / "model_summary.csv", model_rows)
+    write_csv(DATA_DIR / "quest_summary.csv", quest_rows)
+    write_csv(DATA_DIR / "mode_overall.csv", mode_overall_rows)
     build_tables(leaderboard, tiers, tier_rows, mode_by_tier_rows, model_rows)
 
     print(f"Wrote paper data to {DATA_DIR.relative_to(ROOT)} and tables to {TABLE_DIR.relative_to(ROOT)}")

--- a/scripts/build_paper_data.py
+++ b/scripts/build_paper_data.py
@@ -69,6 +69,26 @@ def load_tiers() -> dict[str, list[str]]:
     return tiers
 
 
+def build_tier_map(tiers: dict[str, list[str]]) -> dict[str, str]:
+    tier_map: dict[str, str] = {}
+    duplicate_assignments: dict[str, list[str]] = {}
+
+    for tier, quests in tiers.items():
+        for quest in quests:
+            if quest in tier_map:
+                duplicate_assignments.setdefault(quest, [tier_map[quest]]).append(tier)
+                continue
+            tier_map[quest] = tier
+
+    if duplicate_assignments:
+        details = ", ".join(
+            f"{quest}: {'/'.join(assignments)}" for quest, assignments in sorted(duplicate_assignments.items())
+        )
+        raise SystemExit(f"Tier configs assign quests to multiple tiers: {details}")
+
+    return tier_map
+
+
 def aggregate(rows: list[dict[str, Any]]) -> Aggregate:
     runs = sum(int(row["runs"]) for row in rows)
     weighted_success = sum(float(row["success_rate"]) * int(row["runs"]) for row in rows)
@@ -175,7 +195,7 @@ def main() -> None:
     if missing:
         raise SystemExit(f"Tier configs reference quests not present in leaderboard.json: {missing}")
 
-    tier_map = {quest: tier for tier, quests in tiers.items() for quest in quests}
+    tier_map = build_tier_map(tiers)
     untiered = sorted([quest for quest in all_quests if quest not in tier_map])
     if untiered:
         raise SystemExit(f"Leaderboard contains quests not assigned to any tier: {untiered}")
@@ -236,13 +256,13 @@ def main() -> None:
     model_rows.sort(key=lambda row: (-row["success_rate"], -row["runs"], row["label"]))
 
     quest_rows: list[dict[str, Any]] = []
-    for quest in sorted(all_quests):
+    for quest in sorted(tier_map):
         subset = [row for row in rows if str(row["quest"]) == quest]
         agg = aggregate(subset)
         quest_rows.append(
             {
                 "quest": quest,
-                "tier": tier_map[quest],
+                "tier": tier_map.get(quest, "unassigned"),
                 "runs": agg.runs,
                 "success_rate": round(agg.success_rate, 6),
                 "modes": len({str(row["mode"]) for row in subset}),

--- a/scripts/build_paper_data.py
+++ b/scripts/build_paper_data.py
@@ -44,12 +44,7 @@ class Aggregate:
 
 
 def tex_escape(value: str) -> str:
-    return (
-        value.replace("\\", r"\textbackslash{}")
-        .replace("&", r"\&")
-        .replace("%", r"\%")
-        .replace("_", r"\_")
-    )
+    return value.replace("\\", r"\textbackslash{}").replace("&", r"\&").replace("%", r"\%").replace("_", r"\_")
 
 
 def format_pct(rate: float) -> str:

--- a/scripts/build_paper_data.py
+++ b/scripts/build_paper_data.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Build paper-facing source data from the published leaderboard and tier configs."""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+LEADERBOARD_PATH = ROOT / "site" / "leaderboard.json"
+TIER_CONFIGS = {
+    "easy": ROOT / "configs" / "benchmarks" / "tiered" / "tiered_easy_core_v1.yaml",
+    "medium": ROOT / "configs" / "benchmarks" / "tiered" / "tiered_medium_core_v1.yaml",
+    "hard": ROOT / "configs" / "benchmarks" / "tiered" / "tiered_hard_core_v1.yaml",
+}
+PAPER_DIR = ROOT / "paper"
+DATA_DIR = PAPER_DIR / "data"
+TABLE_DIR = PAPER_DIR / "tables"
+
+MODE_ORDER = ["stub", "reasoning", "light_hints", "planner", "tool_augmented"]
+MODE_LABELS = {
+    "stub": "Baseline (A)",
+    "reasoning": "Prompted (B)",
+    "light_hints": "Knowledge (C)",
+    "planner": "Planner (D)",
+    "tool_augmented": "Tool-augmented (E)",
+}
+TIER_ORDER = ["easy", "medium", "hard"]
+TIER_LABELS = {"easy": "Easy", "medium": "Medium", "hard": "Hard"}
+
+
+@dataclass(frozen=True)
+class Aggregate:
+    runs: int
+    success_rate: float
+    quests: int
+    models: int
+
+
+def tex_escape(value: str) -> str:
+    return (
+        value.replace("\\", r"\textbackslash{}")
+        .replace("&", r"\&")
+        .replace("%", r"\%")
+        .replace("_", r"\_")
+    )
+
+
+def format_pct(rate: float) -> str:
+    return f"{rate * 100:.1f}\\%"
+
+
+def load_leaderboard() -> dict[str, Any]:
+    return json.loads(LEADERBOARD_PATH.read_text(encoding="utf-8"))
+
+
+def load_tiers() -> dict[str, list[str]]:
+    tiers: dict[str, list[str]] = {}
+    for tier, path in TIER_CONFIGS.items():
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        quests = [Path(quest_path).stem for quest_path in payload.get("quests", [])]
+        tiers[tier] = quests
+    return tiers
+
+
+def aggregate(rows: list[dict[str, Any]]) -> Aggregate:
+    runs = sum(int(row["runs"]) for row in rows)
+    weighted_success = sum(float(row["success_rate"]) * int(row["runs"]) for row in rows)
+    quests = len({str(row["quest"]) for row in rows})
+    models = len({str(row["model"]) for row in rows})
+    return Aggregate(
+        runs=runs,
+        success_rate=(weighted_success / runs) if runs else 0.0,
+        quests=quests,
+        models=models,
+    )
+
+
+def write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_tables(
+    leaderboard: dict[str, Any],
+    tiers: dict[str, list[str]],
+    tier_rows: list[dict[str, Any]],
+    mode_by_tier_rows: list[dict[str, Any]],
+    model_rows: list[dict[str, Any]],
+) -> None:
+    tier_summary_lines = [
+        r"\begin{tabular}{lrrr}",
+        r"\toprule",
+        r"Tier & Quests & Runs & Weighted success \\",
+        r"\midrule",
+    ]
+    for row in tier_rows:
+        tier_summary_lines.append(
+            f"{tex_escape(row['tier_label'])} & {row['quest_count']} & {row['runs']} & {format_pct(row['success_rate'])} \\\\"
+        )
+    tier_summary_lines.extend([r"\bottomrule", r"\end{tabular}"])
+    (TABLE_DIR / "tier_summary.tex").write_text("\n".join(tier_summary_lines) + "\n", encoding="utf-8")
+
+    quest_tiers_lines = [
+        r"\begin{tabular}{lp{0.72\linewidth}}",
+        r"\toprule",
+        r"Tier & Quest IDs \\",
+        r"\midrule",
+    ]
+    for tier in TIER_ORDER:
+        joined = ", ".join(tex_escape(quest) for quest in tiers[tier])
+        quest_tiers_lines.append(f"{tex_escape(TIER_LABELS[tier])} & {joined} \\\\")
+    quest_tiers_lines.extend([r"\bottomrule", r"\end{tabular}"])
+    (TABLE_DIR / "quest_tiers.tex").write_text("\n".join(quest_tiers_lines) + "\n", encoding="utf-8")
+
+    mode_lines = [
+        r"\begin{tabular}{lccc}",
+        r"\toprule",
+        r"Mode & Easy & Medium & Hard \\",
+        r"\midrule",
+    ]
+    mode_lookup = {(row["mode"], row["tier"]): row for row in mode_by_tier_rows}
+    for mode in MODE_ORDER:
+        cells = []
+        for tier in TIER_ORDER:
+            row = mode_lookup.get((mode, tier))
+            if row is None:
+                cells.append("n/a")
+            else:
+                cells.append(f"{format_pct(row['success_rate'])} ({row['runs']})")
+        mode_lines.append(f"{tex_escape(MODE_LABELS[mode])} & " + " & ".join(cells) + r" \\")
+    mode_lines.extend([r"\bottomrule", r"\end{tabular}"])
+    (TABLE_DIR / "mode_by_tier.tex").write_text("\n".join(mode_lines) + "\n", encoding="utf-8")
+
+    model_lines = [
+        r"\begin{tabular}{lrrr}",
+        r"\toprule",
+        r"Model & Runs & Weighted success & Covered quests \\",
+        r"\midrule",
+    ]
+    for row in model_rows:
+        model_lines.append(
+            f"{tex_escape(row['label'])} & {row['runs']} & {format_pct(row['success_rate'])} & {row['quests']} \\\\"
+        )
+    model_lines.extend([r"\bottomrule", r"\end{tabular}"])
+    (TABLE_DIR / "model_summary.tex").write_text("\n".join(model_lines) + "\n", encoding="utf-8")
+
+    scope_note = {
+        "leaderboard_generated": leaderboard.get("generated"),
+        "paper_data_generated": datetime.now(UTC).isoformat(timespec="seconds"),
+        "note": "All paper tables are descriptive summaries of the published six-model leaderboard slice.",
+    }
+    (DATA_DIR / "build_metadata.json").write_text(json.dumps(scope_note, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    TABLE_DIR.mkdir(parents=True, exist_ok=True)
+
+    leaderboard = load_leaderboard()
+    tiers = load_tiers()
+    all_quests = {quest["id"] for quest in leaderboard["quests"]}
+    missing = sorted({quest for quests in tiers.values() for quest in quests if quest not in all_quests})
+    if missing:
+        raise SystemExit(f"Tier configs reference quests not present in leaderboard.json: {missing}")
+
+    tier_map = {quest: tier for tier, quests in tiers.items() for quest in quests}
+    model_labels = {model["id"]: model["label"] for model in leaderboard["models"]}
+    rows = list(leaderboard["results"])
+
+    tier_rows: list[dict[str, Any]] = []
+    for tier in TIER_ORDER:
+        subset = [row for row in rows if tier_map.get(str(row["quest"])) == tier]
+        agg = aggregate(subset)
+        tier_rows.append(
+            {
+                "tier": tier,
+                "tier_label": TIER_LABELS[tier],
+                "quest_count": len(tiers[tier]),
+                "quests": ",".join(tiers[tier]),
+                "runs": agg.runs,
+                "success_rate": round(agg.success_rate, 6),
+                "models": agg.models,
+            }
+        )
+
+    mode_by_tier_rows: list[dict[str, Any]] = []
+    for tier in TIER_ORDER:
+        for mode in MODE_ORDER:
+            subset = [row for row in rows if tier_map.get(str(row["quest"])) == tier and str(row["mode"]) == mode]
+            if not subset:
+                continue
+            agg = aggregate(subset)
+            mode_by_tier_rows.append(
+                {
+                    "tier": tier,
+                    "tier_label": TIER_LABELS[tier],
+                    "mode": mode,
+                    "mode_label": MODE_LABELS[mode],
+                    "runs": agg.runs,
+                    "success_rate": round(agg.success_rate, 6),
+                    "quests": agg.quests,
+                    "models": agg.models,
+                    "rows": len(subset),
+                }
+            )
+
+    model_rows: list[dict[str, Any]] = []
+    for model_id in sorted(model_labels):
+        subset = [row for row in rows if str(row["model"]) == model_id]
+        agg = aggregate(subset)
+        model_rows.append(
+            {
+                "model": model_id,
+                "label": model_labels[model_id],
+                "runs": agg.runs,
+                "success_rate": round(agg.success_rate, 6),
+                "quests": agg.quests,
+                "modes": len({str(row["mode"]) for row in subset}),
+            }
+        )
+    model_rows.sort(key=lambda row: (-row["success_rate"], -row["runs"], row["label"]))
+
+    quest_rows: list[dict[str, Any]] = []
+    for quest in sorted(all_quests):
+        subset = [row for row in rows if str(row["quest"]) == quest]
+        agg = aggregate(subset)
+        quest_rows.append(
+            {
+                "quest": quest,
+                "tier": tier_map[quest],
+                "runs": agg.runs,
+                "success_rate": round(agg.success_rate, 6),
+                "modes": len({str(row["mode"]) for row in subset}),
+                "models": agg.models,
+            }
+        )
+    quest_rows.sort(key=lambda row: (TIER_ORDER.index(row["tier"]), -row["success_rate"], row["quest"]))
+
+    mode_overall_rows: list[dict[str, Any]] = []
+    for mode in MODE_ORDER:
+        subset = [row for row in rows if str(row["mode"]) == mode]
+        if not subset:
+            continue
+        agg = aggregate(subset)
+        mode_overall_rows.append(
+            {
+                "mode": mode,
+                "mode_label": MODE_LABELS[mode],
+                "runs": agg.runs,
+                "success_rate": round(agg.success_rate, 6),
+                "quests": agg.quests,
+                "models": agg.models,
+                "rows": len(subset),
+            }
+        )
+
+    summary = {
+        "source": str(LEADERBOARD_PATH.relative_to(ROOT)),
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "leaderboard_generated_at": leaderboard.get("generated"),
+        "total_runs": sum(int(row["runs"]) for row in rows),
+        "total_rows": len(rows),
+        "models": leaderboard["models"],
+        "modes": leaderboard["modes"],
+        "tiers": tiers,
+    }
+
+    (DATA_DIR / "public_summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    write_csv(DATA_DIR / "tier_summary.csv", list(tier_rows[0].keys()), tier_rows)
+    write_csv(DATA_DIR / "mode_by_tier.csv", list(mode_by_tier_rows[0].keys()), mode_by_tier_rows)
+    write_csv(DATA_DIR / "model_summary.csv", list(model_rows[0].keys()), model_rows)
+    write_csv(DATA_DIR / "quest_summary.csv", list(quest_rows[0].keys()), quest_rows)
+    write_csv(DATA_DIR / "mode_overall.csv", list(mode_overall_rows[0].keys()), mode_overall_rows)
+    build_tables(leaderboard, tiers, tier_rows, mode_by_tier_rows, model_rows)
+
+    print(f"Wrote paper data to {DATA_DIR.relative_to(ROOT)} and tables to {TABLE_DIR.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a repository-local `paper/` directory with a LaTeX preprint draft, bibliography, generated source data, and generated TeX tables
- add `scripts/build_paper_data.py` to derive paper-ready CSV/JSON/TeX artifacts from the published six-model leaderboard slice plus the committed tier configs
- add committed easy/medium/hard tier benchmark configs and a rollout plan for the next balanced reruns and ablations

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/build_paper_data.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m py_compile scripts/build_paper_data.py`
- citation-key consistency check between `paper/main.tex` and `paper/references.bib`
- `git diff --check`

## Limitations and Follow-up

- no new expensive benchmark matrices were run in this PR
- the paper draft uses the tracked public leaderboard slice as the canonical evidence base and treats mode-level comparisons as descriptive because coverage is uneven
- TeX compilation was not run because this VPS does not currently have `latexmk`, `pdflatex`, or `bibtex` installed

## Excluded / stale artifacts

- did not restore the deleted `site/paper.html`; the paper work now lives under `paper/`
- did not include the local `results.zip` archive because it is a stale generated artifact and not required for the reviewable draft


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three tiered benchmark configurations (easy, medium, hard) with multi-model evaluation matrices and customizable execution parameters
  * Introduced automated paper data generation pipeline with structured table creation

* **Documentation**
  * Added preprint draft with build instructions, metadata tracking, and experimental planning documentation
  * Included research notes and related work citations for benchmark context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->