### PR TITLE
Polish public benchmark taxonomy and repo hygiene

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+## What happened?
+
+Describe the bug, confusing behavior, or broken command.
+
+## How to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What did you expect to happen instead?
+
+## Environment
+
+- OS:
+- Python version:
+- Node/pnpm version:
+- Command or page affected:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+- <!-- Describe the change. -->
+
+## Validation / testing
+
+- [ ] `uv run ruff check .`
+- [ ] `uv run ruff format --check .`
+- [ ] `uv run pytest`
+- [ ] `pnpm run build`
+- [ ] Other:
+
+## Reviewer context
+
+Note any data, generated artifacts, caveats, or known pre-existing failures reviewers should consider.

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ logs/
 
 # Quest files and utils
 /quests/*
-!/quests/boat.qm
+!/quests/Boat.qm
 tge/
 
 # Local IDE

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Leaderboard](https://img.shields.io/badge/Leaderboard-Live-green.svg)](https://yourconscience.github.io/llm_quest_benchmark/)
 [![About](https://img.shields.io/badge/About-Post-blue.svg)](https://yourconscience.github.io/llm_quest_benchmark/about.html)
 
-Benchmark for evaluating LLM agent architectures on interactive fiction quests. Measures how planning, tool use, and prompt design affect decision-making quality across models and tasks.
+Benchmark for evaluating LLM context scaffolds on interactive fiction quests. Measures how prompt context, compact memory, tools, and planning loops affect sequential decision-making across models and tasks.
 
 **[Project Site](https://yourconscience.github.io/llm_quest_benchmark/)** | **[Leaderboard](https://yourconscience.github.io/llm_quest_benchmark/index.html)** | **[About / Write-up](https://yourconscience.github.io/llm_quest_benchmark/about.html)**
 
-See the [About page](https://yourconscience.github.io/llm_quest_benchmark/about.html) for benchmark design, agent modes, metrics, and model selection rationale.
+See the [About page](https://yourconscience.github.io/llm_quest_benchmark/about.html) for the project narrative, taxonomy, metrics, caveats, and model selection rationale.
 
 ## Quick Start (Docker)
 
@@ -49,19 +49,19 @@ cp .env.template .env
 
 ```bash
 # Run one quest
-llm-quest run --quest quests/Boat.qm --model gemini-3-flash-preview --timeout 120
+uv run llm-quest run --quest quests/Boat.qm --model gemini-3-flash-preview --timeout 120
 
 # Run benchmark matrix
-llm-quest benchmark --config configs/benchmarks/memory_full_transcript.yaml
+uv run llm-quest benchmark --config configs/benchmarks/memory_full_transcript.yaml
 
 # Generate report from benchmark results
-llm-quest benchmark-report --benchmark-id <id> --output report.md
+uv run llm-quest benchmark-report --benchmark-id <id> --output report.md
 
 # Analyze a single run
-llm-quest analyze-run --run-summary results/<agent>/<quest>/run_<id>/run_summary.json
+uv run llm-quest analyze-run --run-summary results/<agent>/<quest>/run_<id>/run_summary.json
 
 # Play as human in terminal
-llm-quest play --quest quests/Boat.qm
+uv run llm-quest play --quest quests/Boat.qm
 
 # Build static site JS assets
 pnpm run build
@@ -73,13 +73,24 @@ pnpm run build:play-assets
 ## Project Structure
 
 - `llm_quest_benchmark/agents/` - Agent implementations (LLM, planner, tool-augmented)
-- `llm_quest_benchmark/prompt_templates/` - Jinja2 prompt templates per agent mode
+- `llm_quest_benchmark/prompt_templates/` - Jinja2 prompt templates for the public context-scaffold taxonomy
 - `llm_quest_benchmark/executors/` - CLI, benchmark orchestration, TS bridge
 - `configs/benchmarks/` - YAML benchmark configurations
 - `quests/` - Quest files (downloaded via `download_quests.sh`)
 - `space-rangers-quest/` - TypeScript quest engine (submodule)
-- `docs/` - Dataset documentation (DATASHEET.md)
+- `docs/ARCHITECTURE.md` - Runtime architecture and taxonomy mapping
+- `docs/DATASHEET.md` - Dataset and public leaderboard slice documentation
 - `research/` - Error analysis, landscape comparison (gitignored)
+
+## Validation
+
+```bash
+uv run llm-quest --help
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest
+pnpm run build
+```
 
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ uv run ruff check .
 uv run ruff format --check .
 uv run pytest
 pnpm run build
+python3 -m json.tool site/leaderboard.json >/tmp/llm_quest_leaderboard_check.json
+
+# Report-only for now: broad pre-existing typing backlog is not a release gate.
+uv run mypy llm_quest_benchmark
 ```
 
 ## License

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,8 +25,8 @@ The runtime loop is:
 
 ### 3. Agent Layer
 - `llm_quest_benchmark/agents/llm_agent.py`: Base LLM agent with template-driven prompts, retry logic, loop-breaking, and safety filters.
-- `llm_quest_benchmark/agents/planner_agent.py`: Mode D - plan-maintain-act loop with observation-diff heuristic for re-planning.
-- `llm_quest_benchmark/agents/tool_agent.py`: Mode E - tool-augmented agent with quest history tool.
+- `llm_quest_benchmark/agents/planner_agent.py`: Planner loop with observation-diff heuristic for re-planning.
+- `llm_quest_benchmark/agents/tool_agent.py`: Tool-using scaffold with quest history tool.
 - `llm_quest_benchmark/agents/agent_factory.py`: Factory that maps template aliases (stub, reasoning, planner, tool_augmented) to agent classes.
 - `llm_quest_benchmark/agents/human_player.py`, `random_agent.py`: Non-LLM agents.
 
@@ -49,10 +49,12 @@ The runtime loop is:
 
 ### 6. Prompt Templates
 - `llm_quest_benchmark/prompt_templates/`: Jinja2 templates for each agent mode.
-  - `stub.jinja`: Minimal prompt (Mode A).
-  - `reasoning.jinja`, `strategic.jinja`, etc.: Prompted modes (Mode B).
-  - `planner.jinja`: Planner agent prompts (Mode D).
-  - `tool_augmented.jinja`: Tool-augmented agent prompts (Mode E).
+  - `stub.jinja`: Minimal prompt.
+  - `reasoning.jinja`, `strategic.jinja`, etc.: Short-context or full-history reasoning depending on memory mode.
+  - `stateful_compact.jinja`, `memo_*.jinja`: Compact memory / memo prompts.
+  - `light_hints.jinja`, `stateful_compact_hints.jinja`: Prompt hints.
+  - `planner.jinja`: Planner loop prompts.
+  - `tool_augmented.jinja`, `tool_augmented_hints.jinja`: Tool prompts with compact memory, optionally with hints.
 
 ## Persistence
 - `metrics.db`: Benchmark/run metrics for CLI workflows.
@@ -62,12 +64,14 @@ The runtime loop is:
 - `.env` (copied from `.env.template`): Provider API keys.
 - `configs/benchmarks/`: Benchmark YAML configs defining model x template x quest matrix.
 
-## Agent Modes (Benchmark Dimension)
-| Mode | Template | Agent Class | Description |
+## Public Taxonomy (Benchmark Dimension)
+| Label | Template / memory source | Agent Class | Description |
 |------|----------|-------------|-------------|
-| A | stub | LLMAgent | Baseline, minimal prompt |
-| B | reasoning/strategic | LLMAgent | Prompted with analysis |
-| D | planner | PlannerAgent | Plan-maintain-act loop |
-| E | tool_augmented | ToolAgent | Quest history tool |
-
-Mode C (knowledge-augmented) is planned but not yet implemented.
+| Minimal prompt | stub | LLMAgent | Smallest action-selection prompt |
+| Short-context reasoning | reasoning/strategic + default memory | LLMAgent | Local prompted analysis |
+| Full-history reasoning | reasoning + full transcript memory | LLMAgent | Whole transcript retained in context |
+| Compact memory / memo | reasoning/stateful/memo templates + compaction | LLMAgent | Summarized state instead of unbounded transcript |
+| Prompt hints | light_hints/stateful_compact_hints | LLMAgent | Mechanics hints injected into prompt |
+| Tools + compact memory | tool_augmented | ToolAgent | Quest history/scratchpad tools with compact context |
+| Tools + hints + compact memory | tool_augmented_hints | ToolAgent | Tool scaffold plus prompt hints |
+| Planner loop | planner | PlannerAgent | Plan-maintain-act loop |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,7 @@ The runtime loop is:
 - `llm_quest_benchmark/agents/llm_agent.py`: Base LLM agent with template-driven prompts, retry logic, loop-breaking, and safety filters.
 - `llm_quest_benchmark/agents/planner_agent.py`: Planner loop with observation-diff heuristic for re-planning.
 - `llm_quest_benchmark/agents/tool_agent.py`: Tool-using scaffold with quest history tool.
-- `llm_quest_benchmark/agents/agent_factory.py`: Factory that maps template aliases (stub, reasoning, planner, tool_augmented) to agent classes.
+- `llm_quest_benchmark/agents/agent_factory.py`: Factory that maps Prompt Template choices to agent classes.
 - `llm_quest_benchmark/agents/human_player.py`, `random_agent.py`: Non-LLM agents.
 
 `LLMAgent` lazily initializes provider clients, so template rendering and agent construction do not require API keys.

--- a/docs/DATASHEET.md
+++ b/docs/DATASHEET.md
@@ -80,16 +80,18 @@ support direct model-to-model comparison.
 
 **How many runs exist?**
 
-1615 published leaderboard runs across 6 primary models and 5 agent modes
+1615 published leaderboard runs across 6 primary models and 8 taxonomy labels
 (as of 2026-05-05).
 
 Model families include Anthropic, DeepSeek, Google, Minimax, Mistral, and
 OpenAI.
 
-Modes: Baseline (A), Prompted (B), Knowledge (C), Planner (D),
-Tool-augmented (E). Baseline and Prompted have the broadest coverage;
-C/D/E are reported where they exist and should be read as intervention
-experiments rather than a complete rectangular matrix.
+Taxonomy labels: Minimal prompt, Short-context reasoning,
+Full-history reasoning, Compact memory / memo, Prompt hints,
+Tools + compact memory, Tools + hints + compact memory, and Planner loop.
+Minimal prompt and short-context reasoning have the broadest coverage;
+the other labels are reported where they exist and should be read as
+intervention experiments rather than a complete rectangular matrix.
 
 **Is there a difficulty distribution?**
 

--- a/docs/DATASHEET.md
+++ b/docs/DATASHEET.md
@@ -80,7 +80,7 @@ support direct model-to-model comparison.
 
 **How many runs exist?**
 
-1615 published leaderboard runs across 6 primary models and 8 taxonomy labels
+1,615 published leaderboard runs across 6 primary models and 8 taxonomy labels
 (as of 2026-05-05).
 
 Model families include Anthropic, DeepSeek, Google, Minimax, Mistral, and
@@ -190,8 +190,9 @@ archive structure.
 Benchmarking LLM decision-making in interactive text environments. Specific
 use cases:
 
-- Comparing LLM agent architectures (baseline, prompted reasoning,
-  knowledge-augmented, planner-based).
+- Comparing LLM context scaffolds: minimal prompt, short-context reasoning,
+  full-history reasoning, compact memory/memo, prompt hints, tool-assisted
+  variants, and planner loops.
 - Measuring how different models handle multi-step sequential decisions.
 - Evaluating reading comprehension and state tracking under game constraints.
 

--- a/docs/EXPERIMENTS_LOG.md
+++ b/docs/EXPERIMENTS_LOG.md
@@ -1,5 +1,10 @@
 # Experiments Log
 
+> Historical / non-authoritative notes. This log preserves experiment history
+> and branch-era shorthand. For the current public taxonomy and public
+> comparison slice, use `site/about.html`, `site/leaderboard.json`,
+> `docs/ARCHITECTURE.md`, and `docs/DATASHEET.md`.
+
 Record of benchmark experiments, findings, and decisions. Keeps history out of source code.
 
 ## Exp 2: Memory Modes (2026-04-27)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -95,3 +95,9 @@ pnpm run build
 
 Provider API keys are required for real LLM runs. Tests and static validation
 should run without external credentials in a prepared checkout.
+
+Reproducible benchmark rows depend on recording the quest file, model/provider
+ID, prompt templates, memory mode, run ID, outcome, and run summaries with
+usage/metrics. Agent responses are parsed into a chosen action plus optional
+analysis/reasoning so action validity, terminal outcome, steps, tokens/cost,
+and repetition diagnostics can be regenerated from stored artifacts.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,242 +1,97 @@
-# SPEC: LLM-Quest
+# SPEC: LLM-Quest Current State
 
-An agentic benchmark for evaluating LLM decision-making in text-based quest environments.
+This document is a current-state project specification, not a roadmap promise.
+For the public narrative and interpretation of results, use the project
+[About page](../site/about.html) as the main story surface.
 
-## Goal
+## Purpose
 
-Build a reproducible, multi-provider benchmark that measures how well LLM agents complete interactive fiction quests under varying agent architectures. Publish results as a static leaderboard site and a data-driven blog post styled as a short research paper.
+LLM Quest Benchmark evaluates how LLMs make sequential choices in Space
+Rangers text quests. The benchmark varies the context scaffold around a model
+while holding the quest environment and result logging consistent.
 
-The benchmark compares five agent modes across providers and quest difficulty levels, measuring success rate, quest progress, and decision quality on structured text quests.
+The core question is practical: which kinds of context help, hurt, or expose
+state-tracking failures during 10-50 turn interactive fiction tasks?
 
-Most agent benchmarks vary tasks and models but treat the agent as a black box. LLM-Quest adds agent architecture as a first-class evaluation dimension: the same model on the same quest produces different outcomes depending on whether it reasons step-by-step, plans ahead, has domain knowledge, or uses tools. The benchmark is a 3D matrix - models x quests x agent modes - across providers and languages. See `research/LANDSCAPE.md` for competitive analysis.
+## Current Public Scope
+
+The public leaderboard is a curated comparable slice, not the full raw
+experiment history. It currently reports:
+
+- 6 primary publication models.
+- 15 comparable quest IDs with coverage across all six primary models.
+- 1,615 published leaderboard runs.
+- Exploratory, one-model, and partial-coverage runs excluded from the public
+  comparison slice unless they support direct comparison.
+
+Raw benchmark artifacts and experiment notes remain useful for follow-up
+analysis, but the public slice is the authoritative comparison surface.
+
+## Current Taxonomy
+
+Use these labels for current public descriptions of benchmark modes:
+
+| Label | Implementation source | Agent class |
+|---|---|---|
+| Minimal prompt | `stub.jinja` | `LLMAgent` |
+| Short-context reasoning | `reasoning.jinja`, `strategic.jinja` with default/recent context | `LLMAgent` |
+| Full-history reasoning | reasoning templates with `full_transcript` memory | `LLMAgent` |
+| Compact memory / memo | `stateful_compact.jinja`, memo templates, compaction memory | `LLMAgent` |
+| Prompt hints | `light_hints.jinja`, `stateful_compact_hints.jinja` | `LLMAgent` |
+| Tools + compact memory | `tool_augmented.jinja` | `ToolAgent` |
+| Tools + hints + compact memory | `tool_augmented_hints.jinja` | `ToolAgent` |
+| Planner loop | `planner.jinja` | `PlannerAgent` |
+
+Older internal experiment labels are historical and should not be presented as
+the current public taxonomy.
+
+## Implemented Runtime
+
+- Quest execution uses the TypeScript `space-rangers-quest` submodule through
+  the Python bridge in `llm_quest_benchmark/executors/ts_bridge/`.
+- Environment state is exposed through `llm_quest_benchmark/environments/qm.py`.
+- Agents live under `llm_quest_benchmark/agents/` and are selected by template
+  aliases and agent factory wiring.
+- Provider calls are normalized in `llm_quest_benchmark/llm/client.py` with
+  OpenAI-compatible, Anthropic, Google, and DeepSeek adapters.
+- Benchmark execution is CLI + YAML driven through `uv run llm-quest ...`.
+- Static public results are generated into `site/leaderboard.json` and rendered
+  by `site/index.html`.
+
+## Metrics
+
+Current public metrics include success rate, average steps, token/cost
+statistics, and repetition rate. Repetition is interpreted as a diagnostic
+signal for loopiness or context loss, not as a solved predictor of success.
+
+Progress-style metrics and richer quest difficulty annotations remain future
+work unless present in generated result artifacts.
+
+## Data and Distribution
+
+Quest files are downloaded with `download_quests.sh` from the Space Rangers
+community archive and are not redistributed as benchmark source data. The
+repository includes benchmark code, configs, tests, static site assets, and the
+curated public leaderboard JSON.
 
 ## Non-goals
 
-- Full RAG pipeline with vector DB (potential follow-up). Lightweight knowledge injection is in scope as the knowledge-injection track.
-- Runtime web UI. The interface is CLI + YAML config.
-- New quest authoring or quest format changes. Quests come from upstream Space Rangers archives via `download_quests.sh`.
-- Competing with TextQuests (HuggingFace) or TextArena on their turf. LLM-Quest focuses on structured quests with clear success/failure, not open-ended IF or adversarial games.
+- Claiming that any context scaffold is universally best. Results are jagged by
+  quest and model.
+- Treating exploratory or partial-coverage runs as public comparison data.
+- Adding a production web service; the benchmark remains CLI/YAML first with a
+  static publication site.
+- Changing quest authoring or the upstream quest format.
 
-## Benchmark design
+## Reproducibility Entry Points
 
-### Quest corpus
-
-- **Source**: Space Rangers `.qm`/`.qmm` quest files, downloaded from GitLab upstream.
-- **Languages**: Bilingual RU/EN. Minimum 35 English quests + 1-2 Russian collections of comparable size.
-- **Qualification**: A quest is "working" if it can be loaded by the TypeScript engine, has at least one reachable success ending, and has been completed at least once by any agent or human.
-- **Target**: 50+ working quests total, each with 20+ non-zero completion attempts in the final results.
-
-### Evaluation metrics
-
-Inspired by TextQuests (CAIS, 2025) and AgentQuest (NEC, NAACL 2024). See `research/LANDSCAPE.md`.
-
-**Primary metrics** (reported on leaderboard):
-- **Success rate** (%) = successful completions / total attempts per quest per agent config.
-- **Quest progress** (%) = fraction of labeled checkpoints reached, averaged across attempts. Measures how far the agent gets even on failed runs. Requires checkpoint labeling per quest (see Risks).
-
-**Secondary metrics** (reported in blog post / detailed results):
-- **Avg steps to completion**: How efficiently the agent solves a quest.
-- **Repetition rate**: Fraction of steps where the agent repeats a recently taken action (Levenshtein similarity threshold). Borrowed from AgentQuest - measures wasted effort and loop behavior.
-- **Bad decision rate**: Fraction of choices that lead to immediate failure states or dead ends.
-- **Token cost per run**: Average API cost in USD.
-- **Timeout rate**: Fraction of runs that hit the step limit without resolution.
-
-**Outcome model**: Binary at the quest level. `QuestOutcome.SUCCESS` (1) vs `QuestOutcome.FAILURE` (0). Error/timeout runs are excluded from success rate but reported separately. Progress % provides a continuous signal for failed runs.
-
-### Agent modes
-
-| Mode | ID | Description |
-|------|----|-------------|
-| Baseline | `A` | Single-step, minimal prompt. Picks an action number with no reasoning. |
-| Prompted | `B` | Existing reasoning/strategic/loop-aware templates. The agent analyzes options and reasons about consequences. |
-| Knowledge | `C` | Domain knowledge injected into context. See knowledge gradient below. Same decision loop as B. |
-| Planner | `D` | Multi-step planning agent. Maintains a plan, re-plans when the situation changes, then picks an action aligned with the plan. |
-| Tool-assisted | `E` | Agent has access to tools: quest history (memory of past quest states within the same quest). Calculator and domain knowledge lookup deferred to future PRs. |
-
-### Knowledge gradient (historical C-track levels)
-
-Knowledge injection is a dimension, not a binary toggle. Tested as sub-levels of the historical C track:
-
-| Level | Tag | What's injected | Effort |
-|-------|-----|-----------------|--------|
-| C0 | `no-knowledge` | Nothing (same as the prompted control group) | None |
-| C1 | `light-hints` | General quest mechanics and game rules (static, quest-agnostic) | Low |
-| C2 | `heavy-context` | Quest-specific hints, walkthrough fragments, or known-good strategies | Medium |
-| C3 | `rag` | Retrieval from a knowledge base of past runs, quest descriptions, and game lore | High |
-
-**Priority**: C1 first (cheap, high signal). C2 if C1 shows improvement. C3 is stretch goal only - requires building an embedding index and retrieval pipeline.
-
-The C1-vs-C0 delta is the "does knowledge help?" finding. The C2-vs-C1 delta measures diminishing returns of heavier context. C3 tests whether retrieval beats manually curated knowledge.
-
-### Provider matrix
-
-Mid-tier models: we benchmark the "Sonnet-equivalent" production tier for each provider - the models most developers actually use. This keeps per-run cost in the $0.01-0.04 range and makes the comparison fair (similar capability/price class). High-tier comparison (Claude Sonnet, GPT-5.4, Gemini Pro) is a planned follow-up.
-
-**Primary (6 models, all via OpenRouter, Arena ELO 1403-1474):**
-
-| Provider | Model | OpenRouter ID | In $/1M | Out $/1M | Arena ELO |
-|---|---|---|---|---|---|
-| Google | Gemini 3 Flash | `google/gemini-3-flash-preview` | $0.50 | $3.00 | 1474 |
-| OpenAI | GPT-5.4 Mini | `openai/gpt-5.4-mini` | $0.75 | $4.50 | 1458 |
-| DeepSeek | V3.2 | `deepseek/deepseek-v3.2` | $0.26 | $0.42 | 1424 |
-| Mistral | Medium 3.1 | `mistralai/mistral-medium-3.1` | $0.40 | $2.00 | 1410 |
-| Anthropic | Claude Haiku 4.5 | `anthropic/claude-haiku-4.5` | $1.00 | $5.00 | 1408 |
-| Minimax | M2.5 | `minimax/minimax-m2.5` | $0.12 | $0.99 | 1403 |
-
-Selection rationale: one model per major provider, mid-tier production class (ELO 1400-1475), all tested for speed and reliability via OpenRouter. Qwen excluded (all recent models too slow on OpenRouter routing). Kimi K2.5 and GLM-5 excluded (latency and parse reliability issues on OpenRouter).
-
-**Excluded from main benchmark (high-tier, follow-up):**
-- Anthropic Claude Sonnet 4.6 ($3/$15) - frontier tier
-- OpenAI GPT-5.4 ($1.25/$10) - frontier tier
-- Google Gemini 3 Pro - frontier tier
-
-### Run budget
-
-3 runs per cell (model x quest x mode). Comparable papers use 3-5: TextQuests used 3, AgentQuest used 5. Binary outcomes don't need large N per cell - breadth across quests and modes matters more than depth per combination. Targeted 10-run follow-ups on specific cells where tighter confidence intervals are needed.
-
-**Phase 1 (baseline re-run with telemetry):** 17 quests x 6 models x 2 modes (A+B) x 3 runs = ~612 runs, ~$14
-**Phase 2 (intervention runs):** 10 hard quests x 3 best models x 3 modes (C/D/E) x 3 runs = ~270 runs, ~$6
-**Phase 3 (new quests):** 18 untested EN quests x 4 models x mode B x 3 runs = ~216 runs, ~$5
-**Total: ~1100 runs, ~$25**
-
-## Architecture changes
-
-### CLI interface
-
-```
-llm-quest download-quests          # runs download_quests.sh, validates corpus
-llm-quest run --quest X --agent-mode B --model gpt-5-mini
-llm-quest benchmark --config configs/benchmarks/full_matrix.yaml
-llm-quest report --benchmark-id <ID> --format md
-llm-quest leaderboard --output site/leaderboard.json
+```bash
+uv sync --extra dev
+pnpm install
+uv run llm-quest --help
+uv run llm-quest benchmark --config configs/benchmarks/memory_full_transcript.yaml
+pnpm run build
 ```
 
-### Agent mode implementation
-
-- Modes A and B: already exist (stub.jinja, reasoning.jinja, strategic.jinja, etc.).
-- Knowledge-injection track (levels C0-C3): C0 is the prompted control. C1: new template with general game mechanics block prepended (static YAML). C2: quest-specific hints curated manually. C3 (stretch): RAG retrieval from an embedding index of past runs and game lore.
-- Planner track: new agent class wrapping the LLM client with a plan-maintain-act loop. Plan is text, re-evaluated every N steps or on significant state change.
-- Tool track: new agent class with tool-use support. Tools are simple Python functions registered as available actions alongside the quest options.
-
-### Static site
-
-- Stack: Hugo, MkDocs-Material, or plain HTML/JS - whatever generates a clean single-page benchmark site from JSON data.
-- Hosted on GitHub Pages from a `docs/` or `site/` directory in the repo.
-- Content:
-  - Leaderboard table: model x agent mode, sortable by success rate.
-  - Quest difficulty distribution chart.
-  - Per-quest breakdown (expandable or linked).
-  - Blog post / research write-up as a page on the same site.
-- Data source: `site/leaderboard.json` generated by `llm-quest leaderboard` from benchmark results.
-  The public JSON is a curated comparison slice: six primary models and only
-  quests with coverage from all six. Exploratory or partial-coverage runs
-  remain in raw benchmark artifacts but are excluded from the public table.
-
-### Blog post
-
-- Part of the static site, not a separate publication.
-- Styled as a short research paper: abstract, introduction, method, results, discussion, limitations.
-- Central claim: determined by data. Run the full benchmark matrix first, then write the narrative around the strongest finding.
-- Minimum content: method description, results tables, at least one chart, honest discussion of limitations.
-
-## Acceptance criteria
-
-All criteria must be met for the spec to be considered complete:
-
-1. **Leaderboard deployed**: Static site on GitHub Pages showing results from at least 6 provider families.
-2. **Mode comparison**: Results table comparing agent modes A-B (all quests) and C/D/E (hard quests) across providers.
-3. **Performance bar**: Best model + agent mode combination achieves >= 80% success rate on at least 10 different quests. If no config hits 80% success, report progress % as the primary metric and explain the ceiling (TextQuests found zero models completing any game without clues - an honest null result is still publishable).
-4. **Corpus scale**: 35+ working EN quests in the corpus, each with >= 3 completion attempts per model in published results.
-5. **Reproducibility**: Full benchmark can be reproduced from a clean clone with `uv` or Docker via a single documented command.
-6. **Blog post**: Published on the project site with method, results, and discussion sections.
-7. **CLI-first benchmark runtime**: Benchmark execution remains CLI + YAML driven; static site assets are generated for publication and play mode.
-
-## Constraints
-
-- **Runtime**: Python 3.11+, managed with `uv`. TypeScript quest engine via existing bridge.
-- **Cost**: LLM API calls cost real money. The full matrix (~1100 runs across 6 mid-tier models) is estimated at ~$25. Design configs for incremental runs: single-quest smoke test, single-provider sweep, full matrix.
-- **Quest files**: Not committed to repo. Downloaded via `download_quests.sh`. CI/CD must handle this.
-- **Determinism**: LLM outputs are non-deterministic. Success rates are statistical. Report confidence intervals or at minimum the number of attempts.
-
-## Dependencies / integrations
-
-- `space-rangers-quest` TypeScript submodule (quest engine, already integrated).
-- LLM provider SDKs: `openai`, `anthropic`, `google-generativeai`, existing in project.
-- Static site generator: TBD (Hugo, MkDocs-Material, or custom).
-- GitHub Pages: deployment target.
-
-## Risks / open questions
-
-1. **English quest count**: Need to verify that `download_quests.sh` yields 35+ distinct working English quests. If not, options: translate Russian quests, source additional IF quests, or lower the threshold.
-2. **Quest success detection**: Some quests may have ambiguous endings. Need a human pass to label which endings count as success vs failure for edge cases.
-3. **Checkpoint labeling for progress %**: Progress metric requires defining intermediate checkpoints per quest. The .qm format has location/state data that may be extractable, but manual validation is needed. Start with 10 quests, then scale.
-4. **Cost of full matrix**: ~1200 runs at ~$27 for 7 mid-tier models. High-tier follow-up (Claude Sonnet, GPT-5.4, Gemini Pro) adds ~$50-100 depending on scope.
-5. **Planner/tool complexity**: Planner and tool-assisted agents are new code. Scope creep risk - keep implementations shallow and iterate.
-6. **Models may not complete quests at all**: TextQuests (2025) found zero models completing any Infocom game without clues. Our quests are shorter and choice-based (easier), but the same ceiling effect is possible. Progress % and the knowledge gradient provide a publishable story even if success rates are low.
-7. **TextQuests differentiation**: HuggingFace's TextQuests (2025) is the closest competitor. Key differentiators: agent architecture comparison (5 modes vs 1), bilingual RU/EN, choice-based vs parser-based IF, knowledge gradient experiment. Lead with "vary the agent, not the task" framing.
-
-## Agent response protocol
-
-All agents return structured JSON. The canonical response schema:
-
-```json
-{"memo": "<max 20 words>", "reasoning": "<max 25 words>", "result": <action_number>}
-```
-
-Fields:
-- `memo` - Short state tracker maintained across turns. Agents use this to track inventory, health, codes, quest phase, and anything else worth remembering. Max 20 words. This is the **single** key for all state tracking: no aliases (`subgoal`, `state_notes`, etc.).
-- `reasoning` - Brief explanation for the choice. Max 25 words.
-- `analysis` - Optional deeper analysis (used by some templates).
-- `result` - 1-based action number.
-
-The `memo` field is stored in decision history, passed through compaction, and displayed in trace views. Templates that use state tracking must use this key.
-
-## Codebase notes
-
-- Prompt templates: `llm_quest_benchmark/prompt_templates/*.jinja` - modes A/B reuse these.
-- Agent implementations: `llm_quest_benchmark/agents/` - modes D/E add new agent classes here.
-- Benchmark configs: `configs/benchmarks/*.yaml` - add new configs for the full matrix.
-- Quest outcome: `llm_quest_benchmark/environments/state.py:QuestOutcome` - binary SUCCESS/FAILURE already implemented.
-- Existing CLI: `llm_quest_benchmark/executors/cli/commands.py` - extend with new commands.
-
-## Phases
-
-### Phase 1: Foundation
-- Download and validate quest corpus (run `download_quests.sh`, count working quests per language).
-- Implement progress % metric: extract location/state data from quest engine, label checkpoints for 10 pilot quests.
-- Implement repetition rate metric.
-- Ensure modes A and B run cleanly on 10+ quests across 2+ providers with all metrics reported.
-- Set up static site scaffold with placeholder leaderboard.
-
-### Phase 2: Agent modes C-E
-- Implement the light-hints level first. Run minimal-prompt vs prompted-control vs light-hints pilots.
-- If C1 shows improvement, implement C2 (heavy context with quest-specific hints).
-- Implement planner agent (mode D).
-- Implement tool-augmented agent (mode E).
-- Validate each mode on a small quest subset before scaling.
-- Estimate cost for full matrix based on pilot results.
-
-### Phase 3: Full benchmark
-- Label checkpoints for all 50+ quests (progress % requires this).
-- Run complete matrix: modes A-E x 4 providers x 50+ quests x 20+ attempts.
-- If budget allows, run C3 (RAG) on a subset.
-- Generate leaderboard JSON from results.
-- Populate static site with real data.
-
-### Phase 4: Publication
-- Analyze results, identify strongest finding. Candidates:
-  - "Agent architecture matters more than model choice"
-  - "Knowledge unlocks quests that reasoning alone cannot solve"
-  - "Frontier models plateau on easy quests but diverge on hard ones"
-  - "No model completes hard quests without knowledge" (null result, still publishable)
-- Write blog post with method, results, discussion.
-- Deploy site to GitHub Pages.
-- Update README to lead with benchmark framing.
-
-## Current implementation status
-
-- **Interface**: CLI + YAML config for benchmark execution; static GitHub Pages site for publication and play mode.
-- **Agent modes**: A (baseline), B (prompted), C (knowledge/light hints), D (planner), E (tool-augmented) implemented.
-- **Memory modes**: `full_transcript` and `compaction` (configurable interval).
-- **LLM client**: OpenAI-compatible SDK with `timeout=30`, `max_retries=0`. All providers routed via OpenRouter.
-- **Metrics**: Success rate, token cost, step count, and repetition rate implemented. Progress % remains future work.
+Provider API keys are required for real LLM runs. Tests and static validation
+should run without external credentials in a prepared checkout.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -12,7 +12,7 @@ Most agent benchmarks vary tasks and models but treat the agent as a black box. 
 
 ## Non-goals
 
-- Full RAG pipeline with vector DB (potential follow-up). Lightweight knowledge injection is in scope as Mode C.
+- Full RAG pipeline with vector DB (potential follow-up). Lightweight knowledge injection is in scope as the knowledge-injection track.
 - Runtime web UI. The interface is CLI + YAML config.
 - New quest authoring or quest format changes. Quests come from upstream Space Rangers archives via `download_quests.sh`.
 - Competing with TextQuests (HuggingFace) or TextArena on their turf. LLM-Quest focuses on structured quests with clear success/failure, not open-ended IF or adversarial games.
@@ -51,15 +51,15 @@ Inspired by TextQuests (CAIS, 2025) and AgentQuest (NEC, NAACL 2024). See `resea
 | Prompted | `B` | Existing reasoning/strategic/loop-aware templates. The agent analyzes options and reasons about consequences. |
 | Knowledge | `C` | Domain knowledge injected into context. See knowledge gradient below. Same decision loop as B. |
 | Planner | `D` | Multi-step planning agent. Maintains a plan, re-plans when the situation changes, then picks an action aligned with the plan. |
-| Tool-augmented | `E` | Agent has access to tools: quest history (memory of past quest states within the same quest). Calculator and domain knowledge lookup deferred to future PRs. |
+| Tool-assisted | `E` | Agent has access to tools: quest history (memory of past quest states within the same quest). Calculator and domain knowledge lookup deferred to future PRs. |
 
-### Knowledge gradient (Mode C levels)
+### Knowledge gradient (historical C-track levels)
 
-Knowledge injection is a dimension, not a binary toggle. Tested as sub-levels of Mode C:
+Knowledge injection is a dimension, not a binary toggle. Tested as sub-levels of the historical C track:
 
 | Level | Tag | What's injected | Effort |
 |-------|-----|-----------------|--------|
-| C0 | `no-knowledge` | Nothing (same as Mode B, control group) | None |
+| C0 | `no-knowledge` | Nothing (same as the prompted control group) | None |
 | C1 | `light-hints` | General quest mechanics and game rules (static, quest-agnostic) | Low |
 | C2 | `heavy-context` | Quest-specific hints, walkthrough fragments, or known-good strategies | Medium |
 | C3 | `rag` | Retrieval from a knowledge base of past runs, quest descriptions, and game lore | High |
@@ -114,9 +114,9 @@ llm-quest leaderboard --output site/leaderboard.json
 ### Agent mode implementation
 
 - Modes A and B: already exist (stub.jinja, reasoning.jinja, strategic.jinja, etc.).
-- Mode C (levels C0-C3): C0 is Mode B (control). C1: new template with general game mechanics block prepended (static YAML). C2: quest-specific hints curated manually. C3 (stretch): RAG retrieval from an embedding index of past runs and game lore.
-- Mode D: new agent class wrapping the LLM client with a plan-maintain-act loop. Plan is text, re-evaluated every N steps or on significant state change.
-- Mode E: new agent class with tool-use support. Tools are simple Python functions registered as available actions alongside the quest options.
+- Knowledge-injection track (levels C0-C3): C0 is the prompted control. C1: new template with general game mechanics block prepended (static YAML). C2: quest-specific hints curated manually. C3 (stretch): RAG retrieval from an embedding index of past runs and game lore.
+- Planner track: new agent class wrapping the LLM client with a plan-maintain-act loop. Plan is text, re-evaluated every N steps or on significant state change.
+- Tool track: new agent class with tool-use support. Tools are simple Python functions registered as available actions alongside the quest options.
 
 ### Static site
 
@@ -171,7 +171,7 @@ All criteria must be met for the spec to be considered complete:
 2. **Quest success detection**: Some quests may have ambiguous endings. Need a human pass to label which endings count as success vs failure for edge cases.
 3. **Checkpoint labeling for progress %**: Progress metric requires defining intermediate checkpoints per quest. The .qm format has location/state data that may be extractable, but manual validation is needed. Start with 10 quests, then scale.
 4. **Cost of full matrix**: ~1200 runs at ~$27 for 7 mid-tier models. High-tier follow-up (Claude Sonnet, GPT-5.4, Gemini Pro) adds ~$50-100 depending on scope.
-5. **Mode D/E complexity**: Planner and tool-augmented agents are new code. Scope creep risk - keep implementations shallow and iterate.
+5. **Planner/tool complexity**: Planner and tool-assisted agents are new code. Scope creep risk - keep implementations shallow and iterate.
 6. **Models may not complete quests at all**: TextQuests (2025) found zero models completing any Infocom game without clues. Our quests are shorter and choice-based (easier), but the same ceiling effect is possible. Progress % and the knowledge gradient provide a publishable story even if success rates are low.
 7. **TextQuests differentiation**: HuggingFace's TextQuests (2025) is the closest competitor. Key differentiators: agent architecture comparison (5 modes vs 1), bilingual RU/EN, choice-based vs parser-based IF, knowledge gradient experiment. Lead with "vary the agent, not the task" framing.
 
@@ -209,7 +209,7 @@ The `memo` field is stored in decision history, passed through compaction, and d
 - Set up static site scaffold with placeholder leaderboard.
 
 ### Phase 2: Agent modes C-E
-- Implement Mode C level C1 (light knowledge hints) first. Run A vs B vs C1 on pilot quests.
+- Implement the light-hints level first. Run minimal-prompt vs prompted-control vs light-hints pilots.
 - If C1 shows improvement, implement C2 (heavy context with quest-specific hints).
 - Implement planner agent (mode D).
 - Implement tool-augmented agent (mode E).

--- a/llm_quest_benchmark/core/leaderboard.py
+++ b/llm_quest_benchmark/core/leaderboard.py
@@ -13,22 +13,32 @@ from typing import Any, cast
 from llm_quest_benchmark.core.quest_lang import canonical_quest_id
 from llm_quest_benchmark.llm.client import parse_model_name
 
-TEMPLATE_TO_MODE = {
-    "stub": ("stub", "Baseline (A)"),
-    "reasoning": ("reasoning", "Prompted (B)"),
-    "strategic": ("reasoning", "Prompted (B)"),
-    "stateful_compact": ("reasoning", "Prompted (B)"),
-    "memo_cot": ("reasoning", "Prompted (B)"),
-    "memo_extended": ("reasoning", "Prompted (B)"),
-    "memo_structured": ("reasoning", "Prompted (B)"),
-    "light_hints": ("light_hints", "Knowledge (C)"),
-    "stateful_compact_hints": ("light_hints", "Knowledge (C)"),
-    "planner": ("planner", "Planner (D)"),
-    "tool_augmented": ("tool_augmented", "Tool-aug (E)"),
-    "tool_augmented_hints": ("tool_augmented", "Tool-aug (E)"),
+TAXONOMY_MODES = {
+    "minimal_prompt": "Minimal prompt",
+    "short_context_reasoning": "Short-context reasoning",
+    "full_history_reasoning": "Full-history reasoning",
+    "compact_memory_memo": "Compact memory / memo",
+    "prompt_hints": "Prompt hints",
+    "tools_compact_memory": "Tools + compact memory",
+    "tools_hints_compact_memory": "Tools + hints + compact memory",
+    "planner_loop": "Planner loop",
 }
 
-MODE_ORDER = ["stub", "reasoning", "light_hints", "planner", "tool_augmented"]
+TEMPLATE_TO_MODE = {
+    "stub": ("minimal_prompt", TAXONOMY_MODES["minimal_prompt"]),
+    "strategic": ("short_context_reasoning", TAXONOMY_MODES["short_context_reasoning"]),
+    "stateful_compact": ("compact_memory_memo", TAXONOMY_MODES["compact_memory_memo"]),
+    "memo_cot": ("compact_memory_memo", TAXONOMY_MODES["compact_memory_memo"]),
+    "memo_extended": ("compact_memory_memo", TAXONOMY_MODES["compact_memory_memo"]),
+    "memo_structured": ("compact_memory_memo", TAXONOMY_MODES["compact_memory_memo"]),
+    "light_hints": ("prompt_hints", TAXONOMY_MODES["prompt_hints"]),
+    "stateful_compact_hints": ("prompt_hints", TAXONOMY_MODES["prompt_hints"]),
+    "planner": ("planner_loop", TAXONOMY_MODES["planner_loop"]),
+    "tool_augmented": ("tools_compact_memory", TAXONOMY_MODES["tools_compact_memory"]),
+    "tool_augmented_hints": ("tools_hints_compact_memory", TAXONOMY_MODES["tools_hints_compact_memory"]),
+}
+
+MODE_ORDER = list(TAXONOMY_MODES)
 
 MODEL_ALIASES = {
     "claude:claude-haiku-4-5-20251001": "claude-haiku-4.5",
@@ -57,9 +67,26 @@ def _strip_template_suffix(template_name: str) -> str:
     return Path(template_name or "").stem
 
 
-def _mode_from_template(template_name: str) -> tuple[str, str]:
+def _mode_from_template(template_name: str, memory_mode: str | None = None) -> tuple[str, str]:
     template_id = _strip_template_suffix(template_name)
+    if template_id == "reasoning":
+        if memory_mode == "full_transcript":
+            return "full_history_reasoning", TAXONOMY_MODES["full_history_reasoning"]
+        if memory_mode == "compaction":
+            return "compact_memory_memo", TAXONOMY_MODES["compact_memory_memo"]
+        return "short_context_reasoning", TAXONOMY_MODES["short_context_reasoning"]
     return TEMPLATE_TO_MODE.get(template_id, (template_id or "unknown", template_id or "unknown"))
+
+
+def _agent_config(db_run: dict[str, Any]) -> dict[str, Any]:
+    raw_config = db_run.get("agent_config")
+    if not isinstance(raw_config, str) or not raw_config:
+        return {}
+    try:
+        parsed = json.loads(raw_config)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def _combine_numeric_tokens(parts: list[str]) -> list[str]:
@@ -181,7 +208,7 @@ def generate_leaderboard(
 
     grouped_rows: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
     model_entries: dict[str, dict[str, str]] = {}
-    mode_entries: dict[str, dict[str, str]] = {}
+    taxonomy_entries: dict[str, dict[str, str]] = {}
     quest_entries: dict[str, dict[str, Any]] = {}
     benchmark_ids: list[str] = []
 
@@ -205,7 +232,6 @@ def generate_leaderboard(
 
             model = str(result_row.get("model") or "unknown")
             template = str(result_row.get("template") or "")
-            mode_id, mode_label = _mode_from_template(template)
             quest_path = str(result_row.get("quest") or "")
             raw_quest_id = _quest_id_from_path(quest_path)
             quest_id = canonical_quest_id(raw_quest_id)
@@ -216,8 +242,10 @@ def generate_leaderboard(
             # Correlate with db_runs by index to get run ID for metrics
             usage: dict[str, Any] = {}
             metrics: dict[str, Any] = {}
+            config: dict[str, Any] = {}
             if i < len(db_runs) and isinstance(db_runs[i], dict):
                 db_run = db_runs[i]
+                config = _agent_config(db_run)
                 run_id = db_run.get("id")
                 quest_name = db_run.get("quest_name")
                 agent_id = db_run.get("agent_id")
@@ -226,6 +254,12 @@ def generate_leaderboard(
                     run_summary = _load_json(run_path) or {}
                     usage = _dict_field(run_summary, "usage")
                     metrics = _dict_field(run_summary, "metrics")
+
+            template_from_config = str(config.get("action_template") or "")
+            if template_from_config:
+                template = template_from_config
+            memory_mode = config.get("memory_mode")
+            mode_id, mode_label = _mode_from_template(template, str(memory_mode) if memory_mode else None)
 
             try:
                 spec = parse_model_name(model)
@@ -256,7 +290,7 @@ def generate_leaderboard(
                     "provider": provider,
                     "label": _model_label(label_source_for_display),
                 }
-            mode_entries[mode_id] = {"id": mode_id, "label": mode_label}
+            taxonomy_entries[mode_id] = {"id": mode_id, "label": mode_label}
             if raw_quest_id != quest_id:
                 existing_quest = quest_entries.setdefault(quest_id, {"id": quest_id, "lang": "EN"})
                 source_langs = existing_quest.get("source_langs")
@@ -318,7 +352,7 @@ def generate_leaderboard(
     included_modes = {row["mode"] for row in agg_results}
     included_quests = {row["quest"] for row in agg_results}
     model_entries = {k: v for k, v in model_entries.items() if k in included_models}
-    mode_entries = {k: v for k, v in mode_entries.items() if k in included_modes}
+    taxonomy_entries = {k: v for k, v in taxonomy_entries.items() if k in included_modes}
     quest_entries = {k: v for k, v in quest_entries.items() if k in included_quests}
 
     mode_rank = {mode_id: index for index, mode_id in enumerate(MODE_ORDER)}
@@ -332,7 +366,7 @@ def generate_leaderboard(
             "note": "Raw benchmark artifacts may contain exploratory runs outside this published comparison slice.",
         },
         "models": sorted(model_entries.values(), key=lambda item: item["id"]),
-        "modes": sorted(mode_entries.values(), key=lambda item: (mode_rank.get(item["id"], 999), item["id"])),
+        "modes": sorted(taxonomy_entries.values(), key=lambda item: (mode_rank.get(item["id"], 999), item["id"])),
         "quests": sorted(quest_entries.values(), key=lambda item: item["id"]),
         "results": sorted(
             agg_results,

--- a/llm_quest_benchmark/core/leaderboard.py
+++ b/llm_quest_benchmark/core/leaderboard.py
@@ -38,6 +38,15 @@ TEMPLATE_TO_MODE = {
     "tool_augmented_hints": ("tools_hints_compact_memory", TAXONOMY_MODES["tools_hints_compact_memory"]),
 }
 
+REASONING_STYLE_TEMPLATES = {
+    "reasoning",
+    "strategic",
+    "loop_aware_reasoning",
+    "objective_guard",
+    "consequence_scan",
+    "consequence_scan_subgoal",
+}
+
 MODE_ORDER = list(TAXONOMY_MODES)
 
 MODEL_ALIASES = {
@@ -69,7 +78,7 @@ def _strip_template_suffix(template_name: str) -> str:
 
 def _mode_from_template(template_name: str, memory_mode: str | None = None) -> tuple[str, str]:
     template_id = _strip_template_suffix(template_name)
-    if template_id == "reasoning":
+    if template_id in REASONING_STYLE_TEMPLATES:
         if memory_mode == "full_transcript":
             return "full_history_reasoning", TAXONOMY_MODES["full_history_reasoning"]
         if memory_mode == "compaction":
@@ -154,6 +163,77 @@ def _detect_quest_lang(quest_path: str) -> str:
     return "EN"
 
 
+def _row_run_id(row: dict[str, Any]) -> str | None:
+    for key in ("run_id", "db_run_id", "id"):
+        value = row.get(key)
+        if value is not None:
+            return str(value)
+    return None
+
+
+def _row_quest_id(row: dict[str, Any]) -> str:
+    quest_ref = row.get("quest") or row.get("quest_file") or row.get("quest_name") or ""
+    return canonical_quest_id(_quest_id_from_path(str(quest_ref)))
+
+
+def _run_match_key(row: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        _row_quest_id(row),
+        str(row.get("agent_id") or ""),
+        str(row.get("outcome") or ""),
+    )
+
+
+def _db_run_matches_result(db_run: dict[str, Any], result_row: dict[str, Any]) -> bool:
+    db_quest = _row_quest_id(db_run)
+    result_quest = _row_quest_id(result_row)
+    if db_quest and result_quest and db_quest != result_quest:
+        return False
+
+    db_agent = db_run.get("agent_id")
+    result_agent = result_row.get("agent_id")
+    if db_agent and result_agent and str(db_agent) != str(result_agent):
+        return False
+
+    db_outcome = db_run.get("outcome")
+    result_outcome = result_row.get("outcome")
+    return not (db_outcome and result_outcome and str(db_outcome) != str(result_outcome))
+
+
+def _db_run_for_result(
+    result_row: dict[str, Any],
+    index: int,
+    db_runs: list[Any],
+    db_runs_by_id: dict[str, dict[str, Any]],
+    db_run_queues: dict[tuple[str, str, str], list[dict[str, Any]]],
+    used_db_run_ids: set[int],
+) -> dict[str, Any] | None:
+    result_run_id = _row_run_id(result_row)
+    if result_run_id is not None:
+        db_run = db_runs_by_id.get(result_run_id)
+        if db_run is not None and id(db_run) not in used_db_run_ids:
+            used_db_run_ids.add(id(db_run))
+            return db_run
+
+    queue = db_run_queues.get(_run_match_key(result_row), [])
+    while queue:
+        db_run = queue.pop(0)
+        if id(db_run) not in used_db_run_ids:
+            used_db_run_ids.add(id(db_run))
+            return db_run
+
+    # Legacy benchmark summaries did not store a run identifier on result rows.
+    # If the positional row still matches all available identifiers, keep it as
+    # a defensive fallback for those artifacts instead of correlating blindly.
+    if index < len(db_runs) and isinstance(db_runs[index], dict):
+        db_run = db_runs[index]
+        if id(db_run) not in used_db_run_ids and _db_run_matches_result(db_run, result_row):
+            used_db_run_ids.add(id(db_run))
+            return db_run
+
+    return None
+
+
 def _mean(values: Iterable[float]) -> float:
     materialized = list(values)
     if not materialized:
@@ -225,6 +305,16 @@ def generate_leaderboard(
         results_list: list[Any] = raw_results if isinstance(raw_results, list) else []
         raw_db_runs = summary.get("db_runs")
         db_runs: list[Any] = raw_db_runs if isinstance(raw_db_runs, list) else []
+        db_runs_by_id: dict[str, dict[str, Any]] = {}
+        db_run_queues: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+        for db_run in db_runs:
+            if not isinstance(db_run, dict):
+                continue
+            run_id = _row_run_id(db_run)
+            if run_id is not None:
+                db_runs_by_id[run_id] = db_run
+            db_run_queues[_run_match_key(db_run)].append(db_run)
+        used_db_run_ids: set[int] = set()
 
         for i, result_row in enumerate(results_list):
             if not isinstance(result_row, dict):
@@ -239,12 +329,12 @@ def generate_leaderboard(
             outcome = str(result_row.get("outcome") or "UNKNOWN")
 
             # TODO: cost tracking is broken - run_summary.json usage data is not populated by OpenRouter runs
-            # Correlate with db_runs by index to get run ID for metrics
+            # Correlate with db_runs to get run ID for metrics.
             usage: dict[str, Any] = {}
             metrics: dict[str, Any] = {}
             config: dict[str, Any] = {}
-            if i < len(db_runs) and isinstance(db_runs[i], dict):
-                db_run = db_runs[i]
+            db_run = _db_run_for_result(result_row, i, db_runs, db_runs_by_id, db_run_queues, used_db_run_ids)
+            if db_run is not None:
                 config = _agent_config(db_run)
                 run_id = db_run.get("id")
                 quest_name = db_run.get("quest_name")
@@ -259,7 +349,7 @@ def generate_leaderboard(
             if template_from_config:
                 template = template_from_config
             memory_mode = config.get("memory_mode")
-            mode_id, mode_label = _mode_from_template(template, str(memory_mode) if memory_mode else None)
+            mode_id, mode_label = _mode_from_template(template, str(memory_mode) if memory_mode is not None else None)
 
             try:
                 spec = parse_model_name(model)

--- a/llm_quest_benchmark/tests/test_leaderboard.py
+++ b/llm_quest_benchmark/tests/test_leaderboard.py
@@ -123,8 +123,8 @@ def test_generate_leaderboard_aggregates_runs(tmp_path, monkeypatch):
         {"id": "gpt-5-mini", "provider": "openai", "label": "GPT-5 Mini"},
     ]
     assert leaderboard["modes"] == [
-        {"id": "stub", "label": "Baseline (A)"},
-        {"id": "planner", "label": "Planner (D)"},
+        {"id": "minimal_prompt", "label": "Minimal prompt"},
+        {"id": "planner_loop", "label": "Planner loop"},
     ]
     assert leaderboard["quests"] == [
         {"id": "Boat", "lang": "RU"},
@@ -132,7 +132,7 @@ def test_generate_leaderboard_aggregates_runs(tmp_path, monkeypatch):
     ]
 
     boat_row = next(row for row in leaderboard["results"] if row["model"] == "gemini-2.5-flash")
-    assert boat_row["mode"] == "stub"
+    assert boat_row["mode"] == "minimal_prompt"
     assert boat_row["quest"] == "Boat"
     assert boat_row["runs"] == 2
     assert boat_row["success_rate"] == pytest.approx(0.5)
@@ -144,7 +144,7 @@ def test_generate_leaderboard_aggregates_runs(tmp_path, monkeypatch):
     scout_row = next(row for row in leaderboard["results"] if row["model"] == "gpt-5-mini")
     assert scout_row == {
         "model": "gpt-5-mini",
-        "mode": "planner",
+        "mode": "planner_loop",
         "quest": "Scout",
         "runs": 1,
         "success_rate": 1.0,

--- a/llm_quest_benchmark/tests/test_leaderboard.py
+++ b/llm_quest_benchmark/tests/test_leaderboard.py
@@ -207,3 +207,72 @@ def test_generate_leaderboard_filters_public_slice(tmp_path, monkeypatch):
     assert [quest["id"] for quest in leaderboard["quests"]] == ["Core"]
     assert {row["quest"] for row in leaderboard["results"]} == {"Core"}
     assert {row["model"] for row in leaderboard["results"]} == {"model-a", "model-b", "model-c"}
+
+
+def test_generate_leaderboard_matches_db_runs_by_identifiers(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    benchmark_dir = Path("results/benchmarks/bench_match")
+    benchmark_dir.mkdir(parents=True, exist_ok=True)
+
+    results = [
+        {
+            "quest": "quests/Alpha.qm",
+            "model": "gpt-5-mini",
+            "template": "stub.jinja",
+            "agent_id": "llm_gpt-5-mini",
+            "outcome": "SUCCESS",
+        },
+        {
+            "quest": "quests/Beta.qm",
+            "model": "gpt-5-mini",
+            "template": "stub.jinja",
+            "agent_id": "llm_gpt-5-mini",
+            "outcome": "SUCCESS",
+        },
+    ]
+    db_runs = [
+        {
+            "id": 20,
+            "quest_file": "quests/Beta.qm",
+            "quest_name": "Beta",
+            "agent_id": "llm_gpt-5-mini",
+            "agent_config": json.dumps(
+                {"model": "gpt-5-mini", "action_template": "reasoning.jinja", "memory_mode": "full_transcript"}
+            ),
+            "outcome": "SUCCESS",
+        },
+        {
+            "id": 10,
+            "quest_file": "quests/Alpha.qm",
+            "quest_name": "Alpha",
+            "agent_id": "llm_gpt-5-mini",
+            "agent_config": json.dumps(
+                {"model": "gpt-5-mini", "action_template": "loop_aware_reasoning.jinja", "memory_mode": "compaction"}
+            ),
+            "outcome": "SUCCESS",
+        },
+    ]
+    (benchmark_dir / "benchmark_summary.json").write_text(
+        json.dumps({"benchmark_id": "bench_match", "agents": [], "results": results, "db_runs": db_runs}),
+        encoding="utf-8",
+    )
+
+    for run_id, quest_name, total_steps in [(10, "Alpha", 10), (20, "Beta", 20)]:
+        path = Path("results/llm_gpt-5-mini") / quest_name / f"run_{run_id}" / "run_summary.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"usage": {"total_tokens": total_steps}, "metrics": {"total_steps": total_steps}}),
+            encoding="utf-8",
+        )
+
+    leaderboard = generate_leaderboard(
+        [str(benchmark_dir)],
+        "site/leaderboard.json",
+        min_runs=0,
+        public_model_ids=None,
+    )
+
+    rows = {(row["quest"], row["mode"]): row for row in leaderboard["results"]}
+    assert rows[("Alpha", "compact_memory_memo")]["avg_steps"] == 10.0
+    assert rows[("Beta", "full_history_reasoning")]["avg_steps"] == 20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,5 @@ include = ["llm_quest_benchmark*"]
 [tool.setuptools.package-data]
 "llm_quest_benchmark" = [
     "prompt_templates/*.jinja",
-    "scripts/*.ts",
+    "executors/ts_bridge/consoleplayer.ts",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,8 @@ ignore = [
 [tool.ruff.lint.isort]
 known-first-party = ["llm_quest_benchmark"]
 
-[tool.setuptools]
-packages = ["llm_quest_benchmark"]
+[tool.setuptools.packages.find]
+include = ["llm_quest_benchmark*"]
 
 [tool.setuptools.package-data]
 "llm_quest_benchmark" = [

--- a/site/about.html
+++ b/site/about.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta property="og:title" content="LLM-Quest Benchmark">
-<meta property="og:description" content="Six models, five wrappers, and 15 comparable text quests. Does agent architecture matter more than the model itself?">
+<meta property="og:description" content="Context engineering for sequential LLM evaluations: six models, 15 comparable text quests, and 1,615 published runs.">
 <meta property="og:image" content="https://yourconscience.github.io/llm_quest_benchmark/img/play_quest_in_progress.png">
 <meta property="og:url" content="https://yourconscience.github.io/llm_quest_benchmark/about.html">
 <meta property="og:type" content="article">
@@ -67,8 +67,8 @@ figcaption { font-size: 0.85rem; color: var(--muted); margin-top: 0.5rem; }
 <div class="container" style="max-width: 780px;">
 
 <div class="hero">
-  <h1>Does Agent Architecture Matter?</h1>
-  <p class="subtitle">Same models, different wrappers, 15 comparable text quests. We measure whether scaffolding matters more than the model itself.</p>
+  <h1>Context Engineering for Sequential LLM Evaluations</h1>
+  <p class="subtitle">Same quests, same models, different context scaffolds. LLM-Quest tests how memory, hints, tools, and planning change multi-turn decisions.</p>
   <div class="cta-row">
     <a href="play.html" class="cta-btn cta-primary">Play a Quest</a>
     <a href="index.html" class="cta-btn cta-secondary">Leaderboard</a>
@@ -77,7 +77,7 @@ figcaption { font-size: 0.85rem; color: var(--muted); margin-top: 0.5rem; }
 
 <div class="stats-row">
   <div class="stat"><div class="stat-num">6</div><div class="stat-label">models</div></div>
-  <div class="stat"><div class="stat-num">5</div><div class="stat-label">agent modes</div></div>
+  <div class="stat"><div class="stat-num">8</div><div class="stat-label">taxonomy labels</div></div>
   <div class="stat"><div class="stat-num">15</div><div class="stat-label">quests</div></div>
   <div class="stat"><div class="stat-num">1615</div><div class="stat-label">runs</div></div>
 </div>
@@ -87,37 +87,40 @@ figcaption { font-size: 0.85rem; color: var(--muted); margin-top: 0.5rem; }
 </div>
 
 <p>
-  Most LLM benchmarks hold the agent architecture constant and vary the model. We did the opposite: same models, five different agent wrappers, 15 comparable text quests. The results were messier than the neat story I wanted.
+  Most LLM benchmarks hold the prompt and context wrapper constant, then compare models. LLM-Quest does the uncomfortable version: keep a comparable slice of six primary models and 15 Space Rangers text quests, then vary the context the model sees while it makes 10-50 sequential choices. The published leaderboard currently contains 1,615 runs after excluding exploratory and partial-coverage history.
 </p>
 
 <h2>The setup</h2>
 <p>
-  Give an LLM a text adventure: read the situation, pick from a list of actions, repeat for 10-50 turns until you win or lose. Now do the same thing five different ways:
+  Give an LLM a text adventure: read the situation, pick from a list of actions, repeat until you win or lose. The benchmark treats context engineering as the experimental variable:
 </p>
   <ul>
-    <li><strong>Baseline (A)</strong> - bare prompt, just pick a number</li>
-    <li><strong>Reasoning (B)</strong> - structured chain-of-thought before choosing</li>
-    <li><strong>Knowledge (C)</strong> - reasoning plus domain hints about game mechanics</li>
-    <li><strong>Planner (D)</strong> - multi-turn planning with strategy updates</li>
-    <li><strong>Tool-augmented (E)</strong> - quest-history tools exposed to the agent</li>
+    <li><strong>Minimal prompt</strong> - the smallest "pick an action" prompt.</li>
+    <li><strong>Short-context reasoning</strong> - structured reasoning over the current turn and local context.</li>
+    <li><strong>Full-history reasoning</strong> - reasoning with the whole transcript kept in context.</li>
+    <li><strong>Compact memory / memo</strong> - summarized state and notes instead of unbounded transcript growth.</li>
+    <li><strong>Prompt hints</strong> - lightweight game-mechanics hints injected into the prompt.</li>
+    <li><strong>Tools + compact memory</strong> - scratchpad/history tools paired with compact context.</li>
+    <li><strong>Tools + hints + compact memory</strong> - tools and prompt hints combined under compaction.</li>
+    <li><strong>Planner loop</strong> - a plan-maintain-act loop that periodically revises strategy.</li>
   </ul>
 <p>
   The quests come from <a href="https://spacerangers.gitlab.io/#/quests">Space Rangers</a>, a corpus of community-authored text adventures with branching narratives and non-obvious optimal paths. They were not designed for LLM evaluation, which is part of why they work: the difficulty is organic, not synthetic.
 </p>
 <p>
-  The public leaderboard keeps the six primary models and the 15 quest IDs covered by all six. Exploratory one-model and partial-coverage runs stay out of the public table so the comparison is cleaner.
+  The public leaderboard keeps the six primary models and the 15 quest IDs covered by all six. Exploratory one-model, raw-history, and partial-coverage runs remain useful for analysis, but they stay out of the public comparison slice unless coverage is comparable.
 </p>
 
 <h2>What we found</h2>
 
 <div class="finding-card">
   <h3>Scaffolding does not automatically help</h3>
-  <p>In the comparable slice, the bare baseline is ahead of raw prompted reasoning. Knowledge, planning, and tool modes are still thinner coverage, so the honest result is not a victory lap for any wrapper.</p>
+  <p>Compact memory/memo, full-history reasoning, prompt hints, tools, and planner runs move differently by quest and model. The honest result is not a victory lap for any scaffold: context can help, hurt, or mostly expose where the agent is losing state.</p>
 </div>
 
 <div class="finding-card">
   <h3>Agents get stuck in loops</h3>
-  <p>The traces are full of agents revisiting the same states and re-picking familiar actions. Loop detection is still the most obvious cheap early stopping signal, but v1.0 reports it as a diagnostic, not a proven predictor.</p>
+  <p>The traces are full of agents revisiting the same states and re-picking familiar actions. Repetition is reported as a diagnostic for loopiness and context loss, not as solved, not as a proven predictor, and not as the primary success metric.</p>
 </div>
 
 <div class="finding-card">
@@ -127,11 +130,11 @@ figcaption { font-size: 0.85rem; color: var(--muted); margin-top: 0.5rem; }
 
 <div class="finding-card">
   <h3>Model rank is not the whole story</h3>
-  <p>Mistral Medium 3.1 leads the current comparable slice, but the gap is small enough that quest selection and wrapper coverage matter. This is a benchmark to inspect, not a trophy table.</p>
+  <p>Mistral Medium 3.1 leads the current comparable slice, but model gaps are tangled with quest selection and uneven scaffold coverage. This is a benchmark to inspect, not a trophy table.</p>
 </div>
 
 <div class="callout">
-  <p>The practical takeaway: run the ablation before buying a bigger model. In this benchmark, architecture can matter, but the effect is jagged and quest-dependent.</p>
+  <p>The practical takeaway: run the context ablation before buying a bigger model. In this benchmark, scaffolding can matter, but the effect is jagged, quest-dependent, and not automatically beneficial.</p>
 </div>
 
 <h2>The failure taxonomy</h2>
@@ -144,8 +147,8 @@ figcaption { font-size: 0.85rem; color: var(--muted); margin-top: 0.5rem; }
   <tbody>
     <tr><td><strong>Spatial confusion</strong></td><td>Model cannot track coordinates or grid state</td><td>State tracker tool</td></tr>
     <tr><td><strong>Constraint overload</strong></td><td>Model drops constraints when juggling multiple goals</td><td>Calculator + constraint log</td></tr>
-    <tr><td><strong>Decision loops</strong></td><td>Model revisits same locations after 15-20 steps</td><td>Planner with visit log (D)</td></tr>
-    <tr><td><strong>Missing domain knowledge</strong></td><td>Model lacks game-specific scoring rules</td><td>Knowledge hints (C)</td></tr>
+    <tr><td><strong>Decision loops</strong></td><td>Model revisits same locations after 15-20 steps</td><td>Planner loop with visit log</td></tr>
+    <tr><td><strong>Missing domain knowledge</strong></td><td>Model lacks game-specific scoring rules</td><td>Prompt hints and quest-specific notes</td></tr>
   </tbody>
 </table>
 
@@ -154,7 +157,7 @@ figcaption { font-size: 0.85rem; color: var(--muted); margin-top: 0.5rem; }
   We built an interactive Play mode where you can <a href="play.html">play the same quests</a> the AI models played. After each decision, you can expand the Decision History to see what the AI cohort chose at that same point - which models agreed with you, which went a different way.
 </p>
 <p>
-  The comparable results are on the <a href="index.html">leaderboard</a> with per-model, per-quest breakdowns. Everything is open source: <a href="https://github.com/yourconscience/llm_quest_benchmark">code, data, configs</a>.
+  The comparable results are on the <a href="index.html">leaderboard</a> with summary and Per Quest views so quest variance stays visible. Everything is open source: <a href="https://github.com/yourconscience/llm_quest_benchmark">code, data, configs</a>.
 </p>
 
 <figure>
@@ -164,15 +167,15 @@ figcaption { font-size: 0.85rem; color: var(--muted); margin-top: 0.5rem; }
 
 <figure>
   <img src="img/early_benchmark.jpg" alt="Early version of the LLM Quest Benchmark, March 2025" class="img-fluid" style="max-width: 100%;">
-  <figcaption>Where it started: first benchmark run (March 2025). Five models, two quests. The public leaderboard now shows 6 primary models, 15 comparable quest IDs, 5 agent architectures, and 1615 runs.</figcaption>
+  <figcaption>Where it started: first benchmark run (March 2025). Five models, two quests. The public leaderboard now shows 6 primary models, 15 comparable quest IDs, and 1615 curated runs across the current context-engineering taxonomy.</figcaption>
 </figure>
 
 <h2>What's next</h2>
 <ul>
-  <li>Fill out tool-augmented, planning, and knowledge-hint coverage</li>
-  <li>Frontier model comparison: Claude Sonnet, GPT-5.4, Gemini Pro</li>
-  <li>Human baseline data from the Play feature</li>
-  <li>Deeper cost-performance Pareto analysis</li>
+  <li>Complete under-covered taxonomy arms: prompt hints, tools + compact memory, tools + hints + compact memory, and planner loop need broader quest/model coverage before strong claims.</li>
+  <li>Add human baseline data from the Play feature so "hard for LLMs" can be separated from "hard quest".</li>
+  <li>Build better loop/context diagnostics: state revisit tracking, action-cycle detection, and summaries that explain why repetition spiked.</li>
+  <li>Run cost/model follow-ups on newer frontier and small models, then report Pareto trade-offs instead of only success-rate rank.</li>
 </ul>
 
 <footer class="text-center py-4 text-muted" style="font-size: 0.85rem; border-top: 1px solid var(--border); margin-top: 3rem;">

--- a/site/index.html
+++ b/site/index.html
@@ -121,6 +121,7 @@ a { color: var(--accent); }
 <script>
 let DATA = null;
 let MODEL_BY_ID = {};
+let MODE_BY_ID = {};
 let barChart = null;
 let sortCol = 'success_rate';
 let sortAsc = false;
@@ -152,7 +153,7 @@ const COLORS = {
 function successColor(v) { return v >= 0.8 ? 'var(--green)' : v >= 0.4 ? 'var(--orange)' : 'var(--red)'; }
 function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 function modelLabel(id) { return MODEL_BY_ID[id]?.label || id; }
-function modeLabel(id) { return DATA.modes.find(m => m.id === id)?.label || id; }
+function modeLabel(id) { return MODE_BY_ID[id]?.label || id; }
 
 function scopedRows() {
   return DATA.results.filter(r => {
@@ -203,6 +204,7 @@ async function init() {
   const resp = await fetch('leaderboard.json');
   DATA = await resp.json();
   MODEL_BY_ID = Object.fromEntries(DATA.models.map(m => [m.id, m]));
+  MODE_BY_ID = Object.fromEntries(DATA.modes.map(m => [m.id, m]));
   document.getElementById('footer-date').textContent = DATA.generated?.split('T')[0] || '';
   buildFilters();
   updateViewChrome();

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta property="og:title" content="Leaderboard - LLM-Quest Benchmark">
-<meta property="og:description" content="How agent architecture affects LLM decision-making. Models x agent modes x quests.">
+<meta property="og:description" content="Context-engineering taxonomy for sequential LLM quest evaluations across six models and 15 comparable quests.">
 <meta property="og:image" content="https://yourconscience.github.io/llm_quest_benchmark/img/play_quest_in_progress.png">
 <meta property="og:url" content="https://yourconscience.github.io/llm_quest_benchmark/">
 <meta property="og:type" content="website">
@@ -24,11 +24,14 @@ body { background: var(--bg); color: var(--text); font-family: -apple-system, Bl
 .table thead th .sort-arrow { font-size: 0.7rem; margin-left: 0.3em; text-transform: none; }
 .table tbody tr:hover { background: rgba(88,166,255,0.05); }
 .badge-mode { font-size: 0.75rem; padding: 0.25em 0.6em; border-radius: 4px; }
-.mode-stub { background: var(--muted); color: var(--bg); }
-.mode-reasoning { background: var(--accent); color: var(--bg); }
-.mode-light_hints { background: #a371f7; color: var(--bg); }
-.mode-planner { background: var(--orange); color: var(--bg); }
-.mode-tool { background: var(--green); color: var(--bg); }
+.mode-minimal_prompt { background: var(--muted); color: var(--bg); }
+.mode-short_context_reasoning { background: var(--accent); color: var(--bg); }
+.mode-full_history_reasoning { background: #79c0ff; color: var(--bg); }
+.mode-compact_memory_memo { background: #a371f7; color: var(--bg); }
+.mode-prompt_hints { background: #db61a2; color: var(--bg); }
+.mode-tools_compact_memory { background: var(--green); color: var(--bg); }
+.mode-tools_hints_compact_memory { background: #56d4dd; color: var(--bg); }
+.mode-planner_loop { background: var(--orange); color: var(--bg); }
 .success-bar { height: 6px; border-radius: 3px; background: var(--border); overflow: hidden; min-width: 60px; }
 .success-fill { height: 100%; border-radius: 3px; transition: width 0.3s; }
 .filter-btn { background: var(--surface); border: 1px solid var(--border); color: var(--text); padding: 0.3em 0.8em; border-radius: 6px; font-size: 0.85rem; cursor: pointer; transition: all 0.15s; }
@@ -67,8 +70,8 @@ a { color: var(--accent); }
 
 <div class="container py-4">
   <div class="mb-4">
-    <h2>Leaderboard <span class="subtitle">How agent architecture affects LLM decision-making</span></h2>
-    <p class="text-muted mb-0">Models x agent modes x quests. Same task, different cognitive scaffolding, different outcomes.</p>
+    <h2>Leaderboard <span class="subtitle">Context engineering for sequential LLM evaluations</span></h2>
+    <p class="text-muted mb-0">Six primary models x current taxonomy x 15 comparable quests. Same task, different context scaffolds, different outcomes. <a href="about.html">Read the story and caveats</a>.</p>
   </div>
 
   <div class="row g-3 mb-4" id="stats-row"></div>
@@ -110,7 +113,7 @@ a { color: var(--accent); }
   </div>
 
   <footer class="text-center py-4 text-muted" style="font-size:0.85rem">
-    <p>LLM-Quest Benchmark - evaluating agent architectures on interactive fiction quests</p>
+    <p>LLM-Quest Benchmark - evaluating context scaffolds on interactive fiction quests</p>
     <p>Data: <span id="footer-date"></span> | <a href="leaderboard.json">Raw JSON</a> | <a href="https://github.com/yourconscience/llm_quest_benchmark">Source</a></p>
   </footer>
 </div>
@@ -125,14 +128,31 @@ let filterMode = 'all';
 let filterQuest = 'all';
 let viewMode = 'summary';
 
-const MODE_LABELS = {stub:'Baseline (A)', reasoning:'Prompted (B)', light_hints:'Knowledge (C)', planner:'Planner (D)', tool_augmented:'Tool-aug (E)'};
-const MODE_CLASSES = {stub:'mode-stub', reasoning:'mode-reasoning', light_hints:'mode-light_hints', planner:'mode-planner', tool_augmented:'mode-tool'};
-const COLORS = {stub:'#c9d1d9', reasoning:'#58a6ff', light_hints:'#a371f7', planner:'#d29922', tool_augmented:'#3fb950'};
+const MODE_CLASSES = {
+  minimal_prompt:'mode-minimal_prompt',
+  short_context_reasoning:'mode-short_context_reasoning',
+  full_history_reasoning:'mode-full_history_reasoning',
+  compact_memory_memo:'mode-compact_memory_memo',
+  prompt_hints:'mode-prompt_hints',
+  tools_compact_memory:'mode-tools_compact_memory',
+  tools_hints_compact_memory:'mode-tools_hints_compact_memory',
+  planner_loop:'mode-planner_loop',
+};
+const COLORS = {
+  minimal_prompt:'#c9d1d9',
+  short_context_reasoning:'#58a6ff',
+  full_history_reasoning:'#79c0ff',
+  compact_memory_memo:'#a371f7',
+  prompt_hints:'#db61a2',
+  tools_compact_memory:'#3fb950',
+  tools_hints_compact_memory:'#56d4dd',
+  planner_loop:'#d29922',
+};
 
 function successColor(v) { return v >= 0.8 ? 'var(--green)' : v >= 0.4 ? 'var(--orange)' : 'var(--red)'; }
 function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 function modelLabel(id) { return MODEL_BY_ID[id]?.label || id; }
-function modeLabel(id) { return MODE_LABELS[id] || DATA.modes.find(m => m.id === id)?.label || id; }
+function modeLabel(id) { return DATA.modes.find(m => m.id === id)?.label || id; }
 
 function scopedRows() {
   return DATA.results.filter(r => {
@@ -283,7 +303,7 @@ function renderTable() {
       <th data-col="success_rate">Success Rate ${sortArrow('success_rate')}</th>
       <th data-col="avg_steps">Steps ${sortArrow('avg_steps')}</th>
       <th data-col="avg_tokens">Tokens ${sortArrow('avg_tokens')}</th>
-      <th data-col="repetition_rate">Repetition <span class="tooltip-icon" title="Fraction of steps where the agent repeats an action from the last 5 steps. High values indicate the agent is stuck in a loop.">?</span>${sortArrow('repetition_rate')}</th>`;
+      <th data-col="repetition_rate">Repetition <span class="tooltip-icon" title="Diagnostic fraction of steps where the agent repeats an action from the last 5 steps. Higher values can flag loopiness or context loss; it is not treated as a solved predictor or primary success metric.">?</span>${sortArrow('repetition_rate')}</th>`;
   }
 
   const rows = tableRows().slice().sort((a,b) => {
@@ -333,7 +353,7 @@ function renderBarChart() {
   const modes = filterMode === 'all' ? DATA.modes : DATA.modes.filter(mode => mode.id === filterMode);
   const rows = scopedRows();
   const series = modes.map(mode => ({
-    name: MODE_LABELS[mode.id], type: 'bar',
+    name: modeLabel(mode.id), type: 'bar',
     data: models.map(m => {
       const scoped = rows.filter(r => r.model === m.id && r.mode === mode.id);
       return scoped.length ? +(weightedRate(scoped) * 100).toFixed(1) : null;

--- a/site/leaderboard.json
+++ b/site/leaderboard.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-05T13:35:04.535791",
+  "generated": "2026-05-06T15:02:54.585995",
   "benchmark_id": "combined",
   "scope": {
     "model_ids": [
@@ -48,24 +48,36 @@
   ],
   "modes": [
     {
-      "id": "stub",
-      "label": "Baseline (A)"
+      "id": "minimal_prompt",
+      "label": "Minimal prompt"
     },
     {
-      "id": "reasoning",
-      "label": "Prompted (B)"
+      "id": "short_context_reasoning",
+      "label": "Short-context reasoning"
     },
     {
-      "id": "light_hints",
-      "label": "Knowledge (C)"
+      "id": "full_history_reasoning",
+      "label": "Full-history reasoning"
     },
     {
-      "id": "planner",
-      "label": "Planner (D)"
+      "id": "compact_memory_memo",
+      "label": "Compact memory / memo"
     },
     {
-      "id": "tool_augmented",
-      "label": "Tool-aug (E)"
+      "id": "prompt_hints",
+      "label": "Prompt hints"
+    },
+    {
+      "id": "tools_compact_memory",
+      "label": "Tools + compact memory"
+    },
+    {
+      "id": "tools_hints_compact_memory",
+      "label": "Tools + hints + compact memory"
+    },
+    {
+      "id": "planner_loop",
+      "label": "Planner loop"
     }
   ],
   "quests": [
@@ -133,7 +145,7 @@
   "results": [
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Badday_eng",
       "runs": 3,
       "success_rate": 1.0,
@@ -144,7 +156,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Banket_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -155,7 +167,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Boat",
       "runs": 3,
       "success_rate": 0.3333333333333333,
@@ -166,7 +178,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Codebox_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -177,7 +189,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Depth_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -188,7 +200,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Driver_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -199,7 +211,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Edelweiss_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -210,7 +222,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Election_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -221,7 +233,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Foncers_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -232,7 +244,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Leonardo_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -243,7 +255,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ministry_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -254,7 +266,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Pizza_eng",
       "runs": 3,
       "success_rate": 1.0,
@@ -265,7 +277,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Prison_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -276,7 +288,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Robots_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -287,7 +299,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ski_eng",
       "runs": 3,
       "success_rate": 0.3333333333333333,
@@ -298,7 +310,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Badday_eng",
       "runs": 3,
       "success_rate": 1.0,
@@ -309,18 +321,18 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Banket_eng",
-      "runs": 5,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 17.0,
-      "avg_tokens": 18453.8,
-      "avg_cost_usd": 0.024785800000000004,
-      "repetition_rate": 0.43344226579520695
+      "avg_steps": 28.333333333333332,
+      "avg_tokens": 30756.333333333332,
+      "avg_cost_usd": 0.04130966666666667,
+      "repetition_rate": 0.7224037763253449
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Boat",
       "runs": 3,
       "success_rate": 1.0,
@@ -331,95 +343,95 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Codebox_eng",
-      "runs": 5,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 14.6,
-      "avg_tokens": 16737.6,
-      "avg_cost_usd": 0.021798400000000002,
-      "repetition_rate": 0.443841642228739
+      "avg_steps": 24.333333333333332,
+      "avg_tokens": 27896.0,
+      "avg_cost_usd": 0.03633066666666667,
+      "repetition_rate": 0.7397360703812317
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Depth_eng",
-      "runs": 5,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 29.2,
-      "avg_tokens": 22311.0,
-      "avg_cost_usd": 0.0307782,
-      "repetition_rate": 0.5895208177044261
+      "avg_steps": 38.0,
+      "avg_tokens": 37185.0,
+      "avg_cost_usd": 0.051297,
+      "repetition_rate": 0.7221180295073769
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Driver_eng",
-      "runs": 5,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 25.0,
-      "avg_tokens": 15927.2,
-      "avg_cost_usd": 0.022196,
-      "repetition_rate": 0.5935531135531136
+      "avg_steps": 28.666666666666668,
+      "avg_tokens": 26545.333333333332,
+      "avg_cost_usd": 0.036993333333333336,
+      "repetition_rate": 0.7841269841269841
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Edelweiss_eng",
-      "runs": 5,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 42.0,
-      "avg_tokens": 28971.8,
-      "avg_cost_usd": 0.040985400000000005,
-      "repetition_rate": 0.5936895539550929
+      "avg_steps": 59.333333333333336,
+      "avg_tokens": 48286.333333333336,
+      "avg_cost_usd": 0.06830900000000001,
+      "repetition_rate": 0.7603159232584882
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Election_eng",
-      "runs": 8,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 44.125,
-      "avg_tokens": 35464.75,
-      "avg_cost_usd": 0.04630275,
-      "repetition_rate": 0.6294326981955649
+      "avg_steps": 80.66666666666667,
+      "avg_tokens": 94572.66666666667,
+      "avg_cost_usd": 0.12347399999999999,
+      "repetition_rate": 0.7326468493478272
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Foncers_eng",
-      "runs": 5,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 29.4,
-      "avg_tokens": 15202.4,
-      "avg_cost_usd": 0.0213896,
-      "repetition_rate": 0.7210801342869655
+      "avg_steps": 29.333333333333332,
+      "avg_tokens": 25337.333333333332,
+      "avg_cost_usd": 0.03564933333333333,
+      "repetition_rate": 0.7468982630272953
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Leonardo_eng",
-      "runs": 6,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 68.83333333333333,
-      "avg_tokens": 47294.0,
-      "avg_cost_usd": 0.06607,
-      "repetition_rate": 0.8600962354638826
+      "avg_steps": 105.66666666666667,
+      "avg_tokens": 94588.0,
+      "avg_cost_usd": 0.13214,
+      "repetition_rate": 0.7826924709277651
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Ministry_eng",
-      "runs": 5,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 95.6,
-      "avg_tokens": 78391.4,
-      "avg_cost_usd": 0.10904660000000002,
-      "repetition_rate": 0.4894860842415768
+      "avg_steps": 159.33333333333334,
+      "avg_tokens": 130652.33333333333,
+      "avg_cost_usd": 0.18174433333333337,
+      "repetition_rate": 0.815810140402628
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Pizza_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -430,7 +442,7 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Prison_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -441,18 +453,18 @@
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Robots_eng",
-      "runs": 8,
-      "success_rate": 0.125,
-      "avg_steps": 35.75,
-      "avg_tokens": 10359.25,
-      "avg_cost_usd": 0.01460025,
-      "repetition_rate": 0.7375319127047764
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.666666666666664,
+      "avg_tokens": 27624.666666666668,
+      "avg_cost_usd": 0.038934,
+      "repetition_rate": 0.743892828999212
     },
     {
       "model": "claude-haiku-4.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Ski_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -462,8 +474,118 @@
       "repetition_rate": 0.6102198455139631
     },
     {
+      "model": "claude-haiku-4.5",
+      "mode": "compact_memory_memo",
+      "quest": "Banket_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 0.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.0
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "compact_memory_memo",
+      "quest": "Codebox_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 0.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.0
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "compact_memory_memo",
+      "quest": "Depth_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 16.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.390625
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "compact_memory_memo",
+      "quest": "Driver_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 19.5,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.3076923076923077
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "compact_memory_memo",
+      "quest": "Edelweiss_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 16.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.34375
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "compact_memory_memo",
+      "quest": "Election_eng",
+      "runs": 5,
+      "success_rate": 0.0,
+      "avg_steps": 22.2,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.5675042075042075
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "compact_memory_memo",
+      "quest": "Foncers_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 29.5,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.6823529411764706
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "compact_memory_memo",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.9375
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "compact_memory_memo",
+      "quest": "Ministry_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 0.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.0
+    },
+    {
+      "model": "claude-haiku-4.5",
+      "mode": "compact_memory_memo",
+      "quest": "Robots_eng",
+      "runs": 5,
+      "success_rate": 0.2,
+      "avg_steps": 37.0,
+      "avg_tokens": 0.0,
+      "avg_cost_usd": 0.0,
+      "repetition_rate": 0.733715362928115
+    },
+    {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Badday_eng",
       "runs": 3,
       "success_rate": 1.0,
@@ -474,7 +596,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Banket_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -485,7 +607,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Boat",
       "runs": 3,
       "success_rate": 0.3333333333333333,
@@ -496,7 +618,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Codebox_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -507,7 +629,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Depth_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -518,7 +640,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Driver_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -529,7 +651,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Edelweiss_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -540,7 +662,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Election_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -551,7 +673,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Foncers_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -562,7 +684,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Leonardo_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -573,7 +695,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ministry_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -584,7 +706,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Pizza_eng",
       "runs": 3,
       "success_rate": 0.6666666666666666,
@@ -595,7 +717,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Prison_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -606,7 +728,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Robots_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -617,7 +739,7 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ski_eng",
       "runs": 3,
       "success_rate": 0.3333333333333333,
@@ -628,172 +750,469 @@
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Badday_eng",
-      "runs": 12,
-      "success_rate": 0.16666666666666666,
-      "avg_steps": 41.583333333333336,
-      "avg_tokens": 67913.5,
-      "avg_cost_usd": 0.0173951675,
-      "repetition_rate": 0.7181676881433127
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 28.333333333333332,
+      "avg_tokens": 20509.0,
+      "avg_cost_usd": 0.005499506666666667,
+      "repetition_rate": 0.7996814018319395
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Banket_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 41.916666666666664,
-      "avg_tokens": 81835.41666666667,
-      "avg_cost_usd": 0.020912323333333333,
-      "repetition_rate": 0.7092106211057639
+      "avg_steps": 27.0,
+      "avg_tokens": 24931.333333333332,
+      "avg_cost_usd": 0.006631793333333334,
+      "repetition_rate": 0.7037037037037037
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Boat",
-      "runs": 12,
-      "success_rate": 0.5,
-      "avg_steps": 21.25,
-      "avg_tokens": 40104.666666666664,
-      "avg_cost_usd": 0.010256600833333334,
-      "repetition_rate": 0.7216626097112715
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 17.0,
+      "avg_tokens": 13725.666666666666,
+      "avg_cost_usd": 0.0036678633333333335,
+      "repetition_rate": 0.8223684210526315
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Codebox_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 49.916666666666664,
-      "avg_tokens": 111280.0,
-      "avg_cost_usd": 0.028359857500000002,
-      "repetition_rate": 0.7160735664822767
+      "avg_steps": 14.333333333333334,
+      "avg_tokens": 12887.333333333334,
+      "avg_cost_usd": 0.0034295899999999997,
+      "repetition_rate": 0.7055555555555556
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Depth_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 62.0,
-      "avg_tokens": 115230.25,
-      "avg_cost_usd": 0.029462324999999998,
-      "repetition_rate": 0.7136891656453952
+      "avg_steps": 32.0,
+      "avg_tokens": 26184.0,
+      "avg_cost_usd": 0.00698387,
+      "repetition_rate": 0.6869070208728653
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Driver_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 43.5,
-      "avg_tokens": 133852.58333333334,
-      "avg_cost_usd": 0.034024640833333335,
-      "repetition_rate": 0.7154813788861457
+      "avg_steps": 31.666666666666668,
+      "avg_tokens": 24717.333333333332,
+      "avg_cost_usd": 0.006606476666666666,
+      "repetition_rate": 0.7776052449965493
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Edelweiss_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 69.41666666666667,
-      "avg_tokens": 98389.91666666667,
-      "avg_cost_usd": 0.025245936666666666,
-      "repetition_rate": 0.7388870365697752
+      "avg_steps": 46.666666666666664,
+      "avg_tokens": 30822.0,
+      "avg_cost_usd": 0.00829105,
+      "repetition_rate": 0.7465110958590712
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Election_eng",
-      "runs": 12,
+      "runs": 7,
       "success_rate": 0.0,
-      "avg_steps": 103.08333333333333,
-      "avg_tokens": 228443.16666666666,
-      "avg_cost_usd": 0.058307961666666665,
-      "repetition_rate": 0.7762995797489115
+      "avg_steps": 113.28571428571429,
+      "avg_tokens": 140594.85714285713,
+      "avg_cost_usd": 0.036351111428571434,
+      "repetition_rate": 0.7768211498561389
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Foncers_eng",
-      "runs": 12,
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.333333333333336,
+      "avg_tokens": 24733.333333333332,
+      "avg_cost_usd": 0.0065982766666666665,
+      "repetition_rate": 0.6585497835497836
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "short_context_reasoning",
+      "quest": "Leonardo_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 127.66666666666667,
+      "avg_tokens": 138042.66666666666,
+      "avg_cost_usd": 0.035806785,
+      "repetition_rate": 0.7813378695816606
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "short_context_reasoning",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 115.0,
+      "avg_tokens": 78660.0,
+      "avg_cost_usd": 0.021086006666666667,
+      "repetition_rate": 0.8229662613051875
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "short_context_reasoning",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 35.666666666666664,
+      "avg_tokens": 27972.333333333332,
+      "avg_cost_usd": 0.007492933333333333,
+      "repetition_rate": 0.5698523698523698
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "short_context_reasoning",
+      "quest": "Prison_eng",
+      "runs": 9,
+      "success_rate": 0.0,
+      "avg_steps": 51.22222222222222,
+      "avg_tokens": 38811.444444444445,
+      "avg_cost_usd": 0.010380174444444444,
+      "repetition_rate": 0.2838899820718003
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "short_context_reasoning",
+      "quest": "Robots_eng",
+      "runs": 9,
+      "success_rate": 0.0,
+      "avg_steps": 11.222222222222221,
+      "avg_tokens": 7759.111111111111,
+      "avg_cost_usd": 0.0020819,
+      "repetition_rate": 0.266973886328725
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "short_context_reasoning",
+      "quest": "Ski_eng",
+      "runs": 9,
+      "success_rate": 0.1111111111111111,
+      "avg_steps": 26.666666666666668,
+      "avg_tokens": 23982.666666666668,
+      "avg_cost_usd": 0.0063763744444444445,
+      "repetition_rate": 0.24506172839506174
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "full_history_reasoning",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 24.666666666666668,
+      "avg_tokens": 85336.66666666667,
+      "avg_cost_usd": 0.021652596666666666,
+      "repetition_rate": 0.7446236559139785
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "full_history_reasoning",
+      "quest": "Banket_eng",
+      "runs": 3,
       "success_rate": 0.0,
       "avg_steps": 44.0,
-      "avg_tokens": 97667.58333333333,
-      "avg_cost_usd": 0.02490410833333333,
-      "repetition_rate": 0.66654554115581
+      "avg_tokens": 169319.66666666666,
+      "avg_cost_usd": 0.04292038666666667,
+      "repetition_rate": 0.5987434113430318
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "full_history_reasoning",
+      "quest": "Boat",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 34.0,
+      "avg_tokens": 99659.0,
+      "avg_cost_usd": 0.02532058333333333,
+      "repetition_rate": 0.6578304048892284
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "full_history_reasoning",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 66.0,
+      "avg_tokens": 294349.0,
+      "avg_cost_usd": 0.07455571,
+      "repetition_rate": 0.7232156553371464
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "full_history_reasoning",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 58.333333333333336,
+      "avg_tokens": 173961.66666666666,
+      "avg_cost_usd": 0.04415233333333333,
+      "repetition_rate": 0.7298515104966717
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "full_history_reasoning",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 82.0,
+      "avg_tokens": 432912.6666666667,
+      "avg_cost_usd": 0.10955947666666666,
+      "repetition_rate": 0.7142900135857883
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "full_history_reasoning",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 28.666666666666668,
+      "avg_tokens": 78367.66666666667,
+      "avg_cost_usd": 0.019888176666666667,
+      "repetition_rate": 0.703030303030303
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "full_history_reasoning",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 110.0,
+      "avg_tokens": 539418.3333333334,
+      "avg_cost_usd": 0.13653179333333335,
+      "repetition_rate": 0.7752136752136752
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "full_history_reasoning",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 73.33333333333333,
+      "avg_tokens": 277083.3333333333,
+      "avg_cost_usd": 0.07022819666666667,
+      "repetition_rate": 0.7601973684210526
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "full_history_reasoning",
       "quest": "Leonardo_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 93.5,
-      "avg_tokens": 112207.16666666667,
-      "avg_cost_usd": 0.028952143333333333,
-      "repetition_rate": 0.7465875186548164
+      "avg_steps": 28.666666666666668,
+      "avg_tokens": 70465.0,
+      "avg_cost_usd": 0.017915813333333332,
+      "repetition_rate": 0.5830566198382291
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "full_history_reasoning",
       "quest": "Ministry_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 58.416666666666664,
-      "avg_tokens": 61781.166666666664,
-      "avg_cost_usd": 0.016049614166666667,
-      "repetition_rate": 0.7911630128440114
+      "avg_steps": 29.666666666666668,
+      "avg_tokens": 62624.333333333336,
+      "avg_cost_usd": 0.015937236666666667,
+      "repetition_rate": 0.8307447232178414
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "full_history_reasoning",
       "quest": "Pizza_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 55.333333333333336,
-      "avg_tokens": 141246.25,
-      "avg_cost_usd": 0.035964665,
-      "repetition_rate": 0.6294022950496094
+      "avg_steps": 74.66666666666667,
+      "avg_tokens": 377571.3333333333,
+      "avg_cost_usd": 0.09556196666666666,
+      "repetition_rate": 0.6473818990498011
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "compact_memory_memo",
+      "quest": "Badday_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 56.666666666666664,
+      "avg_tokens": 82904.16666666667,
+      "avg_cost_usd": 0.021214283333333334,
+      "repetition_rate": 0.6641828474136662
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Banket_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 48.333333333333336,
+      "avg_tokens": 66545.33333333333,
+      "avg_cost_usd": 0.017048556666666666,
+      "repetition_rate": 0.7671976846881602
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Boat",
+      "runs": 6,
+      "success_rate": 0.16666666666666666,
+      "avg_steps": 17.0,
+      "avg_tokens": 23517.0,
+      "avg_cost_usd": 0.0060189783333333335,
+      "repetition_rate": 0.7032258064516128
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Codebox_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 59.666666666666664,
+      "avg_tokens": 68941.83333333333,
+      "avg_cost_usd": 0.017727065,
+      "repetition_rate": 0.7177615275182023
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Depth_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 78.83333333333333,
+      "avg_tokens": 130387.66666666667,
+      "avg_cost_usd": 0.03335654833333333,
+      "repetition_rate": 0.7189990656060218
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Driver_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 30.166666666666668,
+      "avg_tokens": 38890.166666666664,
+      "avg_cost_usd": 0.009966305,
+      "repetition_rate": 0.6850151284811227
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Edelweiss_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 101.16666666666667,
+      "avg_tokens": 142185.0,
+      "avg_cost_usd": 0.03640226,
+      "repetition_rate": 0.753003373694863
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Election_eng",
+      "runs": 2,
+      "success_rate": 0.0,
+      "avg_steps": 57.0,
+      "avg_tokens": 69449.5,
+      "avg_cost_usd": 0.01782119,
+      "repetition_rate": 0.7761029411764706
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Foncers_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 34.666666666666664,
+      "avg_tokens": 44426.833333333336,
+      "avg_cost_usd": 0.011394979999999999,
+      "repetition_rate": 0.6237175063262019
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 90.0,
+      "avg_tokens": 102278.33333333333,
+      "avg_cost_usd": 0.026279189999999997,
+      "repetition_rate": 0.8406177156177156
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Ministry_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 44.5,
+      "avg_tokens": 52920.166666666664,
+      "avg_cost_usd": 0.013587606666666667,
+      "repetition_rate": 0.7554705334265083
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
+      "quest": "Pizza_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 55.5,
+      "avg_tokens": 79720.66666666667,
+      "avg_cost_usd": 0.02040188,
+      "repetition_rate": 0.6501874556481334
+    },
+    {
+      "model": "deepseek-v3.2",
+      "mode": "compact_memory_memo",
       "quest": "Prison_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 43.25,
-      "avg_tokens": 36118.5,
-      "avg_cost_usd": 0.009577879999999999,
-      "repetition_rate": 0.42410169708016593
+      "avg_steps": 19.333333333333332,
+      "avg_tokens": 28039.666666666668,
+      "avg_cost_usd": 0.007170996666666668,
+      "repetition_rate": 0.8447368421052631
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "compact_memory_memo",
       "quest": "Robots_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 15.666666666666666,
-      "avg_tokens": 14690.833333333334,
-      "avg_cost_usd": 0.003839368333333333,
-      "repetition_rate": 0.4014279044127023
+      "avg_steps": 29.0,
+      "avg_tokens": 35486.0,
+      "avg_cost_usd": 0.009111773333333332,
+      "repetition_rate": 0.8047899586646342
     },
     {
       "model": "deepseek-v3.2",
-      "mode": "reasoning",
+      "mode": "compact_memory_memo",
       "quest": "Ski_eng",
-      "runs": 12,
-      "success_rate": 0.08333333333333333,
-      "avg_steps": 28.5,
-      "avg_tokens": 31074.25,
-      "avg_cost_usd": 0.0081310775,
-      "repetition_rate": 0.33820806100217865
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 34.0,
+      "avg_tokens": 52349.0,
+      "avg_cost_usd": 0.013395186666666668,
+      "repetition_rate": 0.6176470588235294
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Badday_eng",
       "runs": 3,
       "success_rate": 1.0,
@@ -804,7 +1223,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Banket_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -815,7 +1234,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Boat",
       "runs": 3,
       "success_rate": 1.0,
@@ -826,7 +1245,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Codebox_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -837,7 +1256,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Depth_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -848,7 +1267,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Driver_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -859,7 +1278,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Edelweiss_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -870,7 +1289,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Election_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -881,7 +1300,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Foncers_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -892,7 +1311,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Leonardo_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -903,7 +1322,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ministry_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -914,7 +1333,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Pizza_eng",
       "runs": 3,
       "success_rate": 1.0,
@@ -925,7 +1344,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Prison_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -936,7 +1355,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Robots_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -947,7 +1366,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ski_eng",
       "runs": 3,
       "success_rate": 0.3333333333333333,
@@ -958,172 +1377,502 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Badday_eng",
-      "runs": 39,
-      "success_rate": 0.07692307692307693,
-      "avg_steps": 28.205128205128204,
-      "avg_tokens": 55211.94871794872,
-      "avg_cost_usd": 0.033111230769230775,
-      "repetition_rate": 0.7553913395333407
-    },
-    {
-      "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
-      "quest": "Banket_eng",
-      "runs": 39,
-      "success_rate": 0.0,
-      "avg_steps": 29.512820512820515,
-      "avg_tokens": 70410.84615384616,
-      "avg_cost_usd": 0.041725935897435895,
-      "repetition_rate": 0.5781475883169225
-    },
-    {
-      "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
-      "quest": "Boat",
-      "runs": 18,
+      "runs": 3,
       "success_rate": 1.0,
-      "avg_steps": 20.77777777777778,
-      "avg_tokens": 24107.222222222223,
-      "avg_cost_usd": 0.015716666666666667,
-      "repetition_rate": 0.8332586273375747
+      "avg_steps": 27.333333333333332,
+      "avg_tokens": 21024.666666666668,
+      "avg_cost_usd": 0.014954,
+      "repetition_rate": 0.804029304029304
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 34.0,
+      "avg_tokens": 34284.333333333336,
+      "avg_cost_usd": 0.0233355,
+      "repetition_rate": 0.5686274509803922
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "short_context_reasoning",
+      "quest": "Boat",
+      "runs": 9,
+      "success_rate": 1.0,
+      "avg_steps": 19.333333333333332,
+      "avg_tokens": 15885.333333333334,
+      "avg_cost_usd": 0.011451833333333335,
+      "repetition_rate": 0.8402046783625731
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "short_context_reasoning",
       "quest": "Codebox_eng",
-      "runs": 39,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 31.666666666666668,
-      "avg_tokens": 92826.35897435897,
-      "avg_cost_usd": 0.05368702564102564,
-      "repetition_rate": 0.7511289021283805
+      "avg_steps": 16.666666666666668,
+      "avg_tokens": 16148.0,
+      "avg_cost_usd": 0.011051499999999999,
+      "repetition_rate": 0.7564102564102564
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Depth_eng",
-      "runs": 39,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 51.0,
-      "avg_tokens": 158778.4871794872,
-      "avg_cost_usd": 0.09214328205128205,
-      "repetition_rate": 0.6902790296465634
+      "avg_steps": 59.0,
+      "avg_tokens": 52901.333333333336,
+      "avg_cost_usd": 0.037241500000000004,
+      "repetition_rate": 0.6614292833457919
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Driver_eng",
-      "runs": 39,
+      "runs": 5,
       "success_rate": 0.0,
-      "avg_steps": 69.1025641025641,
-      "avg_tokens": 240012.15384615384,
-      "avg_cost_usd": 0.13484396153846154,
-      "repetition_rate": 0.7141281002285249
+      "avg_steps": 98.2,
+      "avg_tokens": 307576.8,
+      "avg_cost_usd": 0.17049589999999998,
+      "repetition_rate": 0.7042835815278073
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Edelweiss_eng",
-      "runs": 42,
+      "runs": 6,
       "success_rate": 0.0,
-      "avg_steps": 49.095238095238095,
-      "avg_tokens": 101584.66666666667,
-      "avg_cost_usd": 0.05980054761904762,
-      "repetition_rate": 0.7043058076266848
+      "avg_steps": 74.33333333333333,
+      "avg_tokens": 55309.666666666664,
+      "avg_cost_usd": 0.039599833333333334,
+      "repetition_rate": 0.7139278297396077
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Election_eng",
-      "runs": 42,
-      "success_rate": 0.21428571428571427,
-      "avg_steps": 78.28571428571429,
-      "avg_tokens": 320781.28571428574,
-      "avg_cost_usd": 0.17896891666666667,
-      "repetition_rate": 0.6851140856932394
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 54.833333333333336,
+      "avg_tokens": 59162.833333333336,
+      "avg_cost_usd": 0.039198500000000004,
+      "repetition_rate": 0.6701658351810792
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Foncers_eng",
-      "runs": 42,
+      "runs": 6,
       "success_rate": 0.0,
-      "avg_steps": 40.23809523809524,
-      "avg_tokens": 86276.69047619047,
-      "avg_cost_usd": 0.051272809523809526,
-      "repetition_rate": 0.6814271772780804
+      "avg_steps": 34.833333333333336,
+      "avg_tokens": 27230.666666666668,
+      "avg_cost_usd": 0.019577833333333333,
+      "repetition_rate": 0.6633573869994648
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Leonardo_eng",
-      "runs": 39,
-      "success_rate": 0.10256410256410256,
-      "avg_steps": 106.35897435897436,
-      "avg_tokens": 367574.6666666667,
-      "avg_cost_usd": 0.20699258974358975,
-      "repetition_rate": 0.7700114327021672
-    },
-    {
-      "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
-      "quest": "Ministry_eng",
-      "runs": 42,
-      "success_rate": 0.023809523809523808,
-      "avg_steps": 108.85714285714286,
-      "avg_tokens": 321203.40476190473,
-      "avg_cost_usd": 0.18034414285714287,
-      "repetition_rate": 0.766825407983534
-    },
-    {
-      "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
-      "quest": "Pizza_eng",
-      "runs": 39,
-      "success_rate": 0.1282051282051282,
-      "avg_steps": 34.8974358974359,
-      "avg_tokens": 83104.82051282052,
-      "avg_cost_usd": 0.04946676923076923,
-      "repetition_rate": 0.4988507037089271
-    },
-    {
-      "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
-      "quest": "Prison_eng",
-      "runs": 12,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 76.91666666666667,
-      "avg_tokens": 126717.5,
-      "avg_cost_usd": 0.077118125,
-      "repetition_rate": 0.7927038415852895
+      "avg_steps": 114.33333333333333,
+      "avg_tokens": 93518.66666666667,
+      "avg_cost_usd": 0.06671766666666666,
+      "repetition_rate": 0.7521407286488588
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
+      "quest": "Ministry_eng",
+      "runs": 7,
+      "success_rate": 0.0,
+      "avg_steps": 141.42857142857142,
+      "avg_tokens": 293751.4285714286,
+      "avg_cost_usd": 0.1698539285714286,
+      "repetition_rate": 0.7700909016955764
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "short_context_reasoning",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 32.333333333333336,
+      "avg_tokens": 27288.0,
+      "avg_cost_usd": 0.019610666666666665,
+      "repetition_rate": 0.46653144016227177
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "short_context_reasoning",
+      "quest": "Prison_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 110.0,
+      "avg_tokens": 89863.0,
+      "avg_cost_usd": 0.063404,
+      "repetition_rate": 0.8177483793155434
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "short_context_reasoning",
       "quest": "Robots_eng",
-      "runs": 42,
-      "success_rate": 0.047619047619047616,
-      "avg_steps": 55.92857142857143,
-      "avg_tokens": 180623.95238095237,
-      "avg_cost_usd": 0.10236560714285714,
-      "repetition_rate": 0.76536406568393
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 36.333333333333336,
+      "avg_tokens": 26912.0,
+      "avg_cost_usd": 0.019448916666666666,
+      "repetition_rate": 0.8177262468807108
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Ski_eng",
-      "runs": 42,
-      "success_rate": 0.11904761904761904,
-      "avg_steps": 57.54761904761905,
-      "avg_tokens": 219840.35714285713,
-      "avg_cost_usd": 0.12407549404761904,
-      "repetition_rate": 0.6906527931062216
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 57.833333333333336,
+      "avg_tokens": 57463.0,
+      "avg_cost_usd": 0.039069,
+      "repetition_rate": 0.6425656031674932
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "full_history_reasoning",
+      "quest": "Badday_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 28.272727272727273,
+      "avg_tokens": 67980.63636363637,
+      "avg_cost_usd": 0.0386035,
+      "repetition_rate": 0.7740760840733032
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Banket_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 30.727272727272727,
+      "avg_tokens": 93027.54545454546,
+      "avg_cost_usd": 0.05209263636363636,
+      "repetition_rate": 0.5702103239187638
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Boat",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 20.0,
+      "avg_tokens": 40112.0,
+      "avg_cost_usd": 0.023485166666666668,
+      "repetition_rate": 0.8333333333333334
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Codebox_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 29.818181818181817,
+      "avg_tokens": 118438.90909090909,
+      "avg_cost_usd": 0.06471309090909091,
+      "repetition_rate": 0.7297837243401759
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Depth_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 41.63636363636363,
+      "avg_tokens": 172943.0,
+      "avg_cost_usd": 0.09428399999999999,
+      "repetition_rate": 0.6873215939451929
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Driver_eng",
+      "runs": 9,
+      "success_rate": 0.0,
+      "avg_steps": 69.55555555555556,
+      "avg_tokens": 352221.44444444444,
+      "avg_cost_usd": 0.18795516666666667,
+      "repetition_rate": 0.7103433778383483
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Edelweiss_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 46.72727272727273,
+      "avg_tokens": 143618.36363636365,
+      "avg_cost_usd": 0.0793769090909091,
+      "repetition_rate": 0.7110425360004741
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Election_eng",
+      "runs": 11,
+      "success_rate": 0.09090909090909091,
+      "avg_steps": 89.0,
+      "avg_tokens": 529437.5454545454,
+      "avg_cost_usd": 0.2808449090909091,
+      "repetition_rate": 0.7037445294327515
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Foncers_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 36.09090909090909,
+      "avg_tokens": 111081.63636363637,
+      "avg_cost_usd": 0.061869,
+      "repetition_rate": 0.6791646529795206
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Leonardo_eng",
+      "runs": 11,
+      "success_rate": 0.09090909090909091,
+      "avg_steps": 101.45454545454545,
+      "avg_tokens": 547796.2727272727,
+      "avg_cost_usd": 0.2916154090909091,
+      "repetition_rate": 0.7815445713864072
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Ministry_eng",
+      "runs": 10,
+      "success_rate": 0.1,
+      "avg_steps": 108.4,
+      "avg_tokens": 497800.2,
+      "avg_cost_usd": 0.26645435,
+      "repetition_rate": 0.8079625308886161
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Pizza_eng",
+      "runs": 11,
+      "success_rate": 0.0,
+      "avg_steps": 30.636363636363637,
+      "avg_tokens": 84923.36363636363,
+      "avg_cost_usd": 0.04803872727272727,
+      "repetition_rate": 0.47085354951816055
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Prison_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 45.333333333333336,
+      "avg_tokens": 151967.66666666666,
+      "avg_cost_usd": 0.083868,
+      "repetition_rate": 0.8180602006688963
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Robots_eng",
+      "runs": 11,
+      "success_rate": 0.09090909090909091,
+      "avg_steps": 68.63636363636364,
+      "avg_tokens": 328600.63636363635,
+      "avg_cost_usd": 0.17652781818181817,
+      "repetition_rate": 0.7576059861064846
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "full_history_reasoning",
+      "quest": "Ski_eng",
+      "runs": 11,
+      "success_rate": 0.36363636363636365,
+      "avg_steps": 69.9090909090909,
+      "avg_tokens": 415166.9090909091,
+      "avg_cost_usd": 0.2231677272727273,
+      "repetition_rate": 0.7274216049451824
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Badday_eng",
+      "runs": 25,
+      "success_rate": 0.0,
+      "avg_steps": 28.28,
+      "avg_tokens": 53696.2,
+      "avg_cost_usd": 0.0328735,
+      "repetition_rate": 0.7413334961962416
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Banket_eng",
+      "runs": 25,
+      "success_rate": 0.0,
+      "avg_steps": 28.44,
+      "avg_tokens": 64794.68,
+      "avg_cost_usd": 0.03937144,
+      "repetition_rate": 0.582782401132496
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Boat",
+      "runs": 6,
+      "success_rate": 1.0,
+      "avg_steps": 23.333333333333332,
+      "avg_tokens": 28437.666666666668,
+      "avg_cost_usd": 0.01822966666666667,
+      "repetition_rate": 0.8228021978021979
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Codebox_eng",
+      "runs": 25,
+      "success_rate": 0.0,
+      "avg_steps": 34.28,
+      "avg_tokens": 90758.24,
+      "avg_cost_usd": 0.053951820000000004,
+      "repetition_rate": 0.7598870178413654
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Depth_eng",
+      "runs": 25,
+      "success_rate": 0.0,
+      "avg_steps": 54.16,
+      "avg_tokens": 165251.36,
+      "avg_cost_usd": 0.09778957999999999,
+      "repetition_rate": 0.695042270911259
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Driver_eng",
+      "runs": 25,
+      "success_rate": 0.0,
+      "avg_steps": 63.12,
+      "avg_tokens": 186103.88,
+      "avg_cost_usd": 0.10859354,
+      "repetition_rate": 0.717459504029132
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Edelweiss_eng",
+      "runs": 25,
+      "success_rate": 0.0,
+      "avg_steps": 44.08,
+      "avg_tokens": 94195.84,
+      "avg_cost_usd": 0.05603512,
+      "repetition_rate": 0.6990323618351161
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Election_eng",
+      "runs": 25,
+      "success_rate": 0.32,
+      "avg_steps": 79.2,
+      "avg_tokens": 291760.96,
+      "avg_cost_usd": 0.16768838,
+      "repetition_rate": 0.6805042705707727
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Foncers_eng",
+      "runs": 25,
+      "success_rate": 0.0,
+      "avg_steps": 43.36,
+      "avg_tokens": 89533.56,
+      "avg_cost_usd": 0.05421728,
+      "repetition_rate": 0.6867594376363146
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Leonardo_eng",
+      "runs": 25,
+      "success_rate": 0.12,
+      "avg_steps": 107.56,
+      "avg_tokens": 321163.88,
+      "avg_cost_usd": 0.18659154,
+      "repetition_rate": 0.7670813361674987
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Ministry_eng",
+      "runs": 25,
+      "success_rate": 0.0,
+      "avg_steps": 99.92,
+      "avg_tokens": 258251.24,
+      "avg_cost_usd": 0.14883732,
+      "repetition_rate": 0.7494562205821294
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Pizza_eng",
+      "runs": 25,
+      "success_rate": 0.12,
+      "avg_steps": 37.08,
+      "avg_tokens": 89002.68,
+      "avg_cost_usd": 0.053677840000000004,
+      "repetition_rate": 0.515047763178463
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Prison_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 76.16666666666667,
+      "avg_tokens": 132519.66666666666,
+      "avg_cost_usd": 0.08060025,
+      "repetition_rate": 0.7675033931783591
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Robots_eng",
+      "runs": 25,
+      "success_rate": 0.04,
+      "avg_steps": 55.04,
+      "avg_tokens": 152405.08,
+      "avg_cost_usd": 0.08963424,
+      "repetition_rate": 0.7562106972107787
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "compact_memory_memo",
+      "quest": "Ski_eng",
+      "runs": 25,
+      "success_rate": 0.04,
+      "avg_steps": 52.04,
+      "avg_tokens": 172867.24,
+      "avg_cost_usd": 0.10087647000000001,
+      "repetition_rate": 0.6860154414823738
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "prompt_hints",
       "quest": "Badday_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1134,7 +1883,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Banket_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1145,7 +1894,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Codebox_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1156,7 +1905,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Depth_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1167,7 +1916,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Driver_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1178,7 +1927,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Edelweiss_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1189,7 +1938,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Election_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1200,7 +1949,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Foncers_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1211,7 +1960,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Leonardo_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1222,7 +1971,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Ministry_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1233,7 +1982,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Pizza_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1244,7 +1993,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Robots_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1255,7 +2004,7 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Ski_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -1266,150 +2015,293 @@
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
+      "mode": "tools_compact_memory",
       "quest": "Badday_eng",
-      "runs": 6,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 31.833333333333332,
-      "avg_tokens": 87586.5,
-      "avg_cost_usd": 0.04919158333333334,
-      "repetition_rate": 0.7667500988262482
+      "avg_steps": 30.0,
+      "avg_tokens": 77412.0,
+      "avg_cost_usd": 0.04367933333333333,
+      "repetition_rate": 0.7776580459770116
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
+      "mode": "tools_compact_memory",
       "quest": "Banket_eng",
-      "runs": 6,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 28.833333333333332,
-      "avg_tokens": 97407.16666666667,
-      "avg_cost_usd": 0.05482066666666666,
+      "avg_steps": 29.0,
+      "avg_tokens": 98057.33333333333,
+      "avg_cost_usd": 0.05523533333333333,
       "repetition_rate": 0.5664488017429194
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
+      "mode": "tools_compact_memory",
       "quest": "Codebox_eng",
-      "runs": 6,
+      "runs": 3,
       "success_rate": 0.0,
       "avg_steps": 32.0,
-      "avg_tokens": 161539.66666666666,
-      "avg_cost_usd": 0.09262025,
+      "avg_tokens": 170521.33333333334,
+      "avg_cost_usd": 0.09831816666666666,
       "repetition_rate": 0.78125
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
+      "mode": "tools_compact_memory",
       "quest": "Depth_eng",
-      "runs": 6,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 39.833333333333336,
-      "avg_tokens": 198842.0,
-      "avg_cost_usd": 0.11341141666666667,
-      "repetition_rate": 0.7049825897172924
+      "avg_steps": 45.666666666666664,
+      "avg_tokens": 239329.33333333334,
+      "avg_cost_usd": 0.13514383333333332,
+      "repetition_rate": 0.7389125478556373
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
+      "mode": "tools_compact_memory",
       "quest": "Driver_eng",
-      "runs": 6,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 83.16666666666667,
-      "avg_tokens": 341664.0,
-      "avg_cost_usd": 0.18659699999999999,
-      "repetition_rate": 0.701619529232611
+      "avg_steps": 115.33333333333333,
+      "avg_tokens": 486301.0,
+      "avg_cost_usd": 0.26506633333333335,
+      "repetition_rate": 0.6929773760122155
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
+      "mode": "tools_compact_memory",
       "quest": "Edelweiss_eng",
-      "runs": 6,
-      "success_rate": 0.0,
-      "avg_steps": 37.166666666666664,
-      "avg_tokens": 113210.16666666667,
-      "avg_cost_usd": 0.06317716666666666,
-      "repetition_rate": 0.6999353109302705
-    },
-    {
-      "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
-      "quest": "Election_eng",
-      "runs": 6,
-      "success_rate": 0.8333333333333334,
-      "avg_steps": 89.16666666666667,
-      "avg_tokens": 510114.5,
-      "avg_cost_usd": 0.2845789166666666,
-      "repetition_rate": 0.7042255882371232
-    },
-    {
-      "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
-      "quest": "Foncers_eng",
-      "runs": 6,
-      "success_rate": 0.0,
-      "avg_steps": 35.166666666666664,
-      "avg_tokens": 107388.33333333333,
-      "avg_cost_usd": 0.06047166666666667,
-      "repetition_rate": 0.7033271263050676
-    },
-    {
-      "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
-      "quest": "Leonardo_eng",
-      "runs": 6,
-      "success_rate": 0.16666666666666666,
-      "avg_steps": 85.16666666666667,
-      "avg_tokens": 347644.3333333333,
-      "avg_cost_usd": 0.19101924999999997,
-      "repetition_rate": 0.7439885527289741
-    },
-    {
-      "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
-      "quest": "Ministry_eng",
-      "runs": 6,
-      "success_rate": 0.0,
-      "avg_steps": 83.0,
-      "avg_tokens": 295291.3333333333,
-      "avg_cost_usd": 0.16168941666666667,
-      "repetition_rate": 0.7537505872064695
-    },
-    {
-      "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
-      "quest": "Pizza_eng",
-      "runs": 6,
+      "runs": 3,
       "success_rate": 0.0,
       "avg_steps": 39.333333333333336,
-      "avg_tokens": 133531.16666666666,
-      "avg_cost_usd": 0.074886,
-      "repetition_rate": 0.49834656084656087
+      "avg_tokens": 118153.0,
+      "avg_cost_usd": 0.06555316666666666,
+      "repetition_rate": 0.7033836937559658
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
+      "mode": "tools_compact_memory",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.6666666666666666,
+      "avg_steps": 84.33333333333333,
+      "avg_tokens": 454504.0,
+      "avg_cost_usd": 0.25375366666666666,
+      "repetition_rate": 0.7098376554923044
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_compact_memory",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 36.666666666666664,
+      "avg_tokens": 114543.66666666667,
+      "avg_cost_usd": 0.06434266666666667,
+      "repetition_rate": 0.694574420677362
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_compact_memory",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 82.66666666666667,
+      "avg_tokens": 326756.3333333333,
+      "avg_cost_usd": 0.17958316666666665,
+      "repetition_rate": 0.7586366538952746
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_compact_memory",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 102.66666666666667,
+      "avg_tokens": 371302.0,
+      "avg_cost_usd": 0.20254516666666667,
+      "repetition_rate": 0.7304712598830246
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_compact_memory",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 40.666666666666664,
+      "avg_tokens": 138193.33333333334,
+      "avg_cost_usd": 0.0774475,
+      "repetition_rate": 0.4828042328042328
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_compact_memory",
       "quest": "Robots_eng",
-      "runs": 6,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 61.333333333333336,
-      "avg_tokens": 230640.0,
-      "avg_cost_usd": 0.12707458333333335,
-      "repetition_rate": 0.7597367173069857
+      "avg_steps": 49.0,
+      "avg_tokens": 172333.33333333334,
+      "avg_cost_usd": 0.09538333333333333,
+      "repetition_rate": 0.7685038329368226
     },
     {
       "model": "gemini-3-flash-preview",
-      "mode": "tool_augmented",
+      "mode": "tools_compact_memory",
       "quest": "Ski_eng",
-      "runs": 6,
+      "runs": 3,
       "success_rate": 0.0,
-      "avg_steps": 114.16666666666667,
-      "avg_tokens": 608391.1666666666,
-      "avg_cost_usd": 0.3344751666666667,
-      "repetition_rate": 0.6768024409617867
+      "avg_steps": 108.66666666666667,
+      "avg_tokens": 569379.3333333334,
+      "avg_cost_usd": 0.313923,
+      "repetition_rate": 0.6613089815337007
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.666666666666664,
+      "avg_tokens": 97761.0,
+      "avg_cost_usd": 0.054703833333333333,
+      "repetition_rate": 0.755842151675485
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 28.666666666666668,
+      "avg_tokens": 96757.0,
+      "avg_cost_usd": 0.054406,
+      "repetition_rate": 0.5664488017429194
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 32.0,
+      "avg_tokens": 152558.0,
+      "avg_cost_usd": 0.08692233333333332,
+      "repetition_rate": 0.78125
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 34.0,
+      "avg_tokens": 158354.66666666666,
+      "avg_cost_usd": 0.09167900000000001,
+      "repetition_rate": 0.6710526315789473
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 51.0,
+      "avg_tokens": 197027.0,
+      "avg_cost_usd": 0.10812766666666666,
+      "repetition_rate": 0.7102616824530061
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 35.0,
+      "avg_tokens": 108267.33333333333,
+      "avg_cost_usd": 0.06080116666666666,
+      "repetition_rate": 0.6964869281045751
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 1.0,
+      "avg_steps": 94.0,
+      "avg_tokens": 565725.0,
+      "avg_cost_usd": 0.31540416666666665,
+      "repetition_rate": 0.6986135209819421
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 33.666666666666664,
+      "avg_tokens": 100233.0,
+      "avg_cost_usd": 0.05660066666666667,
+      "repetition_rate": 0.7120798319327731
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 87.66666666666667,
+      "avg_tokens": 368532.3333333333,
+      "avg_cost_usd": 0.20245533333333332,
+      "repetition_rate": 0.7293404515626737
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 63.333333333333336,
+      "avg_tokens": 219280.66666666666,
+      "avg_cost_usd": 0.12083366666666667,
+      "repetition_rate": 0.7770299145299145
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 38.0,
+      "avg_tokens": 128869.0,
+      "avg_cost_usd": 0.0723245,
+      "repetition_rate": 0.5138888888888888
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 73.66666666666667,
+      "avg_tokens": 288946.6666666667,
+      "avg_cost_usd": 0.15876583333333336,
+      "repetition_rate": 0.7509696016771489
+    },
+    {
+      "model": "gemini-3-flash-preview",
+      "mode": "tools_hints_compact_memory",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 119.66666666666667,
+      "avg_tokens": 647403.0,
+      "avg_cost_usd": 0.35502733333333336,
+      "repetition_rate": 0.6922959003898729
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Badday_eng",
       "runs": 4,
       "success_rate": 0.75,
@@ -1420,7 +2312,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Banket_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1431,7 +2323,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Boat",
       "runs": 5,
       "success_rate": 0.4,
@@ -1442,7 +2334,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Codebox_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1453,7 +2345,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Depth_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1464,7 +2356,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Driver_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1475,7 +2367,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Edelweiss_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1486,7 +2378,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Election_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1497,7 +2389,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Foncers_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1508,7 +2400,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Leonardo_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1519,7 +2411,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ministry_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1530,7 +2422,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Pizza_eng",
       "runs": 4,
       "success_rate": 1.0,
@@ -1541,7 +2433,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Prison_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1552,7 +2444,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Robots_eng",
       "runs": 4,
       "success_rate": 0.0,
@@ -1563,7 +2455,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ski_eng",
       "runs": 4,
       "success_rate": 0.5,
@@ -1574,172 +2466,502 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Badday_eng",
-      "runs": 13,
-      "success_rate": 0.23076923076923078,
-      "avg_steps": 34.61538461538461,
-      "avg_tokens": 51076.230769230766,
-      "avg_cost_usd": 0.041502307692307686,
-      "repetition_rate": 0.7446096908607834
+      "runs": 4,
+      "success_rate": 0.75,
+      "avg_steps": 31.5,
+      "avg_tokens": 23026.75,
+      "avg_cost_usd": 0.00888175,
+      "repetition_rate": 0.8158127182119304
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Banket_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 39.38461538461539,
-      "avg_tokens": 60859.153846153844,
-      "avg_cost_usd": 0.04946103846153846,
-      "repetition_rate": 0.7293903114892335
+      "avg_steps": 29.75,
+      "avg_tokens": 27478.75,
+      "avg_cost_usd": 0.009934812500000001,
+      "repetition_rate": 0.7304032258064517
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Boat",
-      "runs": 13,
-      "success_rate": 0.15384615384615385,
-      "avg_steps": 24.692307692307693,
-      "avg_tokens": 35644.92307692308,
-      "avg_cost_usd": 0.030084865384615387,
-      "repetition_rate": 0.7641458873195115
+      "runs": 4,
+      "success_rate": 0.25,
+      "avg_steps": 15.75,
+      "avg_tokens": 12440.25,
+      "avg_cost_usd": 0.0048858750000000005,
+      "repetition_rate": 0.7951704545454545
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Codebox_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 30.076923076923077,
-      "avg_tokens": 57417.61538461538,
-      "avg_cost_usd": 0.046677538461538465,
-      "repetition_rate": 0.7169896005359901
+      "avg_steps": 18.5,
+      "avg_tokens": 17493.75,
+      "avg_cost_usd": 0.00641875,
+      "repetition_rate": 0.7656479909451047
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Depth_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 60.23076923076923,
-      "avg_tokens": 122732.0,
-      "avg_cost_usd": 0.09855338461538461,
-      "repetition_rate": 0.7213147226805607
+      "avg_steps": 44.5,
+      "avg_tokens": 35872.0,
+      "avg_cost_usd": 0.0134991875,
+      "repetition_rate": 0.6382293286047416
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Driver_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 39.69230769230769,
-      "avg_tokens": 65320.692307692305,
-      "avg_cost_usd": 0.05574275,
-      "repetition_rate": 0.7409129670258431
+      "avg_steps": 13.25,
+      "avg_tokens": 10091.75,
+      "avg_cost_usd": 0.0038354375,
+      "repetition_rate": 0.7737179487179487
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Edelweiss_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 64.61538461538461,
-      "avg_tokens": 160552.76923076922,
-      "avg_cost_usd": 0.12810834615384617,
-      "repetition_rate": 0.7390488097280474
+      "avg_steps": 46.75,
+      "avg_tokens": 30945.75,
+      "avg_cost_usd": 0.0127353125,
+      "repetition_rate": 0.7688636363636363
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Election_eng",
-      "runs": 13,
+      "runs": 5,
       "success_rate": 0.0,
-      "avg_steps": 81.07692307692308,
-      "avg_tokens": 106387.53846153847,
-      "avg_cost_usd": 0.08193601923076922,
-      "repetition_rate": 0.7222035405942804
+      "avg_steps": 113.2,
+      "avg_tokens": 139278.8,
+      "avg_cost_usd": 0.08872355,
+      "repetition_rate": 0.7142379767001892
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Foncers_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 59.61538461538461,
-      "avg_tokens": 156237.23076923078,
-      "avg_cost_usd": 0.12556807692307692,
-      "repetition_rate": 0.7013911250655981
+      "avg_steps": 32.25,
+      "avg_tokens": 24082.75,
+      "avg_cost_usd": 0.0093281875,
+      "repetition_rate": 0.6614289664161788
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Leonardo_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 101.84615384615384,
-      "avg_tokens": 213654.23076923078,
-      "avg_cost_usd": 0.16547863461538462,
-      "repetition_rate": 0.7744833198560894
+      "avg_steps": 111.25,
+      "avg_tokens": 83792.25,
+      "avg_cost_usd": 0.0318685,
+      "repetition_rate": 0.7617553965541253
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Ministry_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 42.69230769230769,
-      "avg_tokens": 48233.307692307695,
-      "avg_cost_usd": 0.03815613461538461,
-      "repetition_rate": 0.785077940702907
+      "avg_steps": 52.5,
+      "avg_tokens": 36137.25,
+      "avg_cost_usd": 0.0141241875,
+      "repetition_rate": 0.8453830951235424
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Pizza_eng",
-      "runs": 13,
-      "success_rate": 0.15384615384615385,
-      "avg_steps": 67.07692307692308,
-      "avg_tokens": 112627.23076923077,
-      "avg_cost_usd": 0.09488988461538463,
-      "repetition_rate": 0.7224868725684819
+      "runs": 4,
+      "success_rate": 0.5,
+      "avg_steps": 31.25,
+      "avg_tokens": 24323.75,
+      "avg_cost_usd": 0.0094085625,
+      "repetition_rate": 0.6497960697070819
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Prison_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 50.92307692307692,
-      "avg_tokens": 91187.69230769231,
-      "avg_cost_usd": 0.06175297692307692,
-      "repetition_rate": 0.7738710851606547
+      "avg_steps": 95.25,
+      "avg_tokens": 71758.25,
+      "avg_cost_usd": 0.0272530625,
+      "repetition_rate": 0.8078060826550787
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Robots_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 30.923076923076923,
-      "avg_tokens": 31556.076923076922,
-      "avg_cost_usd": 0.014326210769230768,
-      "repetition_rate": 0.8256115124773957
+      "avg_steps": 47.5,
+      "avg_tokens": 31987.5,
+      "avg_cost_usd": 0.0126663125,
+      "repetition_rate": 0.8103499356803605
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Ski_eng",
-      "runs": 13,
+      "runs": 4,
       "success_rate": 0.0,
-      "avg_steps": 38.61538461538461,
-      "avg_tokens": 51772.307692307695,
-      "avg_cost_usd": 0.022698643076923077,
-      "repetition_rate": 0.6802200919948812
+      "avg_steps": 55.0,
+      "avg_tokens": 48720.0,
+      "avg_cost_usd": 0.017737125,
+      "repetition_rate": 0.6127002368791176
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "full_history_reasoning",
+      "quest": "Badday_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 27.0,
+      "avg_tokens": 69181.66666666667,
+      "avg_cost_usd": 0.05802625,
+      "repetition_rate": 0.6883702756464904
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Banket_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 23.0,
+      "avg_tokens": 73615.66666666667,
+      "avg_cost_usd": 0.060497999999999996,
+      "repetition_rate": 0.752447215445318
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Boat",
+      "runs": 3,
+      "success_rate": 0.3333333333333333,
+      "avg_steps": 21.0,
+      "avg_tokens": 39261.333333333336,
+      "avg_cost_usd": 0.03396225,
+      "repetition_rate": 0.8095238095238094
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Codebox_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 41.0,
+      "avg_tokens": 149292.66666666666,
+      "avg_cost_usd": 0.1209845,
+      "repetition_rate": 0.6216516236124079
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Depth_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 62.333333333333336,
+      "avg_tokens": 278054.3333333333,
+      "avg_cost_usd": 0.22320450000000003,
+      "repetition_rate": 0.8135002210433244
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Driver_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 41.666666666666664,
+      "avg_tokens": 105289.0,
+      "avg_cost_usd": 0.08874675,
+      "repetition_rate": 0.7648062809353132
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Edelweiss_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 85.0,
+      "avg_tokens": 457597.6666666667,
+      "avg_cost_usd": 0.36152325,
+      "repetition_rate": 0.6705567367509252
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Election_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 22.666666666666668,
+      "avg_tokens": 49081.666666666664,
+      "avg_cost_usd": 0.042008750000000004,
+      "repetition_rate": 0.6381184407796102
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Foncers_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 103.0,
+      "avg_tokens": 503806.3333333333,
+      "avg_cost_usd": 0.40037225,
+      "repetition_rate": 0.7450399951151004
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Leonardo_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 138.66666666666666,
+      "avg_tokens": 608095.6666666666,
+      "avg_cost_usd": 0.48652175000000003,
+      "repetition_rate": 0.7267939814814816
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Ministry_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 23.0,
+      "avg_tokens": 49039.333333333336,
+      "avg_cost_usd": 0.0420395,
+      "repetition_rate": 0.6846928916494134
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Pizza_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 53.666666666666664,
+      "avg_tokens": 169129.66666666666,
+      "avg_cost_usd": 0.1386885,
+      "repetition_rate": 0.8236456220419202
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Prison_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 55.666666666666664,
+      "avg_tokens": 251956.0,
+      "avg_cost_usd": 0.20157075,
+      "repetition_rate": 0.6447876447876447
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Robots_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 18.666666666666668,
+      "avg_tokens": 35299.0,
+      "avg_cost_usd": 0.008995056666666666,
+      "repetition_rate": 0.8541666666666666
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "full_history_reasoning",
+      "quest": "Ski_eng",
+      "runs": 3,
+      "success_rate": 0.0,
+      "avg_steps": 29.0,
+      "avg_tokens": 66035.66666666667,
+      "avg_cost_usd": 0.016799876666666668,
+      "repetition_rate": 0.8265784394816653
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Badday_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 40.5,
+      "avg_tokens": 60723.166666666664,
+      "avg_cost_usd": 0.054987375,
+      "repetition_rate": 0.7252607135671653
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Banket_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 54.0,
+      "avg_tokens": 76734.5,
+      "avg_cost_usd": 0.070293375,
+      "repetition_rate": 0.7171865832997125
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Boat",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 32.5,
+      "avg_tokens": 49306.5,
+      "avg_cost_usd": 0.0449455,
+      "repetition_rate": 0.7207738814000674
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Codebox_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 32.333333333333336,
+      "avg_tokens": 38096.0,
+      "avg_cost_usd": 0.03636325,
+      "repetition_rate": 0.7322196620583717
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Depth_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 69.66666666666667,
+      "avg_tokens": 102977.5,
+      "avg_cost_usd": 0.092930625,
+      "repetition_rate": 0.7306122362163915
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Driver_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 56.333333333333336,
+      "avg_tokens": 82155.83333333333,
+      "avg_cost_usd": 0.073845625,
+      "repetition_rate": 0.7070963222763712
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Edelweiss_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 66.33333333333333,
+      "avg_tokens": 98435.0,
+      "avg_cost_usd": 0.08831625,
+      "repetition_rate": 0.7534182951262158
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Election_eng",
+      "runs": 5,
+      "success_rate": 0.0,
+      "avg_steps": 84.0,
+      "avg_tokens": 107879.8,
+      "avg_cost_usd": 0.09910485,
+      "repetition_rate": 0.7806201643771737
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Foncers_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 56.166666666666664,
+      "avg_tokens": 70555.66666666667,
+      "avg_cost_usd": 0.06565925,
+      "repetition_rate": 0.7062081291404599
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Leonardo_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 77.16666666666667,
+      "avg_tokens": 103008.16666666667,
+      "avg_cost_usd": 0.0940305,
+      "repetition_rate": 0.8068132712447028
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Ministry_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 46.0,
+      "avg_tokens": 55894.333333333336,
+      "avg_cost_usd": 0.05223575,
+      "repetition_rate": 0.7950670289492304
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Pizza_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 97.66666666666667,
+      "avg_tokens": 143245.0,
+      "avg_cost_usd": 0.129978125,
+      "repetition_rate": 0.7203680330726959
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Prison_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 19.0,
+      "avg_tokens": 23756.5,
+      "avg_cost_usd": 0.014844033333333333,
+      "repetition_rate": 0.8157894736842105
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Robots_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 26.0,
+      "avg_tokens": 29397.0,
+      "avg_cost_usd": 0.018098386666666667,
+      "repetition_rate": 0.821508319914117
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "compact_memory_memo",
+      "quest": "Ski_eng",
+      "runs": 6,
+      "success_rate": 0.0,
+      "avg_steps": 32.5,
+      "avg_tokens": 46675.5,
+      "avg_cost_usd": 0.028955704999999998,
+      "repetition_rate": 0.6520541549953315
+    },
+    {
+      "model": "gpt-5.4-mini",
+      "mode": "prompt_hints",
       "quest": "Badday_eng",
       "runs": 1,
       "success_rate": 1.0,
@@ -1750,7 +2972,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Banket_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1761,7 +2983,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Boat",
       "runs": 1,
       "success_rate": 1.0,
@@ -1772,7 +2994,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Codebox_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1783,7 +3005,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Depth_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1794,7 +3016,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Driver_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1805,7 +3027,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Edelweiss_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1816,7 +3038,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Election_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1827,7 +3049,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Foncers_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1838,7 +3060,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Leonardo_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1849,7 +3071,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Ministry_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1860,7 +3082,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Pizza_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1871,7 +3093,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Prison_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1882,7 +3104,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Robots_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1893,7 +3115,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "light_hints",
+      "mode": "prompt_hints",
       "quest": "Ski_eng",
       "runs": 1,
       "success_rate": 1.0,
@@ -1904,7 +3126,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Badday_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1915,7 +3137,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Banket_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1926,7 +3148,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Boat",
       "runs": 1,
       "success_rate": 1.0,
@@ -1937,7 +3159,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Codebox_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1948,7 +3170,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Depth_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1959,7 +3181,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Driver_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1970,7 +3192,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Edelweiss_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1981,7 +3203,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Election_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -1992,7 +3214,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Foncers_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -2003,7 +3225,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Leonardo_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -2014,7 +3236,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Ministry_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -2025,7 +3247,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Pizza_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -2036,7 +3258,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Prison_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -2047,7 +3269,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Robots_eng",
       "runs": 1,
       "success_rate": 0.0,
@@ -2058,7 +3280,7 @@
     },
     {
       "model": "gpt-5.4-mini",
-      "mode": "planner",
+      "mode": "planner_loop",
       "quest": "Ski_eng",
       "runs": 1,
       "success_rate": 1.0,
@@ -2069,7 +3291,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Badday_eng",
       "runs": 3,
       "success_rate": 0.3333333333333333,
@@ -2080,7 +3302,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Banket_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2091,7 +3313,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Boat",
       "runs": 3,
       "success_rate": 0.3333333333333333,
@@ -2102,7 +3324,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Codebox_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2113,7 +3335,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Depth_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2124,7 +3346,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Driver_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2135,7 +3357,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Edelweiss_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2146,7 +3368,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Election_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2157,7 +3379,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Foncers_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2168,7 +3390,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Leonardo_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2179,7 +3401,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ministry_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2190,7 +3412,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Pizza_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2201,7 +3423,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Prison_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2212,7 +3434,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Robots_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2223,7 +3445,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ski_eng",
       "runs": 3,
       "success_rate": 0.6666666666666666,
@@ -2234,7 +3456,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Badday_eng",
       "runs": 3,
       "success_rate": 0.3333333333333333,
@@ -2245,7 +3467,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Banket_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2256,7 +3478,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Boat",
       "runs": 3,
       "success_rate": 0.6666666666666666,
@@ -2267,7 +3489,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Codebox_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2278,7 +3500,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Depth_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2289,7 +3511,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Driver_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2300,7 +3522,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Edelweiss_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2311,7 +3533,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Election_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2322,7 +3544,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Foncers_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2333,7 +3555,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Leonardo_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2344,7 +3566,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Ministry_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2355,7 +3577,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Pizza_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2366,7 +3588,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Prison_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2377,7 +3599,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Robots_eng",
       "runs": 3,
       "success_rate": 0.0,
@@ -2388,7 +3610,7 @@
     },
     {
       "model": "minimax-m2.5",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Ski_eng",
       "runs": 3,
       "success_rate": 0.3333333333333333,
@@ -2399,7 +3621,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Badday_eng",
       "runs": 6,
       "success_rate": 1.0,
@@ -2410,7 +3632,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Banket_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2421,7 +3643,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Boat",
       "runs": 6,
       "success_rate": 0.8333333333333334,
@@ -2432,7 +3654,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Codebox_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2443,7 +3665,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Depth_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2454,7 +3676,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Driver_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2465,7 +3687,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Edelweiss_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2476,7 +3698,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Election_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2487,7 +3709,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Foncers_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2498,7 +3720,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Leonardo_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2509,7 +3731,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ministry_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2520,7 +3742,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Pizza_eng",
       "runs": 6,
       "success_rate": 1.0,
@@ -2531,7 +3753,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Prison_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2542,7 +3764,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Robots_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2553,7 +3775,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "stub",
+      "mode": "minimal_prompt",
       "quest": "Ski_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2564,7 +3786,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Badday_eng",
       "runs": 6,
       "success_rate": 0.8333333333333334,
@@ -2575,7 +3797,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Banket_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2586,7 +3808,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Boat",
       "runs": 6,
       "success_rate": 1.0,
@@ -2597,7 +3819,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Codebox_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2608,7 +3830,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Depth_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2619,7 +3841,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Driver_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2630,7 +3852,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Edelweiss_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2641,7 +3863,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Election_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2652,7 +3874,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Foncers_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2663,7 +3885,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Leonardo_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2674,7 +3896,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Ministry_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2685,7 +3907,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Pizza_eng",
       "runs": 6,
       "success_rate": 0.6666666666666666,
@@ -2696,7 +3918,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Prison_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2707,7 +3929,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Robots_eng",
       "runs": 6,
       "success_rate": 0.0,
@@ -2718,7 +3940,7 @@
     },
     {
       "model": "mistral-medium-3.1",
-      "mode": "reasoning",
+      "mode": "short_context_reasoning",
       "quest": "Ski_eng",
       "runs": 6,
       "success_rate": 0.3333333333333333,


### PR DESCRIPTION
## Summary
- Replace legacy A-E mode framing with a context-engineering taxonomy across the public site, docs, and leaderboard generation.
- Reframe the About page and docs around compact memory, full-history context, tools + hints, caveated findings, and experiment next steps.
- Add repo hygiene polish including GitHub issue/PR templates, README validation guidance, package discovery, and gitignore casing fixes.

## Validation
- pytest: 133 passed
- ruff check and ruff format: passed
- pnpm build: passed
- CLI help, leaderboard JSON parse, and package import smoke: passed
- mypy remains report-only due to known pre-existing typing backlog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded leaderboard taxonomy to eight context scaffold categories with updated display labels.

* **Documentation**
  * Added GitHub issue and PR templates.
  * Reorganized and updated project documentation including architecture and datasheet files.
  * Refreshed website content with new taxonomy labels and improved messaging.

* **Chores**
  * Updated build configuration for package discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->