### PR TITLE
Fix leaderboard taxonomy cache busting

### DIFF
--- a/configs/benchmarks/memory_modes_pilot.yaml
+++ b/configs/benchmarks/memory_modes_pilot.yaml
@@ -3,28 +3,28 @@ quests:
 - quests/sr_2_1_2121_eng/Pizza_eng.qm
 - quests/sr_2_1_2121_eng/Ski_eng.qm
 agents:
-# A: Baseline - default memory (3 obs, 5 decisions)
+# Short-context reasoning - default memory (3 obs, 5 decisions)
 - model: openrouter:google/gemini-3-flash-preview
   template: reasoning
   temperature: 0.4
   runs: 3
   memory_mode: default
 
-# B: Loop-aware template - default memory
+# Short-context reasoning - loop-aware template
 - model: openrouter:google/gemini-3-flash-preview
   template: loop_aware_reasoning
   temperature: 0.4
   runs: 3
   memory_mode: default
 
-# C: Full transcript memory
+# Full-history reasoning
 - model: openrouter:google/gemini-3-flash-preview
   template: reasoning
   temperature: 0.4
   runs: 3
   memory_mode: full_transcript
 
-# D: Compaction memory (compact every 10 steps)
+# Compact memory / memo (compact every 10 steps)
 - model: openrouter:google/gemini-3-flash-preview
   template: reasoning
   temperature: 0.4

--- a/llm_quest_benchmark/tests/test_leaderboard.py
+++ b/llm_quest_benchmark/tests/test_leaderboard.py
@@ -155,6 +155,40 @@ def test_generate_leaderboard_aggregates_runs(tmp_path, monkeypatch):
     }
 
 
+def test_public_leaderboard_taxonomy_has_no_legacy_labels():
+    repo_root = Path(__file__).resolve().parents[2]
+    old_labels = [
+        f"{name} ({letter})"
+        for name, letter in [
+            ("Baseline", "A"),
+            ("Prompted", "B"),
+            ("Knowledge", "C"),
+            ("Planner", "D"),
+            ("Tool-aug", "E"),
+        ]
+    ]
+
+    index_html = (repo_root / "site/index.html").read_text(encoding="utf-8")
+    for label in old_labels:
+        assert label not in index_html
+    assert "leaderboard.json?v=" in index_html
+
+    leaderboard = json.loads((repo_root / "site/leaderboard.json").read_text(encoding="utf-8"))
+    mode_labels = {mode["label"] for mode in leaderboard["modes"]}
+    assert mode_labels == {
+        "Minimal prompt",
+        "Short-context reasoning",
+        "Full-history reasoning",
+        "Compact memory / memo",
+        "Prompt hints",
+        "Tools + compact memory",
+        "Tools + hints + compact memory",
+        "Planner loop",
+    }
+    for label in old_labels:
+        assert label not in json.dumps(leaderboard, ensure_ascii=False)
+
+
 def test_generate_leaderboard_filters_public_slice(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 

--- a/site/index.html
+++ b/site/index.html
@@ -129,6 +129,30 @@ let filterMode = 'all';
 let filterQuest = 'all';
 let viewMode = 'summary';
 
+const LEADERBOARD_DATA_VERSION = '2026-05-06-taxonomy-v2';
+const TAXONOMY_LABELS = {
+  minimal_prompt:'Minimal prompt',
+  short_context_reasoning:'Short-context reasoning',
+  full_history_reasoning:'Full-history reasoning',
+  compact_memory_memo:'Compact memory / memo',
+  prompt_hints:'Prompt hints',
+  tools_compact_memory:'Tools + compact memory',
+  tools_hints_compact_memory:'Tools + hints + compact memory',
+  planner_loop:'Planner loop',
+};
+const MODE_ALIASES = {
+  a:'minimal_prompt',
+  baseline:'minimal_prompt',
+  b:'short_context_reasoning',
+  prompted:'short_context_reasoning',
+  c:'compact_memory_memo',
+  knowledge:'compact_memory_memo',
+  d:'planner_loop',
+  planner:'planner_loop',
+  e:'tools_compact_memory',
+  'tool-aug':'tools_compact_memory',
+  tool_augmented:'tools_compact_memory',
+};
 const MODE_CLASSES = {
   minimal_prompt:'mode-minimal_prompt',
   short_context_reasoning:'mode-short_context_reasoning',
@@ -154,6 +178,36 @@ function successColor(v) { return v >= 0.8 ? 'var(--green)' : v >= 0.4 ? 'var(--
 function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
 function modelLabel(id) { return MODEL_BY_ID[id]?.label || id; }
 function modeLabel(id) { return MODE_BY_ID[id]?.label || id; }
+
+function canonicalModeId(id, label) {
+  const rawId = String(id || '').trim();
+  const rawLabel = String(label || '').trim();
+  const key = rawId.toLowerCase().replace(/\s+/g, '_');
+  return TAXONOMY_LABELS[rawId] ? rawId : MODE_ALIASES[key] || MODE_ALIASES[rawLabel.toLowerCase()] || rawId;
+}
+
+function normalizeLeaderboard(data) {
+  const rawModeLabels = Object.fromEntries((data.modes || []).map(mode => [mode.id, mode.label]));
+  const modeSeen = new Set();
+  const modes = (data.modes || []).map(mode => {
+    const id = canonicalModeId(mode.id, mode.label);
+    return {id, label: TAXONOMY_LABELS[id] || mode.label || id};
+  }).filter(mode => {
+    if (modeSeen.has(mode.id)) return false;
+    modeSeen.add(mode.id);
+    return true;
+  });
+  const knownModes = new Set(modes.map(mode => mode.id));
+  const results = (data.results || []).map(row => {
+    const mode = canonicalModeId(row.mode, rawModeLabels[row.mode]);
+    if (!knownModes.has(mode)) {
+      modes.push({id: mode, label: TAXONOMY_LABELS[mode] || mode});
+      knownModes.add(mode);
+    }
+    return {...row, mode};
+  });
+  return {...data, modes, results};
+}
 
 function scopedRows() {
   return DATA.results.filter(r => {
@@ -201,8 +255,8 @@ function weightedRate(rows) {
 }
 
 async function init() {
-  const resp = await fetch('leaderboard.json');
-  DATA = await resp.json();
+  const resp = await fetch(`leaderboard.json?v=${encodeURIComponent(LEADERBOARD_DATA_VERSION)}`, {cache: 'no-store'});
+  DATA = normalizeLeaderboard(await resp.json());
   MODEL_BY_ID = Object.fromEntries(DATA.models.map(m => [m.id, m]));
   MODE_BY_ID = Object.fromEntries(DATA.modes.map(m => [m.id, m]));
   document.getElementById('footer-date').textContent = DATA.generated?.split('T')[0] || '';


### PR DESCRIPTION
## Summary
- Add versioned/no-store fetch for `site/leaderboard.json` so stale cached data cannot keep showing old mode labels.
- Normalize any legacy mode ids/slugs in the client to the new context-engineering taxonomy labels before rendering.
- Remove remaining A-D comments from the memory-mode pilot config and add a regression test that public leaderboard surfaces contain only the new taxonomy.

## Validation
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `pnpm run build`
- `python3 -m json.tool site/leaderboard.json >/tmp/llm_quest_leaderboard_check.json`
- `git diff --check`

## Note
The live `leaderboard.json` already serves the new taxonomy; the screenshot is consistent with a stale cached static asset. After this deploy, the updated `index.html` requests a versioned JSON URL.
