### PR TITLE
Fix limited cohort agreement labels

### DIFF
--- a/llm_quest_benchmark/tests/test_play_share_social.py
+++ b/llm_quest_benchmark/tests/test_play_share_social.py
@@ -30,6 +30,6 @@ def test_play_history_does_not_claim_ai_agreement_with_limited_data():
     assert "const MIN_COHORT_LOCATION_RUNS = 3;" in source
     assert "function hasCohortLocationData(cohortLoc)" in source
     assert "const hasCohortData = isBranching && hasCohortLocationData(cohortLoc);" in source
-    assert "const branchingSteps = path.filter(e => e.isBranching);" in source
-    assert "e.agreed === false ? '\\u{1F7E5}' : '\\u2B1C'" in source
+    assert "const agreementSteps = path.filter(e => e.agreed !== null);" in source
+    assert "Limited AI data: " in source
     assert "Limited AI data" in source

--- a/llm_quest_benchmark/tests/test_play_share_social.py
+++ b/llm_quest_benchmark/tests/test_play_share_social.py
@@ -27,7 +27,7 @@ def test_blog_embeds_current_play_screenshot():
 def test_play_history_does_not_claim_ai_agreement_with_limited_data():
     source = APP_SOURCE.read_text(encoding="utf-8")
 
-    assert "const MIN_COHORT_LOCATION_RUNS = 5;" in source
+    assert "const MIN_COHORT_LOCATION_RUNS = 3;" in source
     assert "function hasCohortLocationData(cohortLoc)" in source
     assert "const hasCohortData = isBranching && hasCohortLocationData(cohortLoc);" in source
     assert "agreed: hasCohortData ? agreed : null" in source

--- a/llm_quest_benchmark/tests/test_play_share_social.py
+++ b/llm_quest_benchmark/tests/test_play_share_social.py
@@ -31,5 +31,7 @@ def test_play_history_does_not_claim_ai_agreement_with_limited_data():
     assert "function hasCohortLocationData(cohortLoc)" in source
     assert "const hasCohortData = isBranching && hasCohortLocationData(cohortLoc);" in source
     assert "const agreementSteps = path.filter(e => e.agreed !== null);" in source
+    assert "agreementSteps.length > 0 ? Math.round((agreeCount / agreementSteps.length) * 100) : null" in source
+    assert "if (aiAgreeRate != null)" in source
     assert "Limited AI data: " in source
     assert "Limited AI data" in source

--- a/llm_quest_benchmark/tests/test_play_share_social.py
+++ b/llm_quest_benchmark/tests/test_play_share_social.py
@@ -30,5 +30,6 @@ def test_play_history_does_not_claim_ai_agreement_with_limited_data():
     assert "const MIN_COHORT_LOCATION_RUNS = 3;" in source
     assert "function hasCohortLocationData(cohortLoc)" in source
     assert "const hasCohortData = isBranching && hasCohortLocationData(cohortLoc);" in source
-    assert "agreed: hasCohortData ? agreed : null" in source
+    assert "const branchingSteps = path.filter(e => e.isBranching);" in source
+    assert "e.agreed === false ? '\\u{1F7E5}' : '\\u2B1C'" in source
     assert "Limited AI data" in source

--- a/llm_quest_benchmark/tests/test_play_share_social.py
+++ b/llm_quest_benchmark/tests/test_play_share_social.py
@@ -22,3 +22,13 @@ def test_blog_embeds_current_play_screenshot():
     assert BLOG_SCREENSHOT.exists()
     assert "img/play_quest_in_progress.png" in blog
     assert "decision history and AI cohort comparison" in blog
+
+
+def test_play_history_does_not_claim_ai_agreement_with_limited_data():
+    source = APP_SOURCE.read_text(encoding="utf-8")
+
+    assert "const MIN_COHORT_LOCATION_RUNS = 5;" in source
+    assert "function hasCohortLocationData(cohortLoc)" in source
+    assert "const hasCohortData = isBranching && hasCohortLocationData(cohortLoc);" in source
+    assert "agreed: hasCohortData ? agreed : null" in source
+    assert "Limited AI data" in source

--- a/site/play/app.js
+++ b/site/play/app.js
@@ -485,13 +485,16 @@ async function shareResult(canvas, questTitle, outcomeLabel) {
 
 function buildShareText(questTitle, outcomeLabel, path, cohortWinRate) {
   const branchingSteps = path.filter(e => e.isBranching);
-  const squares = branchingSteps.map(e => e.agreed === true ? '\u{1F7E9}' : e.agreed === false ? '\u{1F7E5}' : '\u2B1C').join('');
-  const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
+  const agreementSteps = path.filter(e => e.agreed !== null);
+  const limitedCount = branchingSteps.length - agreementSteps.length;
+  const squares = agreementSteps.map(e => e.agreed ? '\u{1F7E9}' : '\u{1F7E5}').join('');
+  const agreeCount = agreementSteps.filter(e => e.agreed === true).length;
   const aiPct = cohortWinRate != null ? Math.round(cohortWinRate * 100) : null;
   let lines = [];
   lines.push('LLM-Quest Benchmark: ' + questTitle);
   lines.push(outcomeLabel + ' in ' + path.length + ' steps');
-  if (squares) lines.push(squares + ' ' + agreeCount + '/' + branchingSteps.length + ' AI agreed');
+  if (squares) lines.push(squares + ' ' + agreeCount + '/' + agreementSteps.length + ' AI agreed');
+  if (limitedCount > 0) lines.push('Limited AI data: ' + limitedCount + ' branching steps');
   if (aiPct != null) lines.push('AI cohort win rate: ' + aiPct + '%');
   lines.push('');
   lines.push(PLAY_URL);
@@ -513,9 +516,9 @@ function EndScreen({
     fail: 'FAILURE',
     dead: 'DEAD'
   }[outcome] || 'FAILURE';
-  const branchingSteps = path.filter(e => e.isBranching);
-  const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
-  const aiAgreeRate = branchingSteps.length > 0 ? Math.round(agreeCount / branchingSteps.length * 100) : 0;
+  const agreementSteps = path.filter(e => e.agreed !== null);
+  const agreeCount = agreementSteps.filter(e => e.agreed === true).length;
+  const aiAgreeRate = agreementSteps.length > 0 ? Math.round(agreeCount / agreementSteps.length * 100) : 0;
   function handleShare() {
     const text = buildShareText(questTitle, outcomeLabel, path, cohortWinRate);
     const canvas = renderShareCard(questTitle, outcomeLabel, path.length, aiAgreeRate, cohortWinRate);

--- a/site/play/app.js
+++ b/site/play/app.js
@@ -187,7 +187,7 @@ function sortQuests(quests) {
 }
 const PLAY_URL = 'https://yourconscience.github.io/llm_quest_benchmark/play.html';
 const SHARE_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';
-const MIN_COHORT_LOCATION_RUNS = 5;
+const MIN_COHORT_LOCATION_RUNS = 3;
 function drawTextLine(ctx, text, x, y, maxWidth) {
   ctx.fillText(text, x, y, maxWidth);
 }

--- a/site/play/app.js
+++ b/site/play/app.js
@@ -484,8 +484,8 @@ async function shareResult(canvas, questTitle, outcomeLabel) {
 // ---- EndScreen ----
 
 function buildShareText(questTitle, outcomeLabel, path, cohortWinRate) {
-  const branchingSteps = path.filter(e => e.agreed !== null);
-  const squares = branchingSteps.map(e => e.agreed ? '\u{1F7E9}' : '\u{1F7E5}').join('');
+  const branchingSteps = path.filter(e => e.isBranching);
+  const squares = branchingSteps.map(e => e.agreed === true ? '\u{1F7E9}' : e.agreed === false ? '\u{1F7E5}' : '\u2B1C').join('');
   const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
   const aiPct = cohortWinRate != null ? Math.round(cohortWinRate * 100) : null;
   let lines = [];
@@ -513,7 +513,7 @@ function EndScreen({
     fail: 'FAILURE',
     dead: 'DEAD'
   }[outcome] || 'FAILURE';
-  const branchingSteps = path.filter(e => e.agreed !== null);
+  const branchingSteps = path.filter(e => e.isBranching);
   const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
   const aiAgreeRate = branchingSteps.length > 0 ? Math.round(agreeCount / branchingSteps.length * 100) : 0;
   function handleShare() {
@@ -699,7 +699,7 @@ function QuestPlay({
       step: stepNum,
       choiceText: stripClr(choice.text),
       isBranching,
-      agreed: hasCohortData ? agreed : null,
+      agreed,
       cohortLoc: isBranching ? cohortLoc : null,
       hasCohortData,
       playerChoiceNorm: isBranching ? choiceNorm : null

--- a/site/play/app.js
+++ b/site/play/app.js
@@ -187,12 +187,16 @@ function sortQuests(quests) {
 }
 const PLAY_URL = 'https://yourconscience.github.io/llm_quest_benchmark/play.html';
 const SHARE_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';
+const MIN_COHORT_LOCATION_RUNS = 5;
 function drawTextLine(ctx, text, x, y, maxWidth) {
   ctx.fillText(text, x, y, maxWidth);
 }
 
 // ---- CohortBars (reusable distribution bars) ----
 
+function hasCohortLocationData(cohortLoc) {
+  return !!cohortLoc && (cohortLoc.n || 0) >= MIN_COHORT_LOCATION_RUNS;
+}
 function CohortBars({
   cohortLoc,
   playerChoiceNorm,
@@ -200,7 +204,7 @@ function CohortBars({
   onFamilyChange,
   families
 }) {
-  if (!cohortLoc || cohortLoc.n < 5) {
+  if (!hasCohortLocationData(cohortLoc)) {
     return /*#__PURE__*/React.createElement("span", {
       style: {
         color: 'var(--muted)',
@@ -274,7 +278,7 @@ function DecisionHistory({
 }) {
   const [openIdx, setOpenIdx] = useState(null);
   const [activeFamily, setActiveFamily] = useState('all');
-  const branchingSteps = path.filter(entry => entry.cohortLoc);
+  const branchingSteps = path.filter(entry => entry.isBranching);
   if (branchingSteps.length === 0) return null;
   return /*#__PURE__*/React.createElement("div", {
     className: "history-section"
@@ -304,7 +308,7 @@ function DecisionHistory({
       style: {
         color: entry.agreed ? 'var(--green)' : entry.agreed === false ? 'var(--red)' : 'var(--muted)'
       }
-    }, entry.agreed === true ? 'AI agreed' : entry.agreed === false ? 'AI disagreed' : ''), /*#__PURE__*/React.createElement("span", {
+    }, entry.agreed === true ? 'AI agreed' : entry.agreed === false ? 'AI disagreed' : entry.hasCohortData === false ? 'Limited AI data' : ''), /*#__PURE__*/React.createElement("span", {
       className: "history-chevron"
     }, "\u25B6")), isOpen && /*#__PURE__*/React.createElement("div", {
       className: "cohort-inline"
@@ -688,13 +692,16 @@ function QuestPlay({
     const choiceNorm = canonicalChoiceNorm(choice);
     const cohortLoc = getCohortLoc(locationId);
     const isBranching = activeChoices.length >= 2;
-    const majority = isBranching && cohortLoc ? getMajorityChoice(cohortLoc) : null;
+    const hasCohortData = isBranching && hasCohortLocationData(cohortLoc);
+    const majority = hasCohortData ? getMajorityChoice(cohortLoc) : null;
     const agreed = majority ? normalizeChoice(majority) === choiceNorm : null;
     setPath(prev => [...prev, {
       step: stepNum,
       choiceText: stripClr(choice.text),
-      agreed: isBranching ? agreed : null,
+      isBranching,
+      agreed: hasCohortData ? agreed : null,
       cohortLoc: isBranching ? cohortLoc : null,
+      hasCohortData,
       playerChoiceNorm: isBranching ? choiceNorm : null
     }]);
     setStepHistory(prev => [...prev, {

--- a/site/play/app.js
+++ b/site/play/app.js
@@ -368,10 +368,13 @@ function renderShareCard(questTitle, outcomeLabel, steps, aiAgreeRate, cohortWin
   const stats = [{
     value: String(steps),
     label: 'steps'
-  }, {
-    value: aiAgreeRate + '%',
-    label: 'AI agreed'
   }];
+  if (aiAgreeRate != null) {
+    stats.push({
+      value: aiAgreeRate + '%',
+      label: 'AI agreed'
+    });
+  }
   if (cohortWinRate != null) {
     stats.push({
       value: Math.round(cohortWinRate * 100) + '%',
@@ -518,7 +521,7 @@ function EndScreen({
   }[outcome] || 'FAILURE';
   const agreementSteps = path.filter(e => e.agreed !== null);
   const agreeCount = agreementSteps.filter(e => e.agreed === true).length;
-  const aiAgreeRate = agreementSteps.length > 0 ? Math.round(agreeCount / agreementSteps.length * 100) : 0;
+  const aiAgreeRate = agreementSteps.length > 0 ? Math.round(agreeCount / agreementSteps.length * 100) : null;
   function handleShare() {
     const text = buildShareText(questTitle, outcomeLabel, path, cohortWinRate);
     const canvas = renderShareCard(questTitle, outcomeLabel, path.length, aiAgreeRate, cohortWinRate);

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -311,8 +311,10 @@ function renderShareCard(questTitle, outcomeLabel, steps, aiAgreeRate, cohortWin
   const statsY = 160;
   const stats = [
     { value: String(steps), label: 'steps' },
-    { value: aiAgreeRate + '%', label: 'AI agreed' },
   ];
+  if (aiAgreeRate != null) {
+    stats.push({ value: aiAgreeRate + '%', label: 'AI agreed' });
+  }
   if (cohortWinRate != null) {
     stats.push({ value: Math.round(cohortWinRate * 100) + '%', label: 'AI win rate' });
   }
@@ -453,7 +455,7 @@ function EndScreen({ outcome, cohortWinRate, path, questTitle, endText, families
   const outcomeLabel = { win: 'SUCCESS', fail: 'FAILURE', dead: 'DEAD' }[outcome] || 'FAILURE';
   const agreementSteps = path.filter(e => e.agreed !== null);
   const agreeCount = agreementSteps.filter(e => e.agreed === true).length;
-  const aiAgreeRate = agreementSteps.length > 0 ? Math.round((agreeCount / agreementSteps.length) * 100) : 0;
+  const aiAgreeRate = agreementSteps.length > 0 ? Math.round((agreeCount / agreementSteps.length) * 100) : null;
 
   function handleShare() {
     const text = buildShareText(questTitle, outcomeLabel, path, cohortWinRate);

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -431,14 +431,17 @@ async function shareResult(canvas, questTitle, outcomeLabel) {
 
 function buildShareText(questTitle, outcomeLabel, path, cohortWinRate) {
   const branchingSteps = path.filter(e => e.isBranching);
-  const squares = branchingSteps.map(e => e.agreed === true ? '\u{1F7E9}' : e.agreed === false ? '\u{1F7E5}' : '\u2B1C').join('');
-  const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
+  const agreementSteps = path.filter(e => e.agreed !== null);
+  const limitedCount = branchingSteps.length - agreementSteps.length;
+  const squares = agreementSteps.map(e => e.agreed ? '\u{1F7E9}' : '\u{1F7E5}').join('');
+  const agreeCount = agreementSteps.filter(e => e.agreed === true).length;
   const aiPct = cohortWinRate != null ? Math.round(cohortWinRate * 100) : null;
 
   let lines = [];
   lines.push('LLM-Quest Benchmark: ' + questTitle);
   lines.push(outcomeLabel + ' in ' + path.length + ' steps');
-  if (squares) lines.push(squares + ' ' + agreeCount + '/' + branchingSteps.length + ' AI agreed');
+  if (squares) lines.push(squares + ' ' + agreeCount + '/' + agreementSteps.length + ' AI agreed');
+  if (limitedCount > 0) lines.push('Limited AI data: ' + limitedCount + ' branching steps');
   if (aiPct != null) lines.push('AI cohort win rate: ' + aiPct + '%');
   lines.push('');
   lines.push(PLAY_URL);
@@ -448,9 +451,9 @@ function buildShareText(questTitle, outcomeLabel, path, cohortWinRate) {
 function EndScreen({ outcome, cohortWinRate, path, questTitle, endText, families, onPlayAgain, onTryAnother }) {
   const [shareStatus, setShareStatus] = useState('');
   const outcomeLabel = { win: 'SUCCESS', fail: 'FAILURE', dead: 'DEAD' }[outcome] || 'FAILURE';
-  const branchingSteps = path.filter(e => e.isBranching);
-  const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
-  const aiAgreeRate = branchingSteps.length > 0 ? Math.round((agreeCount / branchingSteps.length) * 100) : 0;
+  const agreementSteps = path.filter(e => e.agreed !== null);
+  const agreeCount = agreementSteps.filter(e => e.agreed === true).length;
+  const aiAgreeRate = agreementSteps.length > 0 ? Math.round((agreeCount / agreementSteps.length) * 100) : 0;
 
   function handleShare() {
     const text = buildShareText(questTitle, outcomeLabel, path, cohortWinRate);

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -153,6 +153,7 @@ function sortQuests(quests) {
 
 const PLAY_URL = 'https://yourconscience.github.io/llm_quest_benchmark/play.html';
 const SHARE_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';
+const MIN_COHORT_LOCATION_RUNS = 5;
 
 function drawTextLine(ctx, text, x, y, maxWidth) {
   ctx.fillText(text, x, y, maxWidth);
@@ -160,8 +161,12 @@ function drawTextLine(ctx, text, x, y, maxWidth) {
 
 // ---- CohortBars (reusable distribution bars) ----
 
+function hasCohortLocationData(cohortLoc) {
+  return !!cohortLoc && (cohortLoc.n || 0) >= MIN_COHORT_LOCATION_RUNS;
+}
+
 function CohortBars({ cohortLoc, playerChoiceNorm, activeFamily, onFamilyChange, families }) {
-  if (!cohortLoc || cohortLoc.n < 5) {
+  if (!hasCohortLocationData(cohortLoc)) {
     return <span style={{ color: 'var(--muted)', fontSize: '0.85rem' }}>Insufficient data for this location.</span>;
   }
 
@@ -224,7 +229,7 @@ function DecisionHistory({ path, families }) {
   const [openIdx, setOpenIdx] = useState(null);
   const [activeFamily, setActiveFamily] = useState('all');
 
-  const branchingSteps = path.filter(entry => entry.cohortLoc);
+  const branchingSteps = path.filter(entry => entry.isBranching);
   if (branchingSteps.length === 0) return null;
 
   return (
@@ -240,7 +245,7 @@ function DecisionHistory({ path, families }) {
               <span className="history-step">#{entry.step}</span>
               <span className="history-choice">{entry.choiceText}</span>
               <span className="history-agree" style={{ color: entry.agreed ? 'var(--green)' : entry.agreed === false ? 'var(--red)' : 'var(--muted)' }}>
-                {entry.agreed === true ? 'AI agreed' : entry.agreed === false ? 'AI disagreed' : ''}
+                {entry.agreed === true ? 'AI agreed' : entry.agreed === false ? 'AI disagreed' : entry.hasCohortData === false ? 'Limited AI data' : ''}
               </span>
               <span className="history-chevron">&#9654;</span>
             </div>
@@ -578,14 +583,17 @@ function QuestPlay({ quest, cohortData, onQuit }) {
     const choiceNorm = canonicalChoiceNorm(choice);
     const cohortLoc = getCohortLoc(locationId);
     const isBranching = activeChoices.length >= 2;
-    const majority = (isBranching && cohortLoc) ? getMajorityChoice(cohortLoc) : null;
+    const hasCohortData = isBranching && hasCohortLocationData(cohortLoc);
+    const majority = hasCohortData ? getMajorityChoice(cohortLoc) : null;
     const agreed = majority ? normalizeChoice(majority) === choiceNorm : null;
 
     setPath(prev => [...prev, {
       step: stepNum,
       choiceText: stripClr(choice.text),
-      agreed: isBranching ? agreed : null,
+      isBranching,
+      agreed: hasCohortData ? agreed : null,
       cohortLoc: isBranching ? cohortLoc : null,
+      hasCohortData,
       playerChoiceNorm: isBranching ? choiceNorm : null,
     }]);
 

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -430,8 +430,8 @@ async function shareResult(canvas, questTitle, outcomeLabel) {
 // ---- EndScreen ----
 
 function buildShareText(questTitle, outcomeLabel, path, cohortWinRate) {
-  const branchingSteps = path.filter(e => e.agreed !== null);
-  const squares = branchingSteps.map(e => e.agreed ? '\u{1F7E9}' : '\u{1F7E5}').join('');
+  const branchingSteps = path.filter(e => e.isBranching);
+  const squares = branchingSteps.map(e => e.agreed === true ? '\u{1F7E9}' : e.agreed === false ? '\u{1F7E5}' : '\u2B1C').join('');
   const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
   const aiPct = cohortWinRate != null ? Math.round(cohortWinRate * 100) : null;
 
@@ -448,7 +448,7 @@ function buildShareText(questTitle, outcomeLabel, path, cohortWinRate) {
 function EndScreen({ outcome, cohortWinRate, path, questTitle, endText, families, onPlayAgain, onTryAnother }) {
   const [shareStatus, setShareStatus] = useState('');
   const outcomeLabel = { win: 'SUCCESS', fail: 'FAILURE', dead: 'DEAD' }[outcome] || 'FAILURE';
-  const branchingSteps = path.filter(e => e.agreed !== null);
+  const branchingSteps = path.filter(e => e.isBranching);
   const agreeCount = branchingSteps.filter(e => e.agreed === true).length;
   const aiAgreeRate = branchingSteps.length > 0 ? Math.round((agreeCount / branchingSteps.length) * 100) : 0;
 
@@ -591,7 +591,7 @@ function QuestPlay({ quest, cohortData, onQuit }) {
       step: stepNum,
       choiceText: stripClr(choice.text),
       isBranching,
-      agreed: hasCohortData ? agreed : null,
+      agreed,
       cohortLoc: isBranching ? cohortLoc : null,
       hasCohortData,
       playerChoiceNorm: isBranching ? choiceNorm : null,

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -153,7 +153,7 @@ function sortQuests(quests) {
 
 const PLAY_URL = 'https://yourconscience.github.io/llm_quest_benchmark/play.html';
 const SHARE_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';
-const MIN_COHORT_LOCATION_RUNS = 5;
+const MIN_COHORT_LOCATION_RUNS = 3;
 
 function drawTextLine(ctx, text, x, y, maxWidth) {
   ctx.fillText(text, x, y, maxWidth);


### PR DESCRIPTION
## Summary

- Use the same minimum cohort-location coverage gate for agreement labels and expanded cohort bars.
- Show a muted "Limited AI data" state instead of "AI agreed/disagreed" when a branching step has too few cohort samples.
- Add a regression test for the play history agreement-label contract.

## Verification

- `git submodule update --init --recursive`
- `pnpm install`
- `pnpm run build`
- `uv sync --extra dev`
- `uv run pytest llm_quest_benchmark/tests/test_play_share_social.py -x`
- `uv run pytest llm_quest_benchmark/tests/test_play_quest_index.py llm_quest_benchmark/tests/test_play_share_social.py -x`
- `python3 -m json.tool site/play/Borzukhan_eng.json >/tmp/borzukhan_cohort_check.json`
- `git diff --check`
