### PR TITLE
Use canonical locations for RU play cohorts

### DIFF
--- a/llm_quest_benchmark/tests/test_play_quest_index.py
+++ b/llm_quest_benchmark/tests/test_play_quest_index.py
@@ -1,9 +1,11 @@
 import json
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 QUEST_INDEX_PATH = REPO_ROOT / "site" / "play" / "quest-index.json"
 APP_SOURCE_PATH = REPO_ROOT / "site" / "play" / "app.jsx"
+APP_COMPILED_PATH = REPO_ROOT / "site" / "play" / "app.js"
 
 
 def test_ru_quests_share_canonical_en_card_data():
@@ -24,10 +26,13 @@ def test_ru_quests_share_canonical_en_card_data():
 
 
 def test_play_uses_canonical_location_for_cohort_lookup():
-    source = APP_SOURCE_PATH.read_text(encoding="utf-8")
-
-    assert (
-        "const locationId = canonicalPlayer ? canonicalPlayer.getSaving().locationId : player.getSaving().locationId;"
-        in source
+    lookup_pattern = re.compile(
+        r"const\s+locationId\s*=\s*canonicalPlayer\s*\?"
+        r"\s*canonicalPlayer\.getSaving\(\)\.locationId\s*:"
+        r"\s*player\.getSaving\(\)\.locationId\s*;"
     )
-    assert "const cohortId = quest.canonical_id || quest.id;" in source
+
+    for path in [APP_SOURCE_PATH, APP_COMPILED_PATH]:
+        source = path.read_text(encoding="utf-8")
+        assert lookup_pattern.search(source), path
+        assert "const cohortId = quest.canonical_id || quest.id;" in source, path

--- a/llm_quest_benchmark/tests/test_play_quest_index.py
+++ b/llm_quest_benchmark/tests/test_play_quest_index.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 QUEST_INDEX_PATH = REPO_ROOT / "site" / "play" / "quest-index.json"
+APP_SOURCE_PATH = REPO_ROOT / "site" / "play" / "app.jsx"
 
 
 def test_ru_quests_share_canonical_en_card_data():
@@ -20,3 +21,13 @@ def test_ru_quests_share_canonical_en_card_data():
         en_quest = quests[canonical_id]
         assert ru_quest["win_rate"] == en_quest["win_rate"], ru_quest["id"]
         assert ru_quest["total_runs"] == en_quest["total_runs"], ru_quest["id"]
+
+
+def test_play_uses_canonical_location_for_cohort_lookup():
+    source = APP_SOURCE_PATH.read_text(encoding="utf-8")
+
+    assert (
+        "const locationId = canonicalPlayer ? canonicalPlayer.getSaving().locationId : player.getSaving().locationId;"
+        in source
+    )
+    assert "const cohortId = quest.canonical_id || quest.id;" in source

--- a/site/play/app.js
+++ b/site/play/app.js
@@ -694,7 +694,7 @@ function QuestPlay({
     return normalizeChoice(canonicalChoice && canonicalChoice.text || choice.text);
   }
   function handleChoice(choice, activeChoices) {
-    const locationId = player.getSaving().locationId;
+    const locationId = canonicalPlayer ? canonicalPlayer.getSaving().locationId : player.getSaving().locationId;
     const choiceNorm = canonicalChoiceNorm(choice);
     const cohortLoc = getCohortLoc(locationId);
     const isBranching = activeChoices.length >= 2;

--- a/site/play/app.jsx
+++ b/site/play/app.jsx
@@ -584,7 +584,7 @@ function QuestPlay({ quest, cohortData, onQuit }) {
   }
 
   function handleChoice(choice, activeChoices) {
-    const locationId = player.getSaving().locationId;
+    const locationId = canonicalPlayer ? canonicalPlayer.getSaving().locationId : player.getSaving().locationId;
     const choiceNorm = canonicalChoiceNorm(choice);
     const cohortLoc = getCohortLoc(locationId);
     const isBranching = activeChoices.length >= 2;


### PR DESCRIPTION
## Summary

- Use the mirrored canonical EN player location for Play-mode cohort lookups.
- Keep RU quest decisions mapped to the same EN AI trace locations instead of using localized quest location IDs.
- Add a regression guard for canonical cohort lookup wiring.

## Verification

- `pnpm run build:play-jsx`
- `uv run pytest llm_quest_benchmark/tests/test_play_quest_index.py llm_quest_benchmark/tests/test_play_share_social.py -x`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced cohort location data selection to use canonical player information when available, improving accuracy during canonical quest replay.

* **Tests**
  * Added test validating proper usage of canonical player location IDs in cohort lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->