### PR TITLE
Add OPENAI_BASE_URL support and balanced benchmark config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,13 @@ Requires `OPENROUTER_API_KEY` in `.env`.
 
 ### OpenAI-compatible proxies (OAuth, local LLMs)
 
-Set `OPENAI_BASE_URL` to route the `openai:` provider through any compatible endpoint:
+Set `OPENAI_BASE_URL` in `.env` to route the `openai:` provider through any compatible endpoint:
 ```bash
-# Local OAuth proxy (CLIProxyAPI, codex-proxy, openai-oauth, etc.)
+# .env - local OAuth proxy (CLIProxyAPI, codex-proxy, openai-oauth, etc.)
 OPENAI_BASE_URL=http://localhost:8318/v1
-
-# No OPENAI_API_KEY needed when using a local proxy
+```
+No `OPENAI_API_KEY` needed when using a local proxy:
+```bash
 uv run llm-quest run --model gpt-5-mini --quest quests/Boat.qm
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,38 @@ pnpm run build
 pnpm run build:play-assets
 ```
 
+## API Configuration
+
+Set provider API keys in `.env` (see `.env.template`).
+
+### OpenRouter
+
+Any model on OpenRouter can be used with the `openrouter:` prefix:
+```bash
+uv run llm-quest run --model openrouter:openai/gpt-5.4-mini --quest quests/Boat.qm
+```
+Requires `OPENROUTER_API_KEY` in `.env`.
+
+### OpenAI-compatible proxies (OAuth, local LLMs)
+
+Set `OPENAI_BASE_URL` to route the `openai:` provider through any compatible endpoint:
+```bash
+# Local OAuth proxy (CLIProxyAPI, codex-proxy, openai-oauth, etc.)
+OPENAI_BASE_URL=http://localhost:8318/v1
+
+# No OPENAI_API_KEY needed when using a local proxy
+uv run llm-quest run --model gpt-5-mini --quest quests/Boat.qm
+```
+
+### Direct API keys
+
+Provider-specific keys in `.env`:
+- `OPENAI_API_KEY` - OpenAI API
+- `GOOGLE_API_KEY` / `GEMINI_API_KEY` - Google AI Studio
+- `ANTHROPIC_API_KEY` - Anthropic API
+- `DEEPSEEK_API_KEY` - DeepSeek API
+- `OPENROUTER_API_KEY` - OpenRouter (multi-provider gateway)
+
 ## Project Structure
 
 - `llm_quest_benchmark/agents/` - Agent implementations (LLM, planner, tool-augmented)

--- a/configs/benchmarks/balanced_gpt5mini_all_modes.yaml
+++ b/configs/benchmarks/balanced_gpt5mini_all_modes.yaml
@@ -1,0 +1,68 @@
+name: balanced_gpt5mini_all_modes
+quests:
+  # Easy tier
+  - quests/Boat.qm
+  - quests/sr_2_1_2121_eng/Badday_eng.qm
+  - quests/sr_2_1_2121_eng/Pizza_eng.qm
+  # Medium tier
+  - quests/sr_2_1_2121_eng/Ski_eng.qm
+  - quests/sr_2_1_2121_eng/Leonardo_eng.qm
+  - quests/sr_2_1_2121_eng/Robots_eng.qm
+  # Hard tier
+  - quests/sr_2_1_2121_eng/Banket_eng.qm
+  - quests/sr_2_1_2121_eng/Codebox_eng.qm
+  - quests/sr_2_1_2121_eng/Depth_eng.qm
+  - quests/sr_2_1_2121_eng/Driver_eng.qm
+  - quests/sr_2_1_2121_eng/Edelweiss_eng.qm
+  - quests/sr_2_1_2121_eng/Election_eng.qm
+  - quests/sr_2_1_2121_eng/Foncers_eng.qm
+  - quests/sr_2_1_2121_eng/Ministry_eng.qm
+  - quests/sr_2_1_2121_eng/Prison_eng.qm
+agents:
+  # 1. Minimal prompt
+  - model: gpt-5-mini
+    template: stub
+    temperature: 0.4
+    runs: 3
+  # 2. Short-context reasoning
+  - model: gpt-5-mini
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+  # 3. Full-history reasoning
+  - model: gpt-5-mini
+    template: reasoning
+    temperature: 0.4
+    runs: 3
+    memory_mode: full_transcript
+  # 4. Compact memory / memo
+  - model: gpt-5-mini
+    template: stateful_compact
+    temperature: 0.4
+    runs: 3
+    memory_mode: compaction
+    compaction_interval: 50
+  # 5. Prompt hints
+  - model: gpt-5-mini
+    template: light_hints
+    temperature: 0.4
+    runs: 3
+  # 6. Tools + compact memory
+  - model: gpt-5-mini
+    template: tool_augmented
+    temperature: 0.4
+    runs: 3
+  # 7. Tools + hints + compact memory
+  - model: gpt-5-mini
+    template: tool_augmented_hints
+    temperature: 0.4
+    runs: 3
+  # 8. Planner loop
+  - model: gpt-5-mini
+    template: planner
+    temperature: 0.4
+    runs: 3
+debug: false
+quest_timeout: 600
+max_workers: 2
+output_dir: results/benchmarks

--- a/configs/benchmarks/balanced_gpt5mini_all_modes.yaml
+++ b/configs/benchmarks/balanced_gpt5mini_all_modes.yaml
@@ -52,11 +52,15 @@ agents:
     template: tool_augmented
     temperature: 0.4
     runs: 3
+    memory_mode: compaction
+    compaction_interval: 50
   # 7. Tools + hints + compact memory
   - model: gpt-5-mini
     template: tool_augmented_hints
     temperature: 0.4
     runs: 3
+    memory_mode: compaction
+    compaction_interval: 50
   # 8. Planner loop
   - model: gpt-5-mini
     template: planner

--- a/llm_quest_benchmark/llm/client.py
+++ b/llm_quest_benchmark/llm/client.py
@@ -236,7 +236,13 @@ class OpenAICompatibleClient(LLMClient):
 
     def _provider_settings(self) -> tuple[str | None, str | None]:
         if self.provider == "openai":
-            return self._require_api_key("OPENAI_API_KEY"), None
+            base_url = os.getenv("OPENAI_BASE_URL")
+            api_key = os.getenv("OPENAI_API_KEY") or (base_url and "not-needed") or None
+            if not api_key:
+                raise RuntimeError(
+                    "Missing API key for provider 'openai'. Set OPENAI_API_KEY in your environment or .env file."
+                )
+            return api_key, base_url
         if self.provider == "google":
             api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
             if not api_key:


### PR DESCRIPTION
## Summary
- Support `OPENAI_BASE_URL` for OpenAI-compatible proxy routing.
- Add balanced GPT-5.4-mini benchmark configs and benchmark runner stability fix for `max_workers=1` (serial in-process execution to prevent orphan worker leakage).
- Roll back newly added GPT-5.4-mini leaderboard entries pending canonical rerun.

## Verification
- `python3 -m json.tool site/leaderboard.json >/tmp/llm_quest_leaderboard_check.json`
- `gh pr checks 54` shows `lint-and-test` and `CodeRabbit` passing.

## Notes
- Canonical GPT-5.4-mini rerun protocol drafted in `research/gpt54mini_minimal_rerun_protocol_2026-05-08.md` (gitignored, local research artifact).
