### PR TITLE
Avoid forwarding OPENAI_API_KEY to custom OPENAI_BASE_URL; add explicit proxy key support and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ No `OPENAI_API_KEY` needed when using a local proxy:
 ```bash
 uv run llm-quest run --model gpt-5-mini --quest quests/Boat.qm
 ```
+When `OPENAI_BASE_URL` is set, the client will not forward `OPENAI_API_KEY` to that endpoint.
+If your proxy requires bearer auth, set `OPENAI_BASE_URL_API_KEY` explicitly.
 
 ### Direct API keys
 

--- a/llm_quest_benchmark/llm/client.py
+++ b/llm_quest_benchmark/llm/client.py
@@ -237,7 +237,10 @@ class OpenAICompatibleClient(LLMClient):
     def _provider_settings(self) -> tuple[str | None, str | None]:
         if self.provider == "openai":
             base_url = os.getenv("OPENAI_BASE_URL")
-            api_key = os.getenv("OPENAI_API_KEY") or (base_url and "not-needed") or None
+            if base_url:
+                api_key = os.getenv("OPENAI_BASE_URL_API_KEY") or "not-needed"
+            else:
+                api_key = os.getenv("OPENAI_API_KEY")
             if not api_key:
                 raise RuntimeError(
                     "Missing API key for provider 'openai'. Set OPENAI_API_KEY in your environment or .env file."

--- a/llm_quest_benchmark/tests/test_llm_client.py
+++ b/llm_quest_benchmark/tests/test_llm_client.py
@@ -172,3 +172,27 @@ def test_openai_gpt5_retries_empty_with_larger_budget(mock_openai_cls, monkeypat
     assert mock_chat.completions.create.call_count == 2
     second_kwargs = mock_chat.completions.create.call_args_list[1].kwargs
     assert second_kwargs["max_completion_tokens"] >= 800
+
+
+def test_openai_base_url_uses_proxy_key_not_openai_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:8318/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "real-openai-key")
+    monkeypatch.delenv("OPENAI_BASE_URL_API_KEY", raising=False)
+
+    client = get_llm_client("gpt-5-mini")
+    api_key, base_url = client._provider_settings()
+
+    assert base_url == "http://localhost:8318/v1"
+    assert api_key == "not-needed"
+
+
+def test_openai_base_url_uses_explicit_proxy_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:8318/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "real-openai-key")
+    monkeypatch.setenv("OPENAI_BASE_URL_API_KEY", "proxy-key")
+
+    client = get_llm_client("gpt-5-mini")
+    api_key, base_url = client._provider_settings()
+
+    assert base_url == "http://localhost:8318/v1"
+    assert api_key == "proxy-key"


### PR DESCRIPTION
### Motivation
- Prevent accidental exfiltration of a real OpenAI key when a user configures an arbitrary `OPENAI_BASE_URL` for proxies or local endpoints. 
- Make proxy authentication explicit so users must opt-in to forwarding a key to a non-default endpoint.

### Description
- Change `llm_quest_benchmark/llm/client.py` so that when `OPENAI_BASE_URL` is set the client uses `OPENAI_BASE_URL_API_KEY` (if present) or the sentinel value `"not-needed"`, and it no longer falls back to `OPENAI_API_KEY` when a custom base URL is configured. 
- Add two regression tests in `llm_quest_benchmark/tests/test_llm_client.py` (`test_openai_base_url_uses_proxy_key_not_openai_key` and `test_openai_base_url_uses_explicit_proxy_key`) to validate the new credential selection behavior. 
- Update `README.md` to document that the client will not forward `OPENAI_API_KEY` when `OPENAI_BASE_URL` is set and to recommend `OPENAI_BASE_URL_API_KEY` for proxy bearer auth.

### Testing
- Ran `pytest -q llm_quest_benchmark/tests/test_llm_client.py` to execute the updated test file, but the run failed during test bootstrap with `ModuleNotFoundError: No module named 'yaml'` before the new tests could complete. 
- No other automated test suites were executed in this environment due to the missing dependency; the added tests are otherwise self-contained and assert the new `_provider_settings` behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb934d8ac832ba0e3b6575ace3cee)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with guidance for using OpenAI-compatible proxies and clarified API key configuration for proxy endpoints.

* **Tests**
  * Added tests to verify API key handling behavior with custom OpenAI-compatible proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->